### PR TITLE
fix(FEC-7518): captions container overflows

### DIFF
--- a/src/styles/_shell.scss
+++ b/src/styles/_shell.scss
@@ -8,6 +8,8 @@
   overflow: hidden;
   user-select: none;
   width: 100%;
+  height: 100%;
+  position: relative;
 
   &:-webkit-full-screen {
     width: 100%;


### PR DESCRIPTION
### Description of the Changes

captions container overflows outside of player container, this ensures we don't do it.
The issue is when we move the container when hovering or pausing the player and then we need to sync the bottom bar and captions container views.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
