### PR TITLE
fix(FEC-7563): prevent user select of root div element

### DIFF
--- a/src/styles/_shell.scss
+++ b/src/styles/_shell.scss
@@ -10,6 +10,13 @@
   width: 100%;
   height: 100%;
   position: relative;
+  outline: none;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
 
   &:-webkit-full-screen {
     width: 100%;


### PR DESCRIPTION
### Description of the Changes

add CSS rule to prevent root div element of player to be outlined.
caused by #147 

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
