### PR TITLE
fix(FEC-8205): playback UI isn't disappear after ads on mobile

### DIFF
--- a/src/components/shell/shell.js
+++ b/src/components/shell/shell.js
@@ -273,7 +273,10 @@ class Shell extends BaseComponent {
    * @memberof Shell
    */
   componentDidUpdate(prevProps: Object): void {
-    if (!this.props.prePlayback && prevProps.prePlayback) {
+    // Update the hover state if the transition was from pre playback screen
+    // or after an ad break
+    if (!this.props.prePlayback && prevProps.prePlayback ||
+      !this.props.adBreak && prevProps.adBreak) {
       this._updatePlayerHoverState();
     }
   }


### PR DESCRIPTION
### Description of the Changes

Update the hover state if the transition was from pre playback screen
or after an ad break.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
