### PR TITLE
fix(FEC-7963): native menus are not opened in mobile devices (Android/iOS)

### DIFF
--- a/src/components/pre-playback-play-overlay/pre-playback-play-overlay.js
+++ b/src/components/pre-playback-play-overlay/pre-playback-play-overlay.js
@@ -95,6 +95,7 @@ class PrePlaybackPlayOverlay extends BaseComponent {
    * @memberof PrePlaybackPlayOverlay
    */
   handleClick(): void {
+    this.player.getView().focus();
     this.player.play();
     if (this.props.prePlayback) {
       this._hidePrePlayback();
@@ -127,14 +128,14 @@ class PrePlaybackPlayOverlay extends BaseComponent {
         style={rootStyle}
         onClick={() => this.handleClick()}>
         {<a className={style.prePlaybackPlayButton}
-             tabIndex="0"
-             onKeyDown={(e) => {
-               if (e.keyCode === KeyMap.ENTER) {
-                 this.handleClick();
-               }
-             }}>
-            {props.isEnded ? <Icon type={IconType.StartOver}/> : <Icon type={IconType.Play}/>}
-          </a>}
+            tabIndex="0"
+            onKeyDown={(e) => {
+              if (e.keyCode === KeyMap.ENTER) {
+                this.handleClick();
+              }
+            }}>
+          {props.isEnded ? <Icon type={IconType.StartOver}/> : <Icon type={IconType.Play}/>}
+        </a>}
       </div>
     )
   }

--- a/src/components/shell/shell.js
+++ b/src/components/shell/shell.js
@@ -50,7 +50,6 @@ class Shell extends BaseComponent {
   state: Object;
   _hoverTimeout: number;
   _fallbackToMutedAutoPlayMode: boolean;
-  _el: HTMLDivElement;
 
   /**
    * Creates an instance of Shell.
@@ -114,9 +113,6 @@ class Shell extends BaseComponent {
     if (this._fallbackToMutedAutoPlayMode) {
       this.player.muted = false;
       this._fallbackToMutedAutoPlayMode = false;
-    }
-    if (!this.state.nav) {
-      this._el.focus();
     }
   }
 
@@ -226,7 +222,6 @@ class Shell extends BaseComponent {
     return (
       <div
         tabIndex="0"
-        ref={el => this._el = el}
         className={playerClasses}
         onClick={() => this.onClick()}
         onMouseOver={() => this.onMouseOver()}


### PR DESCRIPTION
### Description of the Changes

Issue occurs because the shell catch any click on it and focused his own element.
Moved the pre playback click logic to the pre playback component.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
