### PR TITLE
fix(FEC-8012): captions on ipad displayed in center

### DIFF
--- a/src/components/fullscreen/_fullscreen.scss
+++ b/src/components/fullscreen/_fullscreen.scss
@@ -23,3 +23,8 @@
     transform: scale(1.1);
   }
 }
+
+.native-fullscreen video {
+  width: auto;
+  height: auto;
+}

--- a/src/components/fullscreen/_fullscreen.scss
+++ b/src/components/fullscreen/_fullscreen.scss
@@ -24,7 +24,7 @@
   }
 }
 
-.native-fullscreen video {
+.native-tablet-fullscreen video {
   width: auto;
   height: auto;
 }

--- a/src/components/fullscreen/fullscreen.js
+++ b/src/components/fullscreen/fullscreen.js
@@ -101,13 +101,13 @@ class FullscreenControl extends BaseComponent {
   attachIosFullscreenListeners(): void {
     this.player.getVideoElement().addEventListener('webkitbeginfullscreen', () => {
       if (this.player.env.device.type === 'tablet') {
-        this.props.addPlayerClass(style.nativeFullscreen);
+        this.props.addPlayerClass(style.nativeTabletFullscreen);
       }
       this.fullscreenEnterHandler();
     });
     this.player.getVideoElement().addEventListener('webkitendfullscreen', () => {
       if (this.player.env.device.type === 'tablet') {
-        this.props.removePlayerClass(style.nativeFullscreen);
+        this.props.removePlayerClass(style.nativeTabletFullscreen);
       }
       this.fullscreenExitHandler();
     });

--- a/src/components/fullscreen/fullscreen.js
+++ b/src/components/fullscreen/fullscreen.js
@@ -4,7 +4,8 @@ import {h} from 'preact';
 import {Localizer, Text} from 'preact-i18n';
 import {connect} from 'preact-redux';
 import {bindActions} from '../../utils/bind-actions';
-import {actions} from '../../reducers/fullscreen';
+import {actions} from '../../reducers/shell';
+import {actions as fullscreenActions} from '../../reducers/fullscreen';
 import BaseComponent from '../base';
 import {default as Icon, IconType} from '../icon';
 
@@ -19,7 +20,7 @@ const mapStateToProps = state => ({
   isMobile: state.shell.isMobile
 });
 
-@connect(mapStateToProps, bindActions(actions))
+@connect(mapStateToProps, bindActions(Object.assign(actions, fullscreenActions)))
   /**
    * FullscreenControl component
    *
@@ -51,10 +52,11 @@ class FullscreenControl extends BaseComponent {
     document.addEventListener('MSFullscreenChange', () => this.fullscreenChangeHandler());
     this.player.addEventListener(this.player.Event.REQUESTED_ENTER_FULLSCREEN, () => this.enterFullscreen());
     this.player.addEventListener(this.player.Event.REQUESTED_EXIT_FULLSCREEN, () => this.exitFullscreen());
+    this.player.addEventListener(this.player.Event.SOURCE_SELECTED, () => this.attachIosFullscreenListeners());
   }
 
   /**
-   * fullscreen change handler function. updates the store with new value
+   * fullscreen change handler function.
    *
    * @returns {void}
    * @memberof FullscreenControl
@@ -65,8 +67,47 @@ class FullscreenControl extends BaseComponent {
       typeof document.mozFullScreenElement !== 'undefined' && Boolean(document.mozFullScreenElement) ||
       typeof document.msFullscreenElement !== 'undefined' && Boolean(document.msFullscreenElement);
 
-    isFullscreen ? this.player.notifyEnterFullscreen() : this.player.notifyExitFullscreen();
-    this.props.updateFullscreen(isFullscreen);
+    isFullscreen ? this.fullscreenEnterHandler() : this.fullscreenExitHandler();
+  }
+
+  /**
+   * fullscreen enter handler function. updates the store with new value
+   *
+   * @returns {void}
+   * @memberof FullscreenControl
+   */
+  fullscreenEnterHandler(): void {
+    this.player.notifyEnterFullscreen();
+    this.props.updateFullscreen(true);
+  }
+
+  /**
+   * fullscreen exit handler function. updates the store with new value
+   *
+   * @returns {void}
+   * @memberof FullscreenControl
+   */
+  fullscreenExitHandler(): void {
+    this.player.notifyExitFullscreen();
+    this.props.updateFullscreen(false);
+  }
+
+  /**
+   *
+   */
+  attachIosFullscreenListeners(): void {
+    this.player.getVideoElement().addEventListener('webkitbeginfullscreen', () => {
+      if (this.player.env.device.type === 'tablet') {
+        this.props.addPlayerClass(style.nativeFullscreen);
+      }
+      this.fullscreenEnterHandler();
+    });
+    this.player.getVideoElement().addEventListener('webkitendfullscreen', () => {
+      if (this.player.env.device.type === 'tablet') {
+        this.props.removePlayerClass(style.nativeFullscreen);
+      }
+      this.fullscreenExitHandler();
+    });
   }
 
   /**
@@ -96,14 +137,14 @@ class FullscreenControl extends BaseComponent {
 
   /**
    * if mobile detected, get the video element and request fullscreen.
-   * otherwise, request fullscreen to the parent plater view than includes the GUI as well
+   * otherwise, request fullscreen to the parent player view than includes the GUI as well
    *
    * @returns {void}
    * @memberof FullscreenControl
    */
   enterFullscreen(): void {
     if (this.props.isMobile && this.player.env.os.name === 'iOS') {
-      this.player.getView().getElementsByTagName('video')[0].webkitEnterFullscreen();
+      this.player.getVideoElement().webkitEnterFullscreen();
     } else {
       let elementToFullscreen = document.getElementById(this.props.targetId);
       if (elementToFullscreen) {

--- a/src/components/fullscreen/fullscreen.js
+++ b/src/components/fullscreen/fullscreen.js
@@ -52,6 +52,16 @@ class FullscreenControl extends BaseComponent {
     document.addEventListener('MSFullscreenChange', () => this.fullscreenChangeHandler());
     this.player.addEventListener(this.player.Event.REQUESTED_ENTER_FULLSCREEN, () => this.enterFullscreen());
     this.player.addEventListener(this.player.Event.REQUESTED_EXIT_FULLSCREEN, () => this.exitFullscreen());
+    this.hanldeIosFullscreen();
+  }
+
+  /**
+   * Handle iOS full screen changes
+   *
+   * @returns {void}
+   * @memberof FullscreenControl
+   */
+  hanldeIosFullscreen(): void {
     if (this.player.env.os.name === 'iOS') {
       /**
        * Attach listeners to ios full screen change.

--- a/src/components/fullscreen/fullscreen.js
+++ b/src/components/fullscreen/fullscreen.js
@@ -46,13 +46,34 @@ class FullscreenControl extends BaseComponent {
    * @memberof FullscreenControl
    */
   componentDidMount() {
+    /**
+     * Attach listeners to ios full screen change.
+     * @returns {void}
+     */
+    const attachIosFullscreenListeners = () => {
+      this.player.removeEventListener(this.player.Event.SOURCE_SELECTED, attachIosFullscreenListeners);
+      this.player.getVideoElement().addEventListener('webkitbeginfullscreen', () => {
+        if (this.player.env.device.type === 'tablet') {
+          this.props.addPlayerClass(style.nativeTabletFullscreen);
+        }
+        this.fullscreenEnterHandler();
+      });
+      this.player.getVideoElement().addEventListener('webkitendfullscreen', () => {
+        if (this.player.env.device.type === 'tablet') {
+          this.props.removePlayerClass(style.nativeTabletFullscreen);
+        }
+        this.fullscreenExitHandler();
+      });
+    };
     document.addEventListener('webkitfullscreenchange', () => this.fullscreenChangeHandler());
     document.addEventListener('mozfullscreenchange', () => this.fullscreenChangeHandler());
     document.addEventListener('fullscreenchange', () => this.fullscreenChangeHandler());
     document.addEventListener('MSFullscreenChange', () => this.fullscreenChangeHandler());
     this.player.addEventListener(this.player.Event.REQUESTED_ENTER_FULLSCREEN, () => this.enterFullscreen());
     this.player.addEventListener(this.player.Event.REQUESTED_EXIT_FULLSCREEN, () => this.exitFullscreen());
-    this.player.addEventListener(this.player.Event.SOURCE_SELECTED, () => this.attachIosFullscreenListeners());
+    if (this.player.env.os.name === 'iOS') {
+      this.player.addEventListener(this.player.Event.SOURCE_SELECTED, attachIosFullscreenListeners);
+    }
   }
 
   /**
@@ -90,27 +111,6 @@ class FullscreenControl extends BaseComponent {
   fullscreenExitHandler(): void {
     this.player.notifyExitFullscreen();
     this.props.updateFullscreen(false);
-  }
-
-  /**
-   * Attach listeners to ios full screen change
-   *
-   * @returns {void}
-   * @memberof FullscreenControl
-   */
-  attachIosFullscreenListeners(): void {
-    this.player.getVideoElement().addEventListener('webkitbeginfullscreen', () => {
-      if (this.player.env.device.type === 'tablet') {
-        this.props.addPlayerClass(style.nativeTabletFullscreen);
-      }
-      this.fullscreenEnterHandler();
-    });
-    this.player.getVideoElement().addEventListener('webkitendfullscreen', () => {
-      if (this.player.env.device.type === 'tablet') {
-        this.props.removePlayerClass(style.nativeTabletFullscreen);
-      }
-      this.fullscreenExitHandler();
-    });
   }
 
   /**

--- a/src/components/fullscreen/fullscreen.js
+++ b/src/components/fullscreen/fullscreen.js
@@ -46,25 +46,6 @@ class FullscreenControl extends BaseComponent {
    * @memberof FullscreenControl
    */
   componentDidMount() {
-    /**
-     * Attach listeners to ios full screen change.
-     * @returns {void}
-     */
-    const attachIosFullscreenListeners = () => {
-      this.player.removeEventListener(this.player.Event.SOURCE_SELECTED, attachIosFullscreenListeners);
-      this.player.getVideoElement().addEventListener('webkitbeginfullscreen', () => {
-        if (this.player.env.device.type === 'tablet') {
-          this.props.addPlayerClass(style.nativeTabletFullscreen);
-        }
-        this.fullscreenEnterHandler();
-      });
-      this.player.getVideoElement().addEventListener('webkitendfullscreen', () => {
-        if (this.player.env.device.type === 'tablet') {
-          this.props.removePlayerClass(style.nativeTabletFullscreen);
-        }
-        this.fullscreenExitHandler();
-      });
-    };
     document.addEventListener('webkitfullscreenchange', () => this.fullscreenChangeHandler());
     document.addEventListener('mozfullscreenchange', () => this.fullscreenChangeHandler());
     document.addEventListener('fullscreenchange', () => this.fullscreenChangeHandler());
@@ -72,6 +53,25 @@ class FullscreenControl extends BaseComponent {
     this.player.addEventListener(this.player.Event.REQUESTED_ENTER_FULLSCREEN, () => this.enterFullscreen());
     this.player.addEventListener(this.player.Event.REQUESTED_EXIT_FULLSCREEN, () => this.exitFullscreen());
     if (this.player.env.os.name === 'iOS') {
+      /**
+       * Attach listeners to ios full screen change.
+       * @returns {void}
+       */
+      const attachIosFullscreenListeners = () => {
+        this.player.removeEventListener(this.player.Event.SOURCE_SELECTED, attachIosFullscreenListeners);
+        this.player.getVideoElement().addEventListener('webkitbeginfullscreen', () => {
+          if (this.player.env.device.type === 'tablet') {
+            this.props.addPlayerClass(style.nativeTabletFullscreen);
+          }
+          this.fullscreenEnterHandler();
+        });
+        this.player.getVideoElement().addEventListener('webkitendfullscreen', () => {
+          if (this.player.env.device.type === 'tablet') {
+            this.props.removePlayerClass(style.nativeTabletFullscreen);
+          }
+          this.fullscreenExitHandler();
+        });
+      };
       this.player.addEventListener(this.player.Event.SOURCE_SELECTED, attachIosFullscreenListeners);
     }
   }

--- a/src/components/fullscreen/fullscreen.js
+++ b/src/components/fullscreen/fullscreen.js
@@ -93,7 +93,10 @@ class FullscreenControl extends BaseComponent {
   }
 
   /**
+   * Attach listeners to ios full screen change
    *
+   * @returns {void}
+   * @memberof FullscreenControl
    */
   attachIosFullscreenListeners(): void {
     this.player.getVideoElement().addEventListener('webkitbeginfullscreen', () => {

--- a/src/components/shell/shell.js
+++ b/src/components/shell/shell.js
@@ -190,18 +190,6 @@ class Shell extends BaseComponent {
         this.props.updateDocumentWidth(document.body.clientWidth);
       }
     });
-    /**
-     * Handler for the first playing event - remove the listener and turn on the hover state.
-     * @returns {void}
-     */
-    const onPlaying = () => {
-      this.player.removeEventListener(this.player.Event.PLAYING, onPlaying);
-      this._updatePlayerHoverState();
-    };
-    this.player.addEventListener(this.player.Event.CHANGE_SOURCE_STARTED, () => {
-      this.player.addEventListener(this.player.Event.PLAYING, onPlaying);
-    });
-    this.player.addEventListener(this.player.Event.PLAYING, onPlaying);
   }
 
   /**
@@ -259,6 +247,20 @@ class Shell extends BaseComponent {
     if (this.hoverTimeout) {
       clearTimeout(this.hoverTimeout);
       this.hoverTimeout = null;
+    }
+  }
+
+  /**
+   * when component did update and change its props from prePlayback to !prePlayback
+   * update the hover state
+   *
+   * @param {Object} prevProps - previous props
+   * @returns {void}
+   * @memberof Shell
+   */
+  componentDidUpdate(prevProps: Object): void {
+    if (!this.props.prePlayback && prevProps.prePlayback) {
+      this._updatePlayerHoverState();
     }
   }
 


### PR DESCRIPTION
### Description of the Changes
* correct listening to native ios full screen changes
* on entering to full screen on tablet set the video dimensions to `auto` instead of `100%` 

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [x] Docs have been updated
