### PR TITLE
fix: add live-tag to the tabs order

### DIFF
--- a/src/components/live-tag/live-tag.js
+++ b/src/components/live-tag/live-tag.js
@@ -3,6 +3,7 @@ import style from './_live-tag.scss';
 import {h} from 'preact';
 import {connect} from 'preact-redux';
 import BaseComponent from '../base';
+import {KeyMap} from "../../utils/key-map";
 
 /**
  * mapping state to props
@@ -73,7 +74,14 @@ class LiveTag extends BaseComponent {
     if (props.isDvr && !this.isOnLiveEdge()) tagStyleClass.push(style.nonLivePlayhead);
 
     return (
-      <div className={tagStyleClass.join(' ')} onClick={() => this.onClick()}>Live</div>
+      <div tabIndex="0"
+           className={tagStyleClass.join(' ')}
+           onClick={() => this.onClick()}
+           onKeyDown={(e) => {
+             if (e.keyCode === KeyMap.ENTER) {
+               this.onClick();
+             }
+           }}>Live</div>
     )
   }
 }

--- a/src/styles/_shell.scss
+++ b/src/styles/_shell.scss
@@ -63,7 +63,8 @@
   .custom-captions-applied > a,
   .form-group-row > a,
   .button-save-cvaa,
-  .slider {
+  .slider,
+  .live-tag {
     &:focus {
       outline: 1px solid #00cbff;
     }


### PR DESCRIPTION
### Description of the Changes

Add the live tag to the tabs order.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
