### PR TITLE
fix(pre-playback-state): hide loading spinner on preloading

### DIFF
--- a/src/components/loading/loading.js
+++ b/src/components/loading/loading.js
@@ -37,6 +37,7 @@ class Loading extends BaseComponent {
   constructor(obj: Object) {
     super({name: 'Loading', player: obj.player});
     try {
+      // TODO: Change the dependency on ima to our ads plugin when it will be developed.
       if (this.player.config.playback.preload === "auto" && !this.player.config.plugins.ima) {
         this.isPreloading = true;
         this.player.addEventListener(this.player.Event.PLAYER_STATE_CHANGED, (e) => {

--- a/src/components/loading/loading.js
+++ b/src/components/loading/loading.js
@@ -1,8 +1,8 @@
 //@flow
-import { h } from 'preact';
-import { connect } from 'preact-redux';
-import { bindActions } from '../../utils/bind-actions';
-import { actions } from '../../reducers/loading';
+import {h} from 'preact';
+import {connect} from 'preact-redux';
+import {bindActions} from '../../utils/bind-actions';
+import {actions} from '../../reducers/loading';
 import BaseComponent from '../base';
 
 /**
@@ -17,14 +17,15 @@ const mapStateToProps = state => ({
 });
 
 @connect(mapStateToProps, bindActions(actions))
-/**
- * Loading component
- *
- * @class Loading
- * @example <Loading />
- * @extends {BaseComponent}
- */
+  /**
+   * Loading component
+   *
+   * @class Loading
+   * @example <Loading />
+   * @extends {BaseComponent}
+   */
 class Loading extends BaseComponent {
+  isPreloading: boolean;
   autoplay: boolean;
   mobileAutoplay: boolean;
 
@@ -35,6 +36,19 @@ class Loading extends BaseComponent {
    */
   constructor(obj: Object) {
     super({name: 'Loading', player: obj.player});
+    try {
+      if (this.player.config.playback.preload === "auto" && !this.player.config.plugins.ima) {
+        this.isPreloading = true;
+        this.player.addEventListener(this.player.Event.PLAYER_STATE_CHANGED, (e) => {
+          if (e.payload.oldState.type === this.player.State.LOADING) {
+            this.isPreloading = false;
+          }
+        });
+      }
+    } catch (e) {
+      this.logger.error(e.message);
+      this.isPreloading = false;
+    }
   }
 
   /**
@@ -44,11 +58,19 @@ class Loading extends BaseComponent {
    * @memberof Loading
    */
   componentWillMount() {
-    try { this.autoplay = this.player.config.playback.autoplay; }
-    catch (e) { this.autoplay = false; } // eslint-disable-line no-unused-vars
+    try {
+      this.autoplay = this.player.config.playback.autoplay;
+    }
+    catch (e) {
+      this.autoplay = false;
+    } // eslint-disable-line no-unused-vars
 
-    try { this.mobileAutoplay = this.player.config.playback.mobileAutoplay; }
-    catch (e) { this.mobileAutoplay = false; } // eslint-disable-line no-unused-vars
+    try {
+      this.mobileAutoplay = this.player.config.playback.mobileAutoplay;
+    }
+    catch (e) {
+      this.mobileAutoplay = false;
+    } // eslint-disable-line no-unused-vars
   }
 
   /**
@@ -82,13 +104,13 @@ class Loading extends BaseComponent {
    * @memberof Loading
    */
   render(props: any): React$Element<any> | void {
-    if (!props.show || props.adBreak) return undefined;
+    if (!props.show || props.adBreak || this.isPreloading) return undefined;
 
     return (
       <div className='loading-backdrop show'>
         <div className='spinner-container'>
           <div className='spinner'>
-            {[...Array(8)].map((i) => <span key={i} />)}
+            {[...Array(8)].map((i) => <span key={i}/>)}
           </div>
         </div>
       </div>

--- a/src/components/loading/loading.js
+++ b/src/components/loading/loading.js
@@ -61,16 +61,16 @@ class Loading extends BaseComponent {
     try {
       this.autoplay = this.player.config.playback.autoplay;
     }
-    catch (e) {
+    catch (e) { // eslint-disable-line no-unused-vars
       this.autoplay = false;
-    } // eslint-disable-line no-unused-vars
+    }
 
     try {
       this.mobileAutoplay = this.player.config.playback.mobileAutoplay;
     }
-    catch (e) {
+    catch (e) { // eslint-disable-line no-unused-vars
       this.mobileAutoplay = false;
-    } // eslint-disable-line no-unused-vars
+    }
   }
 
   /**

--- a/src/components/pre-playback-play-overlay/pre-playback-play-overlay.js
+++ b/src/components/pre-playback-play-overlay/pre-playback-play-overlay.js
@@ -1,10 +1,10 @@
 //@flow
-import { h } from 'preact';
-import { connect } from 'preact-redux';
-import { bindActions } from '../../utils/bind-actions';
-import { actions } from '../../reducers/shell';
+import {h} from 'preact';
+import {connect} from 'preact-redux';
+import {bindActions} from '../../utils/bind-actions';
+import {actions} from '../../reducers/shell';
 import BaseComponent from '../base';
-import { default as Icon, IconType } from '../icon';
+import {default as Icon, IconType} from '../icon';
 
 /**
  * mapping state to props
@@ -20,14 +20,15 @@ const mapStateToProps = state => ({
 });
 
 @connect(mapStateToProps, bindActions(actions))
-/**
- * PrePlaybackPlayOverlay component
- *
- * @class PrePlaybackPlayOverlay
- * @example <PrePlaybackPlayOverlay player={this.player} />
- * @extends {BaseComponent}
- */
+  /**
+   * PrePlaybackPlayOverlay component
+   *
+   * @class PrePlaybackPlayOverlay
+   * @example <PrePlaybackPlayOverlay player={this.player} />
+   * @extends {BaseComponent}
+   */
 class PrePlaybackPlayOverlay extends BaseComponent {
+  isPreloading: boolean;
   autoplay: boolean;
   mobileAutoplay: boolean;
 
@@ -38,6 +39,17 @@ class PrePlaybackPlayOverlay extends BaseComponent {
    */
   constructor(obj: Object) {
     super({name: 'PrePlaybackPlayOverlay', player: obj.player});
+    try {
+      if (this.player.config.playback.preload === "auto") {
+        this.isPreloading = true;
+        this.player.addEventListener(this.player.Event.PLAYER_STATE_CHANGED, (e) => {
+          if (e.payload.oldState.type === 'loading') {
+            this.isPreloading = false;
+          }
+        });
+      }
+    } catch (e) {
+    }
   }
 
   /**
@@ -50,11 +62,19 @@ class PrePlaybackPlayOverlay extends BaseComponent {
   componentWillMount() {
     this.props.addPlayerClass('pre-playback');
 
-    try { this.autoplay = this.player.config.playback.autoplay; }
-    catch (e) { this.autoplay = false; } // eslint-disable-line no-unused-vars
+    try {
+      this.autoplay = this.player.config.playback.autoplay;
+    }
+    catch (e) {
+      this.autoplay = false;
+    } // eslint-disable-line no-unused-vars
 
-    try { this.mobileAutoplay = this.player.config.playback.mobileAutoplay; }
-    catch (e) { this.mobileAutoplay = false; } // eslint-disable-line no-unused-vars
+    try {
+      this.mobileAutoplay = this.player.config.playback.mobileAutoplay;
+    }
+    catch (e) {
+      this.mobileAutoplay = false;
+    } // eslint-disable-line no-unused-vars
   }
 
   /**
@@ -110,15 +130,17 @@ class PrePlaybackPlayOverlay extends BaseComponent {
    */
   render(props: any): React$Element<any> | void {
     if (
+      this.isPreloading ||
       (!props.isEnded && !props.prePlayback) ||
       (!props.isEnded && !props.isMobile && this.autoplay) ||
       (!props.isEnded && props.isMobile && this.mobileAutoplay)
     ) return undefined;
 
     return (
-      <div className='pre-playback-play-overlay' style={{backgroundImage: `url(${props.poster})`}} onClick={() => this.handleClick()}>
+      <div className='pre-playback-play-overlay' style={{backgroundImage: `url(${props.poster})`}}
+           onClick={() => this.handleClick()}>
         <a className='pre-playback-play-button'>
-          {props.isEnded ? <Icon type={IconType.Startover} /> : <Icon type={IconType.Play} />}
+          {props.isEnded ? <Icon type={IconType.Startover}/> : <Icon type={IconType.Play}/>}
         </a>
       </div>
     )

--- a/src/components/pre-playback-play-overlay/pre-playback-play-overlay.js
+++ b/src/components/pre-playback-play-overlay/pre-playback-play-overlay.js
@@ -43,7 +43,7 @@ class PrePlaybackPlayOverlay extends BaseComponent {
       if (this.player.config.playback.preload === "auto") {
         this.isPreloading = true;
         this.player.addEventListener(this.player.Event.PLAYER_STATE_CHANGED, (e) => {
-          if (e.payload.oldState.type === 'loading') {
+          if (e.payload.oldState.type === this.player.State.LOADING) {
             this.isPreloading = false;
           }
         });

--- a/src/components/pre-playback-play-overlay/pre-playback-play-overlay.js
+++ b/src/components/pre-playback-play-overlay/pre-playback-play-overlay.js
@@ -101,6 +101,7 @@ class PrePlaybackPlayOverlay extends BaseComponent {
    * @memberof PrePlaybackPlayOverlay
    */
   handleClick(): void {
+    // TODO: The promise handling should be in the play API of the player.
     new Promise((resolve, reject) => {
       try {
         if (this.player.config.playback.preload === "auto" && !this.player.config.plugins.ima) {

--- a/src/components/pre-playback-play-overlay/pre-playback-play-overlay.js
+++ b/src/components/pre-playback-play-overlay/pre-playback-play-overlay.js
@@ -49,6 +49,7 @@ class PrePlaybackPlayOverlay extends BaseComponent {
         });
       }
     } catch (e) {
+      this.isPreloading = false;
     }
   }
 


### PR DESCRIPTION
### Description of the Changes

If player is preloading media a spinner showing in the background of the pre playback button.
This solution will hides the loading spinner and shows only pre-playback button.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
