### PR TITLE
fix(FEC-8024): black screen on replay - ie11

### DIFF
--- a/src/components/pre-playback-play-overlay/_pre-playback-play-overlay.scss
+++ b/src/components/pre-playback-play-overlay/_pre-playback-play-overlay.scss
@@ -13,7 +13,7 @@
   }
 
   .pre-playback-play-button {
-    z-index: 10;
+    z-index: 1;
     position: absolute;
     top: 50%;
     left: 50%;


### PR DESCRIPTION
### Description of the Changes

decrease the `.pre-playback-play-button` `z-index` to `1`
### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
