### PR TITLE
fix: inaccessible play overlay bug fix

### DIFF
--- a/src/styles/_shell.scss
+++ b/src/styles/_shell.scss
@@ -37,6 +37,9 @@
       top: 0; left: 0;
       width: 100%; height: 100%;
     }
+    &.overlay-active :global(#overlay-portal) {
+      z-index: 11;
+    }
     &.metadata-loaded .player-gui,
     &.state-paused .player-gui,
     &.overlay-active .player-gui,

--- a/src/styles/_shell.scss
+++ b/src/styles/_shell.scss
@@ -36,7 +36,6 @@
       position: absolute;
       top: 0; left: 0;
       width: 100%; height: 100%;
-      z-index: 10;
     }
     &.metadata-loaded .player-gui,
     &.state-paused .player-gui,


### PR DESCRIPTION
### Description of the Changes

overlay-portal need to have z-index only when overlay active in order to make play overlay accessible.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
