### PR TITLE
fix(FEC-7144): round up the timer values of an ad

### DIFF
--- a/src/components/time-display-ads-container/time-display-ads-container.js
+++ b/src/components/time-display-ads-container/time-display-ads-container.js
@@ -40,7 +40,7 @@ class TimeDisplayAdsContainer extends BaseComponent {
   render(props: any): React$Element<any> {
     return (
       <TimeDisplay
-        currentTime={Math.ceil(props.adProgress.currentTime)}
+        currentTime={Math.round(props.adProgress.currentTime)}
         duration={Math.ceil(props.adProgress.duration)}
         {...props}
       />

--- a/src/components/time-display-ads-container/time-display-ads-container.js
+++ b/src/components/time-display-ads-container/time-display-ads-container.js
@@ -1,6 +1,6 @@
 //@flow
-import { h } from 'preact';
-import { connect } from 'preact-redux';
+import {h} from 'preact';
+import {connect} from 'preact-redux';
 import BaseComponent from '../base';
 import TimeDisplay from '../time-display';
 
@@ -14,13 +14,13 @@ const mapStateToProps = state => ({
 });
 
 @connect(mapStateToProps)
-/**
- * TimeDisplayAdsContainer component
- *
- * @class TimeDisplayAdsContainer
- * @example <TimeDisplayAdsContainer format='-left seconds left' />
- * @extends {BaseComponent}
- */
+  /**
+   * TimeDisplayAdsContainer component
+   *
+   * @class TimeDisplayAdsContainer
+   * @example <TimeDisplayAdsContainer format='-left seconds left' />
+   * @extends {BaseComponent}
+   */
 class TimeDisplayAdsContainer extends BaseComponent {
   /**
    * Creates an instance of TimeDisplayAdsContainer.
@@ -40,8 +40,8 @@ class TimeDisplayAdsContainer extends BaseComponent {
   render(props: any): React$Element<any> {
     return (
       <TimeDisplay
-        currentTime={props.adProgress.currentTime}
-        duration={props.adProgress.duration}
+        currentTime={Math.ceil(props.adProgress.currentTime)}
+        duration={Math.ceil(props.adProgress.duration)}
         {...props}
       />
     )

--- a/src/components/time-display-ads-container/time-display-ads-container.js
+++ b/src/components/time-display-ads-container/time-display-ads-container.js
@@ -41,7 +41,7 @@ class TimeDisplayAdsContainer extends BaseComponent {
     return (
       <TimeDisplay
         currentTime={Math.round(props.adProgress.currentTime)}
-        duration={Math.ceil(props.adProgress.duration)}
+        duration={Math.round(props.adProgress.duration)}
         {...props}
       />
     )


### PR DESCRIPTION
### Description of the Changes

Ads "left timer counts" doesn't present the last second, round up the current time and duration.
### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
