### PR TITLE
fix(FEC-7992): on replay, hovering causes watermark to move up and down

### DIFF
--- a/src/components/pre-playback-play-overlay/pre-playback-play-overlay.js
+++ b/src/components/pre-playback-play-overlay/pre-playback-play-overlay.js
@@ -89,6 +89,20 @@ class PrePlaybackPlayOverlay extends BaseComponent {
   }
 
   /**
+   * change in component props or state shouldn't render the component again
+   *
+   * @returns {boolean} shouldComponentUpdate
+   * @param {Object} nextProps - nextProps
+   * @memberof PrePlaybackPlayOverlay
+   */
+  shouldComponentUpdate(nextProps: Object): boolean {
+    if (nextProps.isEnded) {
+      this.props.addPlayerClass(style.prePlayback);
+    }
+    return true;
+  }
+
+  /**
    * play on click
    *
    * @returns {void}


### PR DESCRIPTION
### Description of the Changes

add `pre-playback` class to the player on `ended`

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
