### PR TITLE
fix(FEC-7196, FEC-7200): ios - live icon is not highlighted and scrubber at left

### DIFF
--- a/src/components/engine-connector/engine-connector.js
+++ b/src/components/engine-connector/engine-connector.js
@@ -55,8 +55,11 @@ class EngineConnector extends BaseComponent {
       this.props.updateDuration(this.player.duration);
     });
 
-    this.player.addEventListener(this.player.Event.LOADED_METADATA, () => {
+    this.player.addEventListener(this.player.Event.LOADED_DATA, () => {
       this.props.updateDuration(this.player.duration);
+    });
+
+    this.player.addEventListener(this.player.Event.LOADED_METADATA, () => {
       this.props.updateMuted(this.player.muted);
       this.props.updateMetadataLoadingStatus(true);
       this.props.updatePlayerPoster(this.player.poster);


### PR DESCRIPTION
### Description of the Changes

'loadedmetadata' is too early to get duration on ios.
get it on `loadeddata`

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
