### PR TITLE
fix(FEC-7964): touch while playing on mobiles always pause/resume the video

### DIFF
--- a/src/components/shell/shell.js
+++ b/src/components/shell/shell.js
@@ -199,6 +199,9 @@ class Shell extends BaseComponent {
       this.player.removeEventListener(this.player.Event.PLAYING, onPlaying);
       this._updatePlayerHoverState();
     };
+    this.player.addEventListener(this.player.Event.CHANGE_SOURCE_STARTED, () => {
+      this.player.addEventListener(this.player.Event.PLAYING, onPlaying);
+    });
     this.player.addEventListener(this.player.Event.PLAYING, onPlaying);
   }
 

--- a/src/components/shell/shell.js
+++ b/src/components/shell/shell.js
@@ -191,9 +191,15 @@ class Shell extends BaseComponent {
         this.props.updateDocumentWidth(document.body.clientWidth);
       }
     });
-    this.player.addEventListener(this.player.Event.FIRST_PLAY, () => {
+    /**
+     * Handler for the first playing event - remove the listener and turn on the hover state.
+     * @returns {void}
+     */
+    const onPlaying = () => {
+      this.player.removeEventListener(this.player.Event.PLAYING, onPlaying);
       this._updatePlayerHoverState();
-    });
+    };
+    this.player.addEventListener(this.player.Event.PLAYING, onPlaying);
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

Fix regression issue when bottom bar doesn't appears on mobiles when video starts to play.
Change the hover state to start on first playing instead of first play.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
