### PR TITLE
fix(FEC-7157): dont show volume bar when smart container open

### DIFF
--- a/src/components/smart-container/smart-container.js
+++ b/src/components/smart-container/smart-container.js
@@ -1,7 +1,9 @@
 //@flow
-import style from './_smart-container.scss';
+import style from '../../styles/style.scss';
 import { h, Component } from 'preact';
 import { connect } from 'preact-redux';
+import { bindActions } from '../../utils/bind-actions';
+import { actions } from '../../reducers/shell';
 import Portal from 'preact-portal';
 import Overlay from '../overlay';
 
@@ -14,7 +16,7 @@ const mapStateToProps = state => ({
   isMobile: state.shell.isMobile
 });
 
-@connect(mapStateToProps)
+@connect(mapStateToProps, bindActions(actions))
 /**
  * SmartContainer component
  *
@@ -31,6 +33,26 @@ const mapStateToProps = state => ({
  * @extends {Component}
  */
 class SmartContainer extends Component {
+
+  /**
+   * before component mounted, add player css class
+   *
+   * @returns {void}
+   * @memberof SmartContainer
+   */
+  componentWillMount() {
+    this.props.addPlayerClass(style.smartContainerOpen);
+  }
+
+  /**
+   * after component unmounted, remove player css class
+   *
+   * @returns {void}
+   * @memberof SmartContainer
+   */
+  componentWillUnmount() {
+    this.props.removePlayerClass(style.smartContainerOpen);
+  }
 
   /**
    * if mobile detected, smart container representation is an overlay. hence, render overlay with its children.

--- a/src/components/volume/_volume.scss
+++ b/src/components/volume/_volume.scss
@@ -2,7 +2,7 @@
 
 .control-button-container.volume-control {
 
-    &:hover {
+    &.hover {
         .volume-control-bar {
             display: block !important;
         }
@@ -73,6 +73,10 @@
     }
 }
 
-.touch .control-button-container.volume-control:hover .volume-control-bar {
+.player.smart-container-open .control-button-container.volume-control.hover .volume-control-bar {
+  display: none !important;
+}
+
+.touch .control-button-container.volume-control.hover .volume-control-bar {
   display: none !important;
 }

--- a/src/components/volume/volume.js
+++ b/src/components/volume/volume.js
@@ -179,9 +179,15 @@ class VolumeControl extends BaseComponent {
       var controlButtonClass = [style.controlButtonContainer, style.volumeControl];
       if (this.props.isDraggingActive) controlButtonClass.push(style.draggingActive);
       if (this.props.muted || this.props.volume === 0) controlButtonClass.push(style.isMuted);
+      if (this.state.hover && !this.props.smartContainerOpen) controlButtonClass.push(style.hover);
 
       return (
-        <div ref={c => this._volumeControlElement=c} className={controlButtonClass.join(' ')}>
+        <div
+          ref={c => this._volumeControlElement=c}
+          className={controlButtonClass.join(' ')}
+          onMouseOver={() => this.setState({hover: true})}
+          onMouseOut={() => this.setState({hover: false})}
+        >
           <button className={style.controlButton} onClick={() => this.onVolumeControlButtonClick()} aria-label='Volume'>
             <Icon type={IconType.VolumeBase} />
             <Icon type={IconType.VolumeWaves} />


### PR DESCRIPTION
### Description of the Changes

adding player class when smart container menu open and using it as a dependency to show volume bar.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
