### PR TITLE
revert(FEC-7368): pause of the spinner when loading an ad

### DIFF
--- a/src/components/loading/_loading.scss
+++ b/src/components/loading/_loading.scss
@@ -32,7 +32,6 @@
   background-color: rgba(0, 0, 0, 0.3);
   transition: 100ms opacity;
   opacity: 0;
-  z-index: 5;
 
   &.show {
     opacity: 1;

--- a/src/components/loading/loading.js
+++ b/src/components/loading/loading.js
@@ -37,7 +37,6 @@ class Loading extends BaseComponent {
    */
   constructor(obj: Object) {
     super({name: 'Loading', player: obj.player});
-    this.setState({afterFirstPlay: false});
     try {
       // TODO: Change the dependency on ima to our ads plugin when it will be developed.
       if (this.player.config.playback.preload === "auto" && !this.player.config.plugins.ima) {
@@ -90,9 +89,6 @@ class Loading extends BaseComponent {
     }
 
     this.player.addEventListener(this.player.Event.PLAYER_STATE_CHANGED, e => {
-      if (!this.state.afterFirstPlay) {
-        return;
-      }
       if (e.payload.newState.type === 'idle' || e.payload.newState.type === 'playing' || e.payload.newState.type === 'paused') {
         this.props.updateLoadingSpinnerState(false);
       }
@@ -115,14 +111,6 @@ class Loading extends BaseComponent {
 
     this.player.addEventListener(this.player.Event.ALL_ADS_COMPLETED, () => {
       this.props.updateLoadingSpinnerState(false);
-    });
-
-    this.player.addEventListener(this.player.Event.FIRST_PLAY, () => {
-      this.setState({afterFirstPlay: true});
-    });
-
-    this.player.addEventListener(this.player.Event.CHANGE_SOURCE_STARTED, () => {
-      this.setState({afterFirstPlay: false});
     });
   }
 


### PR DESCRIPTION
reverts #133 (commit a5ea06aec6894e0cf8bd984e048480ab384104f9)

due to n issue that is caused when autoplaying with native adapter.

### Description of the Changes


### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
