### PR TITLE
fix(FEC-8121): Sometime captions menu close when changing lang although it's in focus

### DIFF
--- a/src/components/shell/shell.js
+++ b/src/components/shell/shell.js
@@ -91,11 +91,18 @@ class Shell extends BaseComponent {
 
   /**
    * on mouse leave, remove the hover class (hide the player gui)
-   *
+   * @param {Event} event - the mouse leave event
    * @returns {void}
    * @memberof Shell
    */
-  onMouseLeave(): void {
+  onMouseLeave(event: Event): void {
+    /**
+     * a hack to fix 'mouseleave' bug in chrome - the event is called sometimes on a click inside the div.
+     * https://bugs.chromium.org/p/chromium/issues/detail?id=798535
+     */
+    if (!event.toElement) {
+      return;
+    }
     if (this.props.isMobile) {
       return;
     }
@@ -310,7 +317,7 @@ class Shell extends BaseComponent {
         onTouchEnd={(e) => this.onTouchEnd(e)}
         onMouseOver={() => this.onMouseOver()}
         onMouseMove={() => this.onMouseMove()}
-        onMouseLeave={() => this.onMouseLeave()}
+        onMouseLeave={(event) => this.onMouseLeave(event)}
         onKeyDown={(e) => this.onKeyDown(e)}>
         {props.children}
       </div>


### PR DESCRIPTION
### Description of the Changes

when mouseleave is dispatched from a click within the div it is listening to - it has null in it's 'toElement'. added this check until google fix there bug.
https://bugs.chromium.org/p/chromium/issues/detail?id=798535

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
