### PR TITLE
fix(pre-playback-overlay): remove workaround from click handler

### DIFF
--- a/src/components/pre-playback-play-overlay/pre-playback-play-overlay.js
+++ b/src/components/pre-playback-play-overlay/pre-playback-play-overlay.js
@@ -93,27 +93,15 @@ class PrePlaybackPlayOverlay extends BaseComponent {
    * @memberof PrePlaybackPlayOverlay
    */
   handleClick(): void {
-    // TODO: The promise handling should be in the play API of the player.
-    new Promise((resolve, reject) => {
-      try {
-        if (this.player.config.playback.preload === "auto" && !this.player.config.plugins.ima) {
-          this.player.ready().then(resolve);
-        } else {
-          resolve();
-        }
-      } catch (e) {
-        reject(e);
-      }
-    }).then(() => {
+    this.player.ready().then(() => {
       this.player.play();
       if (this.props.prePlayback) {
         this._hidePrePlayback();
       }
-    }).catch((e) => {
-      this.logger.error(e.message);
     });
   }
 
+  /**
   /**
    * render component
    *


### PR DESCRIPTION
### Description of the Changes

Now that the player handling the play promise we can remove the workaround here.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
