### PR TITLE
fix: remove unused font family

### DIFF
--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -7,7 +7,7 @@ $success-color: #009444;
 $danger-color: #db1f26;
 $ads-color: #F9A71B;
 $live-color: #DA1F26;
-$font-family: 'Lato', sans-serif;
+$font-family: sans-serif;
 $progress-bar-height: 4px;
 $progress-bar-border-radius: $progress-bar-height / 2;
 $spinner-circle-radius: 4px;


### PR DESCRIPTION
### Description of the Changes

following the removal of external Google fonts in https://github.com/kaltura/playkit-js-ui/pull/69 we should remove this reference from scss variables

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
