### PR TITLE
fix(FEC-8108): no playback after preroll - android browser

### DIFF
--- a/src/components/pre-playback-play-overlay/pre-playback-play-overlay.js
+++ b/src/components/pre-playback-play-overlay/pre-playback-play-overlay.js
@@ -58,6 +58,7 @@ class PrePlaybackPlayOverlay extends BaseComponent {
       if (this.autoplay === true) {
         this.player.addEventListener(this.player.Event.AUTOPLAY_FAILED, () => {
           this.autoplay = false;
+          this.forceUpdate();
         });
       }
     } catch (e) { // eslint-disable-line no-unused-vars


### PR DESCRIPTION
### Description of the Changes

call to `forceUpdate` on `AUTOPLAY_FAILED` event, as the ui must be updated

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
