### PR TITLE
fix(FEC-8368): isVr method throws exception on change media

### DIFF
--- a/src/player-gui.js
+++ b/src/player-gui.js
@@ -14,7 +14,8 @@ const mapStateToProps = state => ({
       adBreak: state.engine.adBreak,
       isLive: state.engine.isLive,
       hasError: state.engine.hasError,
-      isIdle: state.engine.isIdle
+      isIdle: state.engine.isIdle,
+      isVr: state.engine.isVr
     }
   },
   config: state.config

--- a/src/ui-presets/live.js
+++ b/src/ui-presets/live.js
@@ -46,7 +46,7 @@ export function liveUI(props: any): React$Element<any> {
             <LiveTag player={props.player}/>
           </div>
           <div className={style.rightControls}>
-            {(props.player.isVr() && shouldRenderComponent(props.config, VrStereoToggleControl.displayName))
+            {(props.state.engine.isVr && shouldRenderComponent(props.config, VrStereoToggleControl.displayName))
               ? <VrStereoToggleControl player={props.player}/>
               : undefined}
             <VolumeControl player={props.player}/>

--- a/src/ui-presets/playback.js
+++ b/src/ui-presets/playback.js
@@ -47,7 +47,7 @@ export function playbackUI(props: any): React$Element<any> {
             <TimeDisplayPlaybackContainer format='current / total'/>
           </div>
           <div className={style.rightControls}>
-            {(props.player.isVr() && shouldRenderComponent(props.config, VrStereoToggleControl.displayName))
+            {(props.state.engine.isVr && shouldRenderComponent(props.config, VrStereoToggleControl.displayName))
               ? <VrStereoToggleControl player={props.player}/>
               : undefined}
             <VolumeControl player={props.player}/>


### PR DESCRIPTION
### Description of the Changes

get `isVr` from `props.state.engine.isVr` instead of from player API

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
