### PR TITLE
fix: generates new preview image on playerPoster change

### DIFF
--- a/src/components/seekbar/seekbar.js
+++ b/src/components/seekbar/seekbar.js
@@ -50,7 +50,20 @@ class SeekBarControl extends Component {
    */
   componentDidUpdate() {
     if (this.props.playerPoster && !this.framePreviewImg) {
-      this.framePreviewImg = this.getFramePreviewImg();
+      this.framePreviewImg = this.getFramePreviewImg(this.props.playerPoster);
+    }
+  }
+
+  /**
+   * before component update, check if the player poster changed and create new preview image url.
+   *
+   * @param {any} nextProps
+   * @returns {void}
+   * @memberof SeekBarControl
+   */
+  componentWillUpdate(nextProps: any) {
+    if(this.props.playerPoster !== nextProps.playerPoster) {
+      this.framePreviewImg = this.getFramePreviewImg(nextProps.playerPoster);
     }
   }
 
@@ -296,11 +309,12 @@ class SeekBarControl extends Component {
   /**
    * get the frame preview sprite based on player poster
    *
+   * @param {string} posterUrl poster url
    * @returns {string} image url
    * @memberof SeekBarControl
    */
-  getFramePreviewImg(): string {
-    let parts = this.props.playerPoster.split('/');
+  getFramePreviewImg(posterUrl: string): string {
+    let parts = posterUrl.split('/');
     let heightValueIndex = parts.indexOf('height') + 1;
     let widthValueIndex = parts.indexOf('width') + 1;
     parts[heightValueIndex] = 90;

--- a/src/components/seekbar/seekbar.js
+++ b/src/components/seekbar/seekbar.js
@@ -317,8 +317,8 @@ class SeekBarControl extends Component {
     let parts = posterUrl.split('/');
     let heightValueIndex = parts.indexOf('height') + 1;
     let widthValueIndex = parts.indexOf('width') + 1;
-    parts[heightValueIndex] = 90;
-    parts[widthValueIndex] = 160;
+    parts[heightValueIndex] = '90';
+    parts[widthValueIndex] = '160';
     parts.push('vid_slices/100');
 
     return parts.join('/');

--- a/src/components/seekbar/seekbar.js
+++ b/src/components/seekbar/seekbar.js
@@ -57,7 +57,7 @@ class SeekBarControl extends Component {
   /**
    * before component update, check if the player poster changed and create new preview image url.
    *
-   * @param {any} nextProps
+   * @param {any} nextProps props for the next component update
    * @returns {void}
    * @memberof SeekBarControl
    */


### PR DESCRIPTION
### Description of the Changes

On playerPoster change, generate new preview image in seek bar.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
