### PR TITLE
fix(FEC-7988): [watermark] - when using a custom image it partially h…

### DIFF
--- a/src/components/pre-playback-play-overlay/_pre-playback-play-overlay.scss
+++ b/src/components/pre-playback-play-overlay/_pre-playback-play-overlay.scss
@@ -4,7 +4,6 @@
   left: 0;
   width: 100%;
   height: 100%;
-  z-index: 10;
   background-position: center center;
   background-size: contain;
   background-repeat: no-repeat;
@@ -14,6 +13,7 @@
   }
 
   .pre-playback-play-button {
+    z-index: 10;
     position: absolute;
     top: 50%;
     left: 50%;

--- a/src/components/watermark/_watermark.scss
+++ b/src/components/watermark/_watermark.scss
@@ -1,7 +1,7 @@
 .player .watermark {
   position: absolute;
   padding: 5px;
-  z-index: 11;
+  z-index: 5;
   transition: visibility 0s 1s, opacity 1s linear, transform ease-out 100ms;
   &.hide-watermark {
     visibility: hidden;


### PR DESCRIPTION
…ides the play/replay icons

### Description of the Changes

* move the `z-index` setting from `pre-playback-overlay` to `pre-playback-button`
* decrease the watermark `z-index` to not overlap the menus

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
