### PR TITLE
fix(FEC-8177): playback UI isn't displayed on fatal ad error when changing media

### DIFF
--- a/src/components/engine-connector/engine-connector.js
+++ b/src/components/engine-connector/engine-connector.js
@@ -161,6 +161,12 @@ class EngineConnector extends BaseComponent {
       this.props.updateAdIsPlaying(false);
     });
 
+    this.player.addEventListener(this.player.Event.AD_ERROR, e => {
+      if (e.payload.fatal) {
+        this.props.updateAdBreak(false);
+      }
+    });
+
     this.player.addEventListener(this.player.Event.AD_LOADED, e => {
       this.props.updateAdClickUrl(e.payload.ad.g.clickThroughUrl);
       this.props.updateAdSkipTimeOffset(e.payload.ad.getSkipTimeOffset());


### PR DESCRIPTION
### Description of the Changes

Add `AD_ERROR` listener in the `engine-connector` component and in case the error is fatal update the ad break state.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
