### PR TITLE
fix(FEC-7907): No play button when preload and ima plugin

### DIFF
--- a/src/components/loading/loading.js
+++ b/src/components/loading/loading.js
@@ -26,7 +26,6 @@ const mapStateToProps = state => ({
    * @extends {BaseComponent}
    */
 class Loading extends BaseComponent {
-  isPreloading: boolean;
   autoplay: boolean;
   mobileAutoplay: boolean;
 
@@ -38,20 +37,6 @@ class Loading extends BaseComponent {
   constructor(obj: Object) {
     super({name: 'Loading', player: obj.player});
     this.setState({afterPlayingEvent: false});
-    try {
-      // TODO: Change the dependency on ima to our ads plugin when it will be developed.
-      if (this.player.config.playback.preload === "auto" && !this.player.config.plugins.ima) {
-        this.isPreloading = true;
-        this.player.addEventListener(this.player.Event.PLAYER_STATE_CHANGED, (e) => {
-          if (e.payload.oldState.type === this.player.State.LOADING) {
-            this.isPreloading = false;
-          }
-        });
-      }
-    } catch (e) {
-      this.logger.error(e.message);
-      this.isPreloading = false;
-    }
   }
 
   /**
@@ -139,7 +124,7 @@ class Loading extends BaseComponent {
    * @memberof Loading
    */
   render(props: any): React$Element<any> | void {
-    if (!props.show || this.isPreloading) return undefined;
+    if (!props.show) return undefined;
 
     return (
       <div className={[style.loadingBackdrop, style.show].join(' ')}>

--- a/src/components/loading/loading.js
+++ b/src/components/loading/loading.js
@@ -125,6 +125,10 @@ class Loading extends BaseComponent {
     this.player.addEventListener(this.player.Event.CHANGE_SOURCE_STARTED, () => {
       this.setState({afterPlayingEvent: false});
     });
+
+    this.player.addEventListener(this.player.Event.WAITING_FOR_SOURCE, () => {
+      this.props.updateLoadingSpinnerState(true);
+    });
   }
 
   /**

--- a/src/components/loading/loading.js
+++ b/src/components/loading/loading.js
@@ -110,10 +110,6 @@ class Loading extends BaseComponent {
     this.player.addEventListener(this.player.Event.CHANGE_SOURCE_STARTED, () => {
       this.setState({afterPlayingEvent: false});
     });
-
-    this.player.addEventListener(this.player.Event.WAITING_FOR_SOURCE, () => {
-      this.props.updateLoadingSpinnerState(true);
-    });
   }
 
   /**

--- a/src/components/pre-playback-play-overlay/pre-playback-play-overlay.js
+++ b/src/components/pre-playback-play-overlay/pre-playback-play-overlay.js
@@ -7,6 +7,7 @@ import {actions} from '../../reducers/shell';
 import BaseComponent from '../base';
 import {default as Icon, IconType} from '../icon';
 import {KeyMap} from "../../utils/key-map";
+import {actions as loadingActions} from '../../reducers/loading';
 
 /**
  * mapping state to props
@@ -21,7 +22,7 @@ const mapStateToProps = state => ({
   isEnded: state.engine.isEnded
 });
 
-@connect(mapStateToProps, bindActions(actions))
+@connect(mapStateToProps, bindActions(Object.assign(actions, loadingActions)))
   /**
    * PrePlaybackPlayOverlay component
    *
@@ -97,6 +98,7 @@ class PrePlaybackPlayOverlay extends BaseComponent {
     this.player.play();
     if (this.props.prePlayback) {
       this._hidePrePlayback();
+      this.props.updateLoadingSpinnerState(true);
     }
   }
 

--- a/src/components/pre-playback-play-overlay/pre-playback-play-overlay.js
+++ b/src/components/pre-playback-play-overlay/pre-playback-play-overlay.js
@@ -50,9 +50,6 @@ class PrePlaybackPlayOverlay extends BaseComponent {
    * @memberof PrePlaybackPlayOverlay
    */
   componentWillMount() {
-    this.player.ready().then(() => {
-      this.setState({isPlayerReady: true});
-    });
     this.props.addPlayerClass(style.prePlayback);
     try {
       this.autoplay = this.player.config.playback.autoplay;
@@ -114,7 +111,6 @@ class PrePlaybackPlayOverlay extends BaseComponent {
     if ((!props.isEnded && !props.prePlayback) || (!props.isEnded && this.autoplay)) {
       return undefined;
     }
-    const isPlayerReady = this.player.config.playback.preload === "auto" ? this.state.isPlayerReady : true;
     let rootStyle = {},
       rootClass = [style.prePlaybackPlayOverlay];
 
@@ -127,9 +123,8 @@ class PrePlaybackPlayOverlay extends BaseComponent {
       <div
         className={rootClass.join(' ')}
         style={rootStyle}
-        onClick={() => isPlayerReady ? this.handleClick() : undefined}>
-        {isPlayerReady ?
-          <a className={style.prePlaybackPlayButton}
+        onClick={() => this.handleClick()}>
+        {<a className={style.prePlaybackPlayButton}
              tabIndex="0"
              onKeyDown={(e) => {
                if (e.keyCode === KeyMap.ENTER) {
@@ -137,8 +132,7 @@ class PrePlaybackPlayOverlay extends BaseComponent {
                }
              }}>
             {props.isEnded ? <Icon type={IconType.StartOver}/> : <Icon type={IconType.Play}/>}
-          </a>
-          : undefined}
+          </a>}
       </div>
     )
   }


### PR DESCRIPTION
### Description of the Changes

show pre playback play button as soon as possible and load spinner once clicked
this change is possible since https://github.com/kaltura/playkit-js/pull/193

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
