### PR TITLE
fix(FEC-7318): volume bar dragging

### DIFF
--- a/src/components/volume/volume.js
+++ b/src/components/volume/volume.js
@@ -62,6 +62,9 @@ class VolumeControl extends BaseComponent {
     this.player.addEventListener(this.player.Event.MUTE_CHANGE, () => {
       this.props.updateMuted(this.player.muted);
     });
+
+    document.addEventListener('mouseup', (e: any) => this.onVolumeProgressBarMouseUp(e));
+    document.addEventListener('mousemove', (e: any) => this.onVolumeProgressBarMouseMove(e));
   }
 
   /**
@@ -189,8 +192,6 @@ class VolumeControl extends BaseComponent {
               className={style.bar}
               ref={c => this._volumeProgressBarElement=c}
               onMouseDown={() => this.onVolumeProgressBarMouseDown()}
-              onMouseUp={e => this.onVolumeProgressBarMouseUp(e)}
-              onMouseMove={e => this.onVolumeProgressBarMouseMove(e)}
             >
               <div className={style.progress} style={{height: this.getVolumeProgressHeight()}} />
             </div>


### PR DESCRIPTION
### Description of the Changes

mouseup and mousemove event changed from progress bar element to document to support ability to change volume from outside of the volume element only.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
