### PR TITLE
fix(FEC-7964):  after first play the control bar is hidden on touch devices

### DIFF
--- a/src/components/shell/shell.js
+++ b/src/components/shell/shell.js
@@ -190,18 +190,6 @@ class Shell extends BaseComponent {
         this.props.updateDocumentWidth(document.body.clientWidth);
       }
     });
-    /**
-     * Handler for the first playing event - remove the listener and turn on the hover state.
-     * @returns {void}
-     */
-    const onPlaying = () => {
-      this.player.removeEventListener(this.player.Event.PLAYING, onPlaying);
-      this._updatePlayerHoverState();
-    };
-    this.player.addEventListener(this.player.Event.CHANGE_SOURCE_STARTED, () => {
-      this.player.addEventListener(this.player.Event.PLAYING, onPlaying);
-    });
-    this.player.addEventListener(this.player.Event.PLAYING, onPlaying);
   }
 
   /**
@@ -259,6 +247,20 @@ class Shell extends BaseComponent {
     if (this.hoverTimeout) {
       clearTimeout(this.hoverTimeout);
       this.hoverTimeout = null;
+    }
+  }
+
+  /**
+   * when component did update and change its props from prePlayback to !prePlayback
+   * update the hover state
+   *
+   * @param {Object} prevProps - previous props
+   * @returns {void}
+   * @memberof Shell
+   */
+  componentDidUpdate(prevProps: Object): void {
+    if (!this.props.prePlayback && prevProps.prePlayback) {
+      this._updatePlayerHoverState();
     }
   }
 


### PR DESCRIPTION
### Description of the Changes

Previous logic shows the hover state on first time the player started to play.
But when we played entry with `preload=auto` it was still too early since `props.prePlayback` was still has `true` value in `_updatePlayerHoverState` what caused the method to terminate.
Change the implementation to when component did update with changes props from prePlayback to !prePlayback => show the hover state for the first time.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
