### PR TITLE
fix(FEC-7535): Setting autoplay causes player spinner before loading media

### DIFF
--- a/src/components/loading/loading.js
+++ b/src/components/loading/loading.js
@@ -26,8 +26,6 @@ const mapStateToProps = state => ({
    * @extends {BaseComponent}
    */
 class Loading extends BaseComponent {
-  autoplay: boolean;
-
   /**
    * Creates an instance of Loading.
    * @param {Object} obj obj
@@ -36,21 +34,6 @@ class Loading extends BaseComponent {
   constructor(obj: Object) {
     super({name: 'Loading', player: obj.player});
     this.setState({afterPlayingEvent: false});
-  }
-
-  /**
-   * before component mount, update the autoplay and mobileAutoplay values from player config
-   *
-   * @returns {void}
-   * @memberof Loading
-   */
-  componentWillMount() {
-    try {
-      this.autoplay = this.player.config.playback.autoplay;
-    } catch (e) { // eslint-disable-line no-unused-vars
-      this.autoplay = false;
-    }
-
   }
 
   /**
@@ -77,7 +60,7 @@ class Loading extends BaseComponent {
     });
 
     this.player.addEventListener(this.player.Event.SOURCE_SELECTED, () => {
-      if (this.autoplay && !this.props.adBreak) {
+      if (this.player.config.autoplay && !this.props.adBreak) {
         this.props.updateLoadingSpinnerState(true);
       }
     });

--- a/src/components/loading/loading.js
+++ b/src/components/loading/loading.js
@@ -62,10 +62,6 @@ class Loading extends BaseComponent {
    * @memberof Loading
    */
   componentDidMount() {
-    if (this.autoplay) {
-      this.props.updateLoadingSpinnerState(true);
-    }
-
     this.player.addEventListener(this.player.Event.PLAYER_STATE_CHANGED, e => {
       const StateType = this.player.State;
       if (!this.state.afterPlayingEvent) {
@@ -76,6 +72,12 @@ class Loading extends BaseComponent {
         || e.payload.newState.type === StateType.PAUSED) {
         this.props.updateLoadingSpinnerState(false);
       } else {
+        this.props.updateLoadingSpinnerState(true);
+      }
+    });
+
+    this.player.addEventListener(this.player.Event.SOURCE_SELECTED, () => {
+      if (this.autoplay && !this.props.adBreak) {
         this.props.updateLoadingSpinnerState(true);
       }
     });

--- a/src/components/loading/loading.js
+++ b/src/components/loading/loading.js
@@ -60,7 +60,7 @@ class Loading extends BaseComponent {
     });
 
     this.player.addEventListener(this.player.Event.SOURCE_SELECTED, () => {
-      if (this.player.config.autoplay && !this.props.adBreak) {
+      if (this.player.config.autoplay) {
         this.props.updateLoadingSpinnerState(true);
       }
     });


### PR DESCRIPTION
### Description of the Changes

If were setting up the player and calling later in the code to loadMedia (or configure with sources) spinner will be showing endlessly (not the best user experience).
So we need to raise up the spinner only when source selected and autoplay is on and exclude the case of an ad break.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
