### PR TITLE
fix(FEC-7956): When autoplay fails, loading spinner stays in the background

### DIFF
--- a/src/components/loading/loading.js
+++ b/src/components/loading/loading.js
@@ -27,7 +27,6 @@ const mapStateToProps = state => ({
    */
 class Loading extends BaseComponent {
   autoplay: boolean;
-  mobileAutoplay: boolean;
 
   /**
    * Creates an instance of Loading.
@@ -48,17 +47,10 @@ class Loading extends BaseComponent {
   componentWillMount() {
     try {
       this.autoplay = this.player.config.playback.autoplay;
-    }
-    catch (e) { // eslint-disable-line no-unused-vars
+    } catch (e) { // eslint-disable-line no-unused-vars
       this.autoplay = false;
     }
 
-    try {
-      this.mobileAutoplay = this.player.config.playback.mobileAutoplay;
-    }
-    catch (e) { // eslint-disable-line no-unused-vars
-      this.mobileAutoplay = false;
-    }
   }
 
   /**
@@ -70,18 +62,20 @@ class Loading extends BaseComponent {
    * @memberof Loading
    */
   componentDidMount() {
-    if (!this.props.isMobile && this.autoplay || this.props.isMobile && this.mobileAutoplay) {
+    if (this.autoplay) {
       this.props.updateLoadingSpinnerState(true);
     }
 
     this.player.addEventListener(this.player.Event.PLAYER_STATE_CHANGED, e => {
+      const StateType = this.player.State;
       if (!this.state.afterPlayingEvent) {
         return;
       }
-      if (e.payload.newState.type === 'idle' || e.payload.newState.type === 'playing' || e.payload.newState.type === 'paused') {
+      if (e.payload.newState.type === StateType.IDLE
+        || e.payload.newState.type === StateType.PLAYING
+        || e.payload.newState.type === StateType.PAUSED) {
         this.props.updateLoadingSpinnerState(false);
-      }
-      else {
+      } else {
         this.props.updateLoadingSpinnerState(true);
       }
     });
@@ -99,6 +93,10 @@ class Loading extends BaseComponent {
     });
 
     this.player.addEventListener(this.player.Event.ALL_ADS_COMPLETED, () => {
+      this.props.updateLoadingSpinnerState(false);
+    });
+
+    this.player.addEventListener(this.player.Event.AUTOPLAY_FAILED, () => {
       this.props.updateLoadingSpinnerState(false);
     });
 


### PR DESCRIPTION
### Description of the Changes

Hide loading spinner when autoplay failed event is triggered.
Also, get rid of the mobileAutoplay flags since its redundant and doesn't exists in the player.

caused by #156

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
