### PR TITLE
fix(FEC-7520): playkit-ui affects the 'a' elements style outside the …

### DIFF
--- a/src/styles/_links.scss
+++ b/src/styles/_links.scss
@@ -1,4 +1,4 @@
-a {
+.player a {
   color: #01ACCD;
   text-decoration: underline;
   font-size: 15px;


### PR DESCRIPTION
…player

### Description of the Changes
add `player` prefix to `a` elements style

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
