### PR TITLE
fix(FEC-7359): add native caption style

### DIFF
--- a/src/styles/_captions.scss
+++ b/src/styles/_captions.scss
@@ -1,4 +1,13 @@
 .player {
+  video::-webkit-media-text-track-display {
+    transform: translateY(0px);
+    transition: ease-in 100ms;
+  }
+  &.state-paused video::-webkit-media-text-track-display,
+  &.hover video::-webkit-media-text-track-display {
+    transform: translateY(-60px);
+    transition: ease-out 100ms;
+  }
   &.overlay-active {
     :global(.playkit-subtitles) {
       display: none;


### PR DESCRIPTION
### Description of the Changes

When using native captions (currently on Safari) they should be responsive to the player ui.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
