### PR TITLE
feat(pre-playback-btn): listen to AUTOPLAY_FAILED and cancel autoplay

### DIFF
--- a/src/components/pre-playback-play-overlay/pre-playback-play-overlay.js
+++ b/src/components/pre-playback-play-overlay/pre-playback-play-overlay.js
@@ -30,7 +30,6 @@ const mapStateToProps = state => ({
    */
 class PrePlaybackPlayOverlay extends BaseComponent {
   autoplay: boolean;
-  mobileAutoplay: boolean;
 
   /**
    * Creates an instance of PrePlaybackPlayOverlay.
@@ -51,17 +50,15 @@ class PrePlaybackPlayOverlay extends BaseComponent {
    */
   componentWillMount() {
     this.props.addPlayerClass(style.prePlayback);
-
     try {
       this.autoplay = this.player.config.playback.autoplay;
+      if (this.autoplay === true) {
+        this.player.addEventListener(this.player.Event.AUTOPLAY_FAILED, () => {
+          this.autoplay = false;
+        });
+      }
     } catch (e) { // eslint-disable-line no-unused-vars
       this.autoplay = false;
-    }
-
-    try {
-      this.mobileAutoplay = this.player.config.playback.mobileAutoplay;
-    } catch (e) { // eslint-disable-line no-unused-vars
-      this.mobileAutoplay = false;
     }
   }
 
@@ -125,12 +122,9 @@ class PrePlaybackPlayOverlay extends BaseComponent {
    * @memberof PrePlaybackPlayOverlay
    */
   render(props: any): React$Element<any> | void {
-    if (
-      (!props.isEnded && !props.prePlayback) ||
-      (!props.isEnded && !props.isMobile && this.autoplay) ||
-      (!props.isEnded && props.isMobile && this.mobileAutoplay)
-    ) return undefined;
-
+    if ((!props.isEnded && !props.prePlayback) || (!props.isEnded && this.autoplay)) {
+      return undefined;
+    }
     return (
       <div className={style.prePlaybackPlayOverlay} style={{backgroundImage: `url(${props.poster})`}}
            onClick={() => this.handleClick()}>

--- a/src/components/shell/shell.js
+++ b/src/components/shell/shell.js
@@ -1,10 +1,10 @@
 //@flow
 import style from '../../styles/style.scss';
-import { h } from 'preact';
+import {h} from 'preact';
 import BaseComponent from '../base';
-import { connect } from 'preact-redux';
-import { bindActions } from '../../utils/bind-actions';
-import { actions } from '../../reducers/shell';
+import {connect} from 'preact-redux';
+import {bindActions} from '../../utils/bind-actions';
+import {actions} from '../../reducers/shell';
 
 /**
  * mapping state to props
@@ -24,16 +24,17 @@ const mapStateToProps = state => ({
 });
 
 @connect(mapStateToProps, bindActions(actions))
-/**
- * Shell component
- *
- * @class Shell
- * @example <Shell player={this.player}>...</Shell>
- * @extends {BaseComponent}
- */
+  /**
+   * Shell component
+   *
+   * @class Shell
+   * @example <Shell player={this.player}>...</Shell>
+   * @extends {BaseComponent}
+   */
 class Shell extends BaseComponent {
   state: Object;
   hoverTimeout: number;
+  fallbackToMutedAutoPlayMode: boolean;
 
   /**
    * Creates an instance of Shell.
@@ -42,6 +43,10 @@ class Shell extends BaseComponent {
    */
   constructor(obj: Object) {
     super({name: 'Shell', player: obj.player});
+    this.fallbackToMutedAutoPlayMode = false;
+    this.player.addEventListener(this.player.Event.FALLBACK_TO_MUTED_AUTOPLAY, () => {
+      this.fallbackToMutedAutoPlayMode = true
+    });
   }
 
   /**
@@ -89,6 +94,19 @@ class Shell extends BaseComponent {
     if (!this.state.hover) {
       this.setState({hover: true});
       this.props.updatePlayerHoverState(true);
+    }
+  }
+
+  /**
+   * if the ui is in fallback to muted autoplay mode, unmute the player on any click
+   *
+   * @returns {void}
+   * @memberof Shell
+   */
+  onClick(): void {
+    if (this.fallbackToMutedAutoPlayMode) {
+      this.player.muted = false;
+      this.fallbackToMutedAutoPlayMode = false;
     }
   }
 
@@ -145,11 +163,12 @@ class Shell extends BaseComponent {
     return (
       <div
         className={playerClasses}
+        onClick={() => this.onClick()}
         onMouseOver={() => this.onMouseOver()}
         onMouseMove={() => this.onMouseMove()}
         onMouseLeave={() => this.onMouseLeave()}
       >
-        { props.children }
+        {props.children}
       </div>
     )
   }


### PR DESCRIPTION
### Description of the Changes

Following playkit-js changes regarding play promise, in case AUTOPLAY_FAILED event is fired, we will want to show the pre-playback button.
Also, the handling for mobile and desktop is the same from now and no need to separate the cases.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
