### PR TITLE
fix(FEC-8032): captions indentation is too big on pause

### DIFF
--- a/src/styles/_captions.scss
+++ b/src/styles/_captions.scss
@@ -8,6 +8,13 @@
     transform: translateY(-60px);
     transition: ease-out 100ms;
   }
+  &.Safari {
+    &.state-paused video::-webkit-media-text-track-display,
+    &.hover video::-webkit-media-text-track-display {
+      transform: translateY(-30px);
+      transition: ease-out 100ms;
+    }
+  }
   &.fullscreen {
     &.iOS video::-webkit-media-text-track-display {
       transform: translateY(0px);
@@ -32,6 +39,13 @@
       &.iOS :global(.playkit-subtitles) {
         transform: translateY(0px);
       }
+    }
+  }
+  &.Safari {
+    &.state-paused :global(.playkit-subtitles),
+    &.hover :global(.playkit-subtitles) {
+      transform: translateY(-30px);
+      transition: ease-out 100ms;
     }
   }
 }


### PR DESCRIPTION
### Description of the Changes

this happens only in safari (mac+mobile) so i changed the indentation on pause to be -30.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
