### PR TITLE
fix(FEC-8142): overlay ad clickthrough doesn't work

### DIFF
--- a/src/styles/_shell.scss
+++ b/src/styles/_shell.scss
@@ -75,6 +75,9 @@
 }
 
 .player :global([id^=playkit-ads-container]) {
+  &:global(.playkit-overlay-ad) {
+    z-index: 1;
+  }
   transition: transform 100ms;
 }
 

--- a/src/styles/_shell.scss
+++ b/src/styles/_shell.scss
@@ -75,7 +75,7 @@
 }
 
 .player :global([id^=playkit-ads-container]) {
-  &:global(.playkit-overlay-ad) {
+  &:global([data-ad-type="overlay"]) {
     z-index: 1;
   }
   transition: transform 100ms;

--- a/src/styles/_shell.scss
+++ b/src/styles/_shell.scss
@@ -75,7 +75,7 @@
 }
 
 .player :global([id^=playkit-ads-container]) {
-  &:global([data-ad-type="overlay"]) {
+  &:global([data-adtype="overlay"]) {
     z-index: 1;
   }
   transition: transform 100ms;


### PR DESCRIPTION
### Description of the Changes

on overlay ad  set `z-index: 1` to the ads container 

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
