### PR TITLE
fix(FEC-7900): prevent default browser behaviour when using keyboard shortcuts

### DIFF
--- a/src/components/keyboard/keyboard.js
+++ b/src/components/keyboard/keyboard.js
@@ -55,6 +55,7 @@ class KeyboardControl extends BaseComponent {
     }
     playerContainer.onkeydown = (e: KeyboardEvent) => {
       if (!this.props.playerNav && typeof this.keyboardHandlers[e.keyCode] === 'function') {
+        e.preventDefault();
         this.logger.debug(`KeyDown -> keyName: ${getKeyName(e.keyCode)}, shiftKey: ${e.shiftKey.toString()}`);
         this.keyboardHandlers[e.keyCode](e.shiftKey);
       }


### PR DESCRIPTION
### Description of the Changes

When scroll is enabled in the page, clicking on SPACE was also perform scrolling down.
Add `preventDefault()` when `onkeydown` event triggered.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
