### PR TITLE
fix(FEC-7930): slide with the keyboard in CVAA menu seeks back and forth the player

### DIFF
--- a/src/components/slider/slider.js
+++ b/src/components/slider/slider.js
@@ -76,6 +76,7 @@ class Slider extends Component {
    * @memberof Slider
    */
   onKeyboardDragging(e: KeyboardEvent): void {
+    e.stopPropagation();
     this._sliderElementOffsetLeft = this._sliderElement.getBoundingClientRect().left;
     let newValue = this.props.value;
     switch (e.keyCode) {


### PR DESCRIPTION
### Description of the Changes

Stop event propagation in keyboard slide of CVAA menu sliders.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
