### PR TITLE
fix(FEC-7359): captions overlapping on mobile hover

### DIFF
--- a/src/styles/_captions.scss
+++ b/src/styles/_captions.scss
@@ -10,6 +10,7 @@
   }
   &:not(.overlay-active) {
     &.state-paused :global(.playkit-subtitles),
+    &:hover :global(.playkit-subtitles),
     &.hover :global(.playkit-subtitles) {
       transform: translateY(-60px);
       transition: ease-out 100ms;


### PR DESCRIPTION
### Description of the Changes

captions overlapping on mobile 'hover'

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
