### PR TITLE
fix: disable keyboard seek on ad break

### DIFF
--- a/src/components/seekbar-ads-container/seekbar-ads-container.js
+++ b/src/components/seekbar-ads-container/seekbar-ads-container.js
@@ -47,6 +47,7 @@ class SeekBarAdsContainer extends BaseComponent {
   render(props: any): React$Element<any> {
     return (
       <SeekBarControl
+        player={this.props.player}
         playerElement={this.props.playerContainer}
         changeCurrentTime={time => {  // eslint-disable-line no-unused-vars
         }}
@@ -62,7 +63,6 @@ class SeekBarAdsContainer extends BaseComponent {
       />
     )
   }
-
 }
 
 export default SeekBarAdsContainer;

--- a/src/components/seekbar/seekbar.js
+++ b/src/components/seekbar/seekbar.js
@@ -185,6 +185,9 @@ class SeekBarControl extends Component {
    * @memberof SeekBarControl
    */
   onSeekbarKeyDown(e: KeyboardEvent): void {
+    if (this.props.adBreak) {
+      return;
+    }
     let newTime;
     switch (e.keyCode) {
       case KeyMap.LEFT:

--- a/src/ui-presets/ads.js
+++ b/src/ui-presets/ads.js
@@ -42,7 +42,12 @@ export default function adsUI(props: any): ?React$Element<any> {
           {adsUiCustomization.skipButton ? <AdSkip player={props.player}/> : undefined}
         </div>
         <BottomBar>
-          <SeekBarAdsContainer adBreak showFramePreview showTimeBubble player={props.player}/>
+          <SeekBarAdsContainer
+            adBreak
+            showFramePreview
+            showTimeBubble
+            player={props.player}
+            playerContainer={props.playerContainer}/>
           <div className={style.leftControls}>
             <PlayPauseControl player={props.player}/>
             <TimeDisplayAdsContainer/>


### PR DESCRIPTION
### Description of the Changes

Seek is not allowed while ad is playing, so check if `props.adBreak` set to true and if this the case don't run logic.
Also general fix is added where we are passing to the seekbar component the correct playerContainer via the ads preset.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
