### PR TITLE
fix: remove pre-playback-button added css

### DIFF
--- a/src/components/pre-playback-play-overlay/_pre-playback-play-overlay.scss
+++ b/src/components/pre-playback-play-overlay/_pre-playback-play-overlay.scss
@@ -5,8 +5,6 @@
   z-index: 10;
   background-position: center center;
   background-size: contain;
-  background-repeat: no-repeat;
-  background-color: #000;
 
   .pre-playback-play-button {
     position: absolute;


### PR DESCRIPTION
### Description of the Changes

@dvh91 
The css in the following PR causes the issue:
https://github.com/kaltura/playkit-js-ui/pull/102

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
