### PR TITLE
fix(FEC-7561): avoid CSS global name space collision

### DIFF
--- a/src/styles/_inputs.scss
+++ b/src/styles/_inputs.scss
@@ -63,19 +63,20 @@ textarea.form-control {
   min-height: 72px;
 }
 
-select {
-  font-size: 15px;
-  font-family: $font-family;
-  color: #fff;
-  -webkit-appearance: none;
-  border: 0;
-  background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='%23FFFFFF' viewBox='0 0 1024 1024'><path d='M301.255 338.745c-24.994-24.994-65.516-24.994-90.51 0s-24.994 65.516 0 90.51l256 256c24.994 24.994 65.516 24.994 90.51 0l256-256c24.994-24.994 24.994-65.516 0-90.51s-65.516-24.994-90.51 0l-210.745 210.745-210.745-210.745z' /></svg>") no-repeat;
-  background-size: 16px;
-  background-position: 100% center;
-  background-repeat: no-repeat;
-  padding-right: 24px;
+.player {
+  select {
+    font-size: 15px;
+    font-family: $font-family;
+    color: #fff;
+    -webkit-appearance: none;
+    border: 0;
+    background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='%23FFFFFF' viewBox='0 0 1024 1024'><path d='M301.255 338.745c-24.994-24.994-65.516-24.994-90.51 0s-24.994 65.516 0 90.51l256 256c24.994 24.994 65.516 24.994 90.51 0l256-256c24.994-24.994 24.994-65.516 0-90.51s-65.516-24.994-90.51 0l-210.745 210.745-210.745-210.745z' /></svg>") no-repeat;
+    background-size: 16px;
+    background-position: 100% center;
+    background-repeat: no-repeat;
+    padding-right: 24px;
+  }
 }
-
 .checkbox {
   font-size: 15px;
   position: relative;


### PR DESCRIPTION
### Description of the Changes

The "select" CSS was not name spaced, causing the player to take over sites "select" CSS selector.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
