### PR TITLE
fix(FEC-7101): remove auto bitrate option for progressive playback

### DIFF
--- a/src/components/settings/settings.js
+++ b/src/components/settings/settings.js
@@ -190,7 +190,8 @@ class SettingsControl extends BaseComponent {
         value: t
       }));
 
-    if (qualityOptions.length > 1) {
+    //Progressive playback doesn't support auto
+    if ((qualityOptions.length > 1) && (this.player.streamType !== "progressive")) {
       qualityOptions
         .unshift({
           label: 'Auto',


### PR DESCRIPTION
### Description of the Changes

only add auto option for non progressive playback.
depends on exposing streamType on playkit-js here: https://github.com/kaltura/playkit-js/pull/120.
currently we rely on strings but this should be added as types and constants from player.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
