### PR TITLE
fix: posterUrl empty string protection

### DIFF
--- a/src/components/seekbar/seekbar.js
+++ b/src/components/seekbar/seekbar.js
@@ -314,6 +314,8 @@ class SeekBarControl extends Component {
    * @memberof SeekBarControl
    */
   getFramePreviewImg(posterUrl: string): string {
+    if (!posterUrl) return '';
+
     let parts = posterUrl.split('/');
     let heightValueIndex = parts.indexOf('height') + 1;
     let widthValueIndex = parts.indexOf('width') + 1;


### PR DESCRIPTION
### Description of the Changes

Adding protection to getFramePreviewImg function

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
