### PR TITLE
fix(FEC-8421, FEC-8422): Ads UI issues

### DIFF
--- a/src/components/bottom-bar/_bottom-bar.scss
+++ b/src/components/bottom-bar/_bottom-bar.scss
@@ -36,6 +36,7 @@
 
 .player.hover .bottom-bar,
 .player.state-paused .bottom-bar,
+.player.ad-break .bottom-bar,
 .player.menu-active .bottom-bar {
   opacity: 1;
   visibility: visible;

--- a/src/components/top-bar/_top-bar.scss
+++ b/src/components/top-bar/_top-bar.scss
@@ -31,6 +31,7 @@
 
 .player.hover .top-bar,
 .player.state-paused .top-bar,
+.player.ad-break .top-bar,
 .player.menu-active .top-bar {
   opacity: 1;
   visibility: visible;

--- a/src/styles/_shell.scss
+++ b/src/styles/_shell.scss
@@ -53,6 +53,7 @@
   }
   &.metadata-loaded .player-gui,
   &.state-paused .player-gui,
+  &.ad-break .player-gui,
   &.overlay-active .player-gui,
   &.menu-active .player-gui {
     opacity: 1;


### PR DESCRIPTION
* No ads UI Until the playback source is loaded
* Ads UI while postroll is unlike while preroll and midroll

### Description of the Changes
show `player-gui` while ad-break

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
