### PR TITLE
fix(FEC-8134): replay fails on iOS for playback with ads

### DIFF
--- a/src/components/bottom-bar/_bottom-bar.scss
+++ b/src/components/bottom-bar/_bottom-bar.scss
@@ -8,7 +8,6 @@
   width: 100%;
   margin-top: auto;
   position: absolute;
-  z-index: 10;
   bottom: 0;
   left: 0;
 

--- a/src/components/top-bar/_top-bar.scss
+++ b/src/components/top-bar/_top-bar.scss
@@ -9,7 +9,6 @@
   justify-content: space-between;
   width: 100%;
   position: absolute;
-  z-index: 10;
   top: 0;
   left: 0;
 

--- a/src/styles/_shell.scss
+++ b/src/styles/_shell.scss
@@ -75,7 +75,6 @@
 }
 
 .player :global([id^=playkit-ads-container]) {
-  z-index: 5;
   transition: transform 100ms;
 }
 


### PR DESCRIPTION
### Description of the Changes

since z-index exists on the ads container, click on the pre-playback isn't triggered. We can safely remove the z-indexes since the layers are now organised correctly.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
