### PR TITLE
fix(webpack): playkit core externals root value

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -88,7 +88,7 @@ module.exports = {
       commonjs: "playkit-js",
       commonjs2: "playkit-js",
       amd: "playkit-js",
-      root: "Playkit"
+      root: ["playkit", "core"]
     }
   }
 };


### PR DESCRIPTION
### Description of the Changes

After changing the namespace to playkit.x need to update the externals root value of playkit core.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
