### PR TITLE
feat: use off caption from playkit

### DIFF
--- a/src/components/language/language.js
+++ b/src/components/language/language.js
@@ -118,20 +118,14 @@ class LanguageControl extends BaseComponent {
   }
 
   /**
-   * check if option is 'off', if it does- hideTextTrack called.
-   * otherwise, selecting the given text track
+   * Select the given text track
    *
-   * @param {(Object | string)} textTrack - text track or 'off' string
+   * @param {(Object | string)} textTrack - text track
    * @returns {void}
    * @memberof LanguageControl
    */
   onCaptionsChange(textTrack: Object | string): void {
-    if (textTrack === 'off') {
-      this.player.hideTextTrack();
-    }
-    else {
-      this.player.selectTrack(textTrack);
-    }
+    this.player.selectTrack(textTrack);
   }
 
   /**
@@ -215,18 +209,10 @@ class LanguageControl extends BaseComponent {
    * @memberof LanguageControl
    */
   render(props: any): React$Element<any> | void {
-    var audioOptions = props.audioTracks
+    const audioOptions = props.audioTracks
       .filter(t => t.label || t.language)
       .map(t => ({ label: t.label || t.language, active: t.active, value: t }));
-    var textOptions = props.textTracks.filter(t => t.kind === 'subtitles').map(t => ({ label: t.label || t.language, active: t.active, value: t }));
-
-    if (textOptions.length > 0) {
-      textOptions.push({
-        label: 'Off',
-        active: props.textTracks.filter(t => t.kind === 'subtitles' && t.active).length === 0,
-        value: 'off'
-      })
-    }
+    const textOptions = props.textTracks.filter(t => t.kind === 'subtitles').map(t => ({ label: t.label || t.language, active: t.active, value: t }));
 
     if (audioOptions.length > 0 || textOptions.length > 0) {
       return this.renderAll(audioOptions, textOptions);

--- a/src/components/language/language.js
+++ b/src/components/language/language.js
@@ -120,11 +120,11 @@ class LanguageControl extends BaseComponent {
   /**
    * Select the given text track
    *
-   * @param {(Object | string)} textTrack - text track
+   * @param {Object} textTrack - text track
    * @returns {void}
    * @memberof LanguageControl
    */
-  onCaptionsChange(textTrack: Object | string): void {
+  onCaptionsChange(textTrack: Object): void {
     this.player.selectTrack(textTrack);
   }
 


### PR DESCRIPTION
### Description of the Changes

PlayKit creates a pseudo off text track when there are text tracks available.
This is for connivance only and it internally just tells PlayKit to call hideTextTrack, but it supports the model of emitting the text track change with the selected track where in case of off option it will properly add it to the event payload instead of just throwing null.
Depends on https://github.com/kaltura/playkit-js/pull/118

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
