### PR TITLE
fix(settings): hide quality selector in case of only 1 option

### DIFF
--- a/src/components/settings/settings.js
+++ b/src/components/settings/settings.js
@@ -220,7 +220,7 @@ class SettingsControl extends BaseComponent {
         { !this.state.smartContainerOpen ? '' :
         <SmartContainer title='Settings' onClose={() => this.onControlButtonClick()}>
           {
-            qualityOptions.length === 0 ? '' :
+            qualityOptions.length <= 1 ? '' :
             <Localizer>
               <SmartContainerItem icon='quality' label={<Text id='settings.quality' />} options={qualityOptions} onSelect={(o) => this.onQualityChange(o)} />
             </Localizer>


### PR DESCRIPTION
### Description of the Changes

If there's only one quality option then there's no reason to show quality menu for user selection

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
