### PR TITLE
fix(FEC-7540): head-play/scroller seek is not working properly in regular-default mode in PC

### DIFF
--- a/src/components/seekbar-live-playback-container/seekbar-live-playback-container.js
+++ b/src/components/seekbar-live-playback-container/seekbar-live-playback-container.js
@@ -62,16 +62,18 @@ class SeekBarLivePlaybackContainer extends BaseComponent {
    * @memberof SeekBarLivePlaybackContainer
    */
   render(props: any) {
-    if (!props.isDvr) return undefined;
+    if (!props.isDvr) {
+      return undefined;
+    }
     return (
       <SeekBarControl
+        player={this.props.player}
         playerElement={this.props.playerContainer}
         showTimeBubble={this.props.showTimeBubble}
         changeCurrentTime={time => this.player.currentTime = time}
         playerPoster={this.props.poster}
         updateSeekbarDraggingStatus={data => this.props.updateSeekbarDraggingStatus(data)}
         updateCurrentTime={data => this.props.updateCurrentTime(data)}
-
         isDvr={this.props.isDvr}
         currentTime={this.props.currentTime}
         duration={this.props.duration}

--- a/src/ui-presets/live.js
+++ b/src/ui-presets/live.js
@@ -15,6 +15,7 @@ import OverlayPortal from '../components/overlay-portal';
 import KeyboardControl from '../components/keyboard';
 import LiveTag from '../components/live-tag';
 import UnmuteIndication from '../components/unmute-indication';
+import getComponentConfig from '../utils/component-config';
 
 /**
  * Live ui intrface
@@ -33,7 +34,12 @@ export default function liveUI(props: any): React$Element<any> {
         <UnmuteIndication/>
         <OverlayPlay player={props.player}/>
         <BottomBar>
-          <SeekBarLivePlaybackContainer showFramePreview showTimeBubble player={props.player} config={props.config}/>
+          <SeekBarLivePlaybackContainer
+            showFramePreview
+            showTimeBubble
+            player={props.player}
+            playerContainer={props.playerContainer}
+            config={getComponentConfig(props.config, 'seekbar')}/>
           <div className={style.leftControls}>
             <PlayPauseControl player={props.player}/>
             <LiveTag player={props.player}/>


### PR DESCRIPTION
### Description of the Changes

After seekbar refactor, we forgot to pass the `playerContainer` to the seekbar component in the live preset.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
