### PR TITLE
fix(FEC-7959): speed down ui gesture is shown without pressing shift button

### DIFF
--- a/src/components/keyboard/keyboard.js
+++ b/src/components/keyboard/keyboard.js
@@ -182,8 +182,8 @@ class KeyboardControl extends BaseComponent {
           this.logger.debug(`Changing playback rate. ${playbackRate} => ${this.player.playbackRates[index - 1]}`);
           this.player.playbackRate = this.player.playbackRates[index - 1];
         }
+        this.props.updateOverlayActionIcon(IconType.SpeedDown);
       }
-      this.props.updateOverlayActionIcon(IconType.SpeedDown);
     },
     [KeyMap.C]: () => {
       let activeTextTrack = this.player.getActiveTracks().text;


### PR DESCRIPTION
### Description of the Changes

Steps to reproduce:
1. Press <

Expected result:
Player will do nothing

Actual result:
Speed down UI gesture is shown

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
