### PR TITLE
fix(FEC-7235): ads container accessible play/pause area.

### DIFF
--- a/src/components/overlay-play/overlay-play.js
+++ b/src/components/overlay-play/overlay-play.js
@@ -17,7 +17,8 @@ const mapStateToProps = state => ({
   adBreak: state.engine.adBreak,
   adIsPlaying: state.engine.adIsPlaying,
   playerHover: state.shell.playerHover,
-  isMobile: state.shell.isMobile
+  isMobile: state.shell.isMobile,
+  metadataLoaded: state.engine.metadataLoaded
 });
 
 @connect(mapStateToProps, bindActions(actions))
@@ -30,6 +31,7 @@ const mapStateToProps = state => ({
  */
 class OverlayPlay extends BaseComponent {
   state: Object;
+  adsContainerClickHandlerInitialized: boolean;
 
   /**
    * Creates an instance of OverlayPlay.
@@ -37,7 +39,26 @@ class OverlayPlay extends BaseComponent {
    * @memberof OverlayPlay
    */
   constructor(obj: Object) {
-    super({name: 'OverlayPlay', player: obj.player});
+    super({name: 'OverlayPlay', player: obj.player, config: obj.config});
+  }
+
+  /**
+   * Set up click event handler to ads container in order to control play pause
+   *
+   * @returns {void}
+   * @memberof OverlayPlay
+   */
+  componentDidUpdate() {
+    if (!this.adsContainerClickHandlerInitialized && this.props.metadataLoaded) {
+      let player = document.getElementById(this.config.targetId);
+      let adsContainer = player.querySelectorAll('*[id^="ads-container_"]');
+
+      if (adsContainer.length > 0) {
+        adsContainer[0].addEventListener('click', () => {
+          this.togglePlayPause();
+        })
+      }
+    }
   }
 
   /**

--- a/src/components/overlay-play/overlay-play.js
+++ b/src/components/overlay-play/overlay-play.js
@@ -51,7 +51,11 @@ class OverlayPlay extends BaseComponent {
   componentDidUpdate() {
     if (!this.adsContainerClickHandlerInitialized && this.props.metadataLoaded) {
       let player = document.getElementById(this.config.targetId);
-      let adsContainer = player.querySelectorAll('*[id^="ads-container_"]');
+      let adsContainer = [];
+
+      if (player) {
+        adsContainer = player.querySelectorAll('*[id^="ads-container_"]');
+      }
 
       if (adsContainer.length > 0) {
         adsContainer[0].addEventListener('click', () => {

--- a/src/ui-presets/playback.js
+++ b/src/ui-presets/playback.js
@@ -29,7 +29,7 @@ export default function playbackUI(props: any): React$Element<any> {
       <Loading player={props.player} />
       <div className={style.playerGui} id='player-gui'>
         <OverlayPortal />
-        <OverlayPlay player={props.player} />
+        <OverlayPlay player={props.player} config={props.config} />
         <BottomBar>
           <SeekBarPlaybackContainer showFramePreview showTimeBubble player={props.player} config={props.config} />
           <div className={style.leftControls}>


### PR DESCRIPTION
### Description of the Changes

Listening to ads-container click event in order to enable play/pause in mobile.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
