### PR TITLE
fix: mute via iOS native player

### DIFF
--- a/src/components/volume/volume.js
+++ b/src/components/volume/volume.js
@@ -56,6 +56,7 @@ class VolumeControl extends BaseComponent {
     })
 
     this.player.addEventListener(this.player.Event.VOLUME_CHANGE, () => {
+      this.props.updateMuted(this.player.muted);
       this.props.updateVolume(this.player.volume);
     });
 


### PR DESCRIPTION
### Description of the Changes

If were muting/unmuting the player via the iOS native player, our UI was not updated.
The solution is to set the mute prop also in VOLUME_CHANGE event handler.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
