### PR TITLE
fix(FEC-7152): sorting video tracks by bandwidth bug fix

### DIFF
--- a/src/components/settings/settings.js
+++ b/src/components/settings/settings.js
@@ -183,7 +183,7 @@ class SettingsControl extends BaseComponent {
         return t.bandwidth || t.height
       })
       .sort((a, b) => {
-        return a.bandwidth < b.bandwidth
+        return a.bandwidth < b.bandwidth ? 1 : -1;
       })
       .map(t => ({
         label: this.getQualityOptionLabel(t),


### PR DESCRIPTION
### Description of the Changes

Sort function return value should be -1 | 0 | 1 instead of boolean for cross platform support.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
