### PR TITLE
fix(FEC-8180): when video starts fallback muted and user select to change media the unmute icon is not displayed although video still muted

### DIFF
--- a/src/components/engine-connector/engine-connector.js
+++ b/src/components/engine-connector/engine-connector.js
@@ -167,6 +167,10 @@ class EngineConnector extends BaseComponent {
       }
     });
 
+    this.player.addEventListener(this.player.Event.FALLBACK_TO_MUTED_AUTOPLAY, () => {
+      this.props.updateFallbackToMutedAutoPlay(true);
+    });
+
     this.player.addEventListener(this.player.Event.AD_LOADED, e => {
       this.props.updateAdIsLinear(e.payload.ad.isLinear());
       this.props.updateAdClickUrl(e.payload.ad.g.clickThroughUrl);

--- a/src/components/unmute-indication/unmute-indication.js
+++ b/src/components/unmute-indication/unmute-indication.js
@@ -65,12 +65,13 @@ class UnmuteIndication extends BaseComponent {
   /**
    * after component updated, check the fallbackToMutedAutoPlay prop for updating the state of the component
    *
+   * @param {Object} prevProps - previous component props
    * @method componentDidUpdate
    * @returns {void}
    * @memberof UnmuteIndication
    */
-  componentDidUpdate(): void {
-    if (this.props.fallbackToMutedAutoPlay) {
+  componentDidUpdate(prevProps: Object): void {
+    if (!prevProps.fallbackToMutedAutoPlay && this.props.fallbackToMutedAutoPlay) {
       this.player.addEventListener(this.player.Event.PLAYING, this._iconOnlyTimeoutCallback);
       this.player.addEventListener(this.player.Event.AD_STARTED, this._iconOnlyTimeoutCallback);
     }

--- a/src/components/unmute-indication/unmute-indication.js
+++ b/src/components/unmute-indication/unmute-indication.js
@@ -2,8 +2,6 @@
 import style from '../../styles/style.scss';
 import {h} from 'preact';
 import {connect} from 'preact-redux';
-import {bindActions} from '../../utils/bind-actions';
-import {actions} from '../../reducers/volume';
 import BaseComponent from '../base';
 import {default as Icon, IconType} from '../icon';
 
@@ -14,7 +12,20 @@ import {default as Icon, IconType} from '../icon';
  */
 export const MUTED_AUTOPLAY_ICON_ONLY_DEFAULT_TIMEOUT = 3000;
 
-@connect(null, bindActions(actions))
+/**
+ * mapping state to props
+ * @param {*} state - redux store state
+ * @returns {Object} - mapped state to this component
+ */
+const mapStateToProps = state => ({
+  fallbackToMutedAutoPlay: state.engine.fallbackToMutedAutoPlay,
+  isPlaying: state.engine.isPlaying,
+  adBreak: state.engine.adBreak,
+  adIsPlaying: state.engine.adIsPlaying
+});
+
+
+@connect(mapStateToProps, null)
   /**
    * UnmuteIndication component
    *
@@ -42,27 +53,27 @@ class UnmuteIndication extends BaseComponent {
   }
 
   /**
-   * after component mounted, listen to relevant player event for updating the state of the component
+   * check if currently playing ad or playback
    *
-   * @method componentDidMount
+   * @returns {boolean} - if currently playing ad or playback
+   * @memberof UnmuteIndication
+   */
+  isPlayingAdOrPlayback(): boolean {
+    return (this.props.adBreak && this.props.adIsPlaying) || (!this.props.adBreak && this.props.isPlaying);
+  }
+
+  /**
+   * after component updated, check the fallbackToMutedAutoPlay prop for updating the state of the component
+   *
+   * @method componentDidUpdate
    * @returns {void}
    * @memberof UnmuteIndication
    */
-  componentDidMount() {
-    this.player.addEventListener(this.player.Event.MUTE_CHANGE, e => {
-      this.props.updateMuted(e.payload.mute);
-
-      // hide tooltip on user interaction
-      if (!e.payload.mute && this.state.unmuteHint) {
-        this.setState({unmuteHint: false});
-      }
-    });
-
-    this.player.addEventListener(this.player.Event.FALLBACK_TO_MUTED_AUTOPLAY, () => {
-      this.setState({unmuteHint: true});
+  componentDidUpdate(): void {
+    if (this.props.fallbackToMutedAutoPlay) {
       this.player.addEventListener(this.player.Event.PLAYING, this._iconOnlyTimeoutCallback);
       this.player.addEventListener(this.player.Event.AD_STARTED, this._iconOnlyTimeoutCallback);
-    });
+    }
   }
 
   /**
@@ -87,7 +98,7 @@ class UnmuteIndication extends BaseComponent {
    * @memberof UnmuteIndication
    */
   render(props: any): ?React$Element<any> {
-    if (!this.state.unmuteHint) return undefined;
+    if (!this.props.fallbackToMutedAutoPlay || !this.isPlayingAdOrPlayback()) return undefined;
 
     const styleClass = [style.unmuteButtonContainer];
     if (props.hasTopBar) styleClass.push(style.hasTopBar);
@@ -98,11 +109,8 @@ class UnmuteIndication extends BaseComponent {
         className={styleClass.join(' ')}
         onMouseOver={() => this.setState({iconOnly: false})}
         onMouseOut={() => this.setState({iconOnly: true})}
-        onClick={() => this.player.muted = !this.player.muted}
-      >
-        <a
-          className={[style.btn, style.btnDarkTransparent, style.unmuteButton].join(' ')}
-        >
+        onClick={() => this.player.muted = !this.player.muted}>
+        <a className={[style.btn, style.btnDarkTransparent, style.unmuteButton].join(' ')}>
           <div className={style.unmuteIconContainer}>
             <Icon type={IconType.VolumeBase}/>
             <Icon type={IconType.VolumeMute}/>

--- a/src/reducers/engine.js
+++ b/src/reducers/engine.js
@@ -23,7 +23,8 @@ export const types = {
   UPDATE_IS_LIVE: 'engine/UPDATE_IS_LIVE',
   UPDATE_IS_DVR: 'engine/UPDATE_IS_DVR',
   UPDATE_ERROR: 'engine/ERROR',
-  UPDATE_IS_IDLE: 'engine/UPDATE_IS_IDLE'
+  UPDATE_IS_IDLE: 'engine/UPDATE_IS_IDLE',
+  UPDATE_FALLBACK_TO_MUTED_AUTOPLAY: 'engine/UPDATE_FALLBACK_TO_MUTED_AUTOPLAY'
 };
 
 export const initialState = {
@@ -35,6 +36,7 @@ export const initialState = {
     previousState: '',
     currentState: ''
   },
+  fallbackToMutedAutoPlay: false,
   poster: '',
   currentTime: 0,
   duration: 0,
@@ -207,6 +209,12 @@ export default (state: Object = initialState, action: Object) => {
         isIdle: action.IsIdle
       };
 
+    case types.UPDATE_FALLBACK_TO_MUTED_AUTOPLAY:
+      return {
+        ...state,
+        fallbackToMutedAutoPlay: action.fallback
+      };
+
     default:
       return state;
   }
@@ -245,5 +253,6 @@ export const actions = {
   updatePlayerPoster: (poster: string) => ({type: types.UPDATE_PLAYER_POSTER, poster}),
   updateIsLive: (isLive: boolean) => ({type: types.UPDATE_IS_LIVE, isLive}),
   updateIsDvr: (isDvr: boolean) => ({type: types.UPDATE_IS_DVR, isDvr}),
-  updateIsIdle: (IsIdle: boolean) => ({type: types.UPDATE_IS_IDLE, IsIdle: IsIdle})
+  updateIsIdle: (IsIdle: boolean) => ({type: types.UPDATE_IS_IDLE, IsIdle: IsIdle}),
+  updateFallbackToMutedAutoPlay: (fallback: boolean) => ({type: types.UPDATE_FALLBACK_TO_MUTED_AUTOPLAY, fallback})
 };


### PR DESCRIPTION
### Description of the Changes

Save a single state of fallback to muted and use it in shell and unmute-indication components.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
