### PR TITLE
fix(FEC-7807): no unmute icon on ads on mobile

### DIFF
--- a/src/ui-presets/ads.js
+++ b/src/ui-presets/ads.js
@@ -22,7 +22,14 @@ import UnmuteIndication from '../components/unmute-indication';
  */
 export default function adsUI(props: any): ?React$Element<any> {
   if (useDefaultAdsUi(props)) {
-    return undefined;
+    return (
+      <div className={style.adGuiWrapper}>
+        <Loading player={props.player}/>
+        <div className={style.playerGui} id='player-gui'>
+          <UnmuteIndication player={props.player} hasTopBar/>
+        </div>
+      </div>
+    );
   }
   const adsUiCustomization = getAdsUiCustomization();
   return (
@@ -78,7 +85,7 @@ function getAdsUiCustomization(): Object {
  * @param {any} props - component props
  * @returns {boolean} - Whether the default ads ui should be shown or not.
  */
-function useDefaultAdsUi(props: any): boolean {
+    function useDefaultAdsUi(props: any): boolean {
   try {
     let isMobile = !!props.player.env.device.type;
     let adsRenderingSettings = props.player.config.plugins.ima.adsRenderingSettings;

--- a/src/ui-presets/ads.js
+++ b/src/ui-presets/ads.js
@@ -85,7 +85,7 @@ function getAdsUiCustomization(): Object {
  * @param {any} props - component props
  * @returns {boolean} - Whether the default ads ui should be shown or not.
  */
-    function useDefaultAdsUi(props: any): boolean {
+function useDefaultAdsUi(props: any): boolean {
   try {
     let isMobile = !!props.player.env.device.type;
     let adsRenderingSettings = props.player.config.plugins.ima.adsRenderingSettings;


### PR DESCRIPTION
### Description of the Changes

Changed the return element from 'undefined' to return a player wrapper with the unmute component

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
