### PR TITLE
fix(FEC-7578): sound of video started to play, if pause pre-roll Ad using navigation mode

### DIFF
--- a/src/components/keyboard/keyboard.js
+++ b/src/components/keyboard/keyboard.js
@@ -14,7 +14,10 @@ import {CONTROL_BAR_HOVER_DEFAULT_TIMEOUT} from "../shell/shell";
  * @returns {Object} - mapped state to this component
  */
 const mapStateToProps = state => ({
-  playerNav: state.shell.playerNav
+  playerNav: state.shell.playerNav,
+  isPlaying: state.engine.isPlaying,
+  adBreak: state.engine.adBreak,
+  adIsPlaying: state.engine.adIsPlaying
 });
 
 /**
@@ -55,10 +58,21 @@ class KeyboardControl extends BaseComponent {
     }
     playerContainer.onkeydown = (e: KeyboardEvent) => {
       if (!this.props.playerNav && typeof this.keyboardHandlers[e.keyCode] === 'function') {
+        // e.stopPropagation();
         this.logger.debug(`KeyDown -> keyName: ${getKeyName(e.keyCode)}, shiftKey: ${e.shiftKey.toString()}`);
         this.keyboardHandlers[e.keyCode](e.shiftKey);
       }
     };
+  }
+
+  /**
+   * check if currently playing ad or playback
+   *
+   * @returns {boolean} - if currently playing ad or playback
+   * @memberof KeyboardControl
+   */
+  isPlayingAdOrPlayback(): boolean {
+    return (this.props.adBreak && this.props.adIsPlaying) || (!this.props.adBreak && this.props.isPlaying);
   }
 
   /**
@@ -69,12 +83,12 @@ class KeyboardControl extends BaseComponent {
    */
   keyboardHandlers: { [key: number]: Function } = {
     [KeyMap.SPACE]: () => {
-      if (this.player.paused) {
-        this.player.play();
-        this.props.updateOverlayActionIcon(IconType.Play);
-      } else {
+      if (this.isPlayingAdOrPlayback()) {
         this.player.pause();
         this.props.updateOverlayActionIcon(IconType.Pause);
+      } else {
+        this.player.play();
+        this.props.updateOverlayActionIcon(IconType.Play);
       }
     },
     [KeyMap.UP]: () => {

--- a/src/components/keyboard/keyboard.js
+++ b/src/components/keyboard/keyboard.js
@@ -58,7 +58,6 @@ class KeyboardControl extends BaseComponent {
     }
     playerContainer.onkeydown = (e: KeyboardEvent) => {
       if (!this.props.playerNav && typeof this.keyboardHandlers[e.keyCode] === 'function') {
-        // e.stopPropagation();
         this.logger.debug(`KeyDown -> keyName: ${getKeyName(e.keyCode)}, shiftKey: ${e.shiftKey.toString()}`);
         this.keyboardHandlers[e.keyCode](e.shiftKey);
       }

--- a/src/ui-presets/ads.js
+++ b/src/ui-presets/ads.js
@@ -12,6 +12,7 @@ import AdLearnMore from '../components/ad-learn-more';
 import TopBar from '../components/top-bar';
 import BottomBar from '../components/bottom-bar';
 import UnmuteIndication from '../components/unmute-indication';
+import KeyboardControl from '../components/keyboard/keyboard'
 
 /**
  * Ads ui interface
@@ -34,6 +35,7 @@ export default function adsUI(props: any): ?React$Element<any> {
   const adsUiCustomization = getAdsUiCustomization();
   return (
     <div className={style.adGuiWrapper}>
+      <KeyboardControl player={props.player} config={props.config}/>
       <Loading player={props.player}/>
       <div className={style.playerGui} id='player-gui'>
         <UnmuteIndication player={props.player} hasTopBar/>


### PR DESCRIPTION
### Description of the Changes

Keyboard component was missing in the ads UI.
Another fix that needed to be done is to get the ads state to the keyboard component.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
