### PR TITLE
fix(FEC-7990): captions do not move down when the bottom bar disappears

### DIFF
--- a/src/styles/_captions.scss
+++ b/src/styles/_captions.scss
@@ -19,7 +19,6 @@
   }
   &:not(.overlay-active) {
     &.state-paused :global(.playkit-subtitles),
-    &:hover :global(.playkit-subtitles),
     &.hover :global(.playkit-subtitles) {
       transform: translateY(-60px);
       transition: ease-out 100ms;


### PR DESCRIPTION
### Description of the Changes

Fixing the css selectors.
The condition `:hover` isn't correct since we need to relay only on the `.hover` state.
When the mouse is hovering the player but the bottom bar disappears, the `:hover` is true what cause the selector to include a wrong style.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
