### PR TITLE
fix: subtitles font size is too small on mobile

### DIFF
--- a/src/styles/_captions.scss
+++ b/src/styles/_captions.scss
@@ -15,7 +15,7 @@ $hovering-offset: 50px;
   }
   &.state-paused video::-webkit-media-text-track-container,
   &.hover video::-webkit-media-text-track-container {
-    max-height: calc(100% - #{$hovering-offset})
+    max-height: calc(100% - #{$hovering-offset});
   }
   &.fullscreen.iOS {
     video::-webkit-media-text-track-container {

--- a/src/styles/_captions.scss
+++ b/src/styles/_captions.scss
@@ -1,3 +1,5 @@
+$hovering-offset: 50px;
+
 .player {
   video::-webkit-media-text-track-container {
     max-height: none;
@@ -13,7 +15,7 @@
   }
   &.state-paused video::-webkit-media-text-track-container,
   &.hover video::-webkit-media-text-track-container {
-    max-height: calc(100% - 50px);
+    max-height: calc(100% - #{$hovering-offset})
   }
   &.fullscreen.iOS {
     video::-webkit-media-text-track-container {
@@ -26,14 +28,14 @@
     }
   }
   :global(.playkit-subtitles) {
-    top: 50px;
+    top: $hovering-offset;
     transform: translateY(0px);
     transition: ease-in 100ms;
   }
   &:not(.overlay-active) {
     &.state-paused :global(.playkit-subtitles),
     &.hover :global(.playkit-subtitles) {
-      transform: translateY(-50px);
+      transform: translateY(-$hovering-offset);
     }
     &.fullscreen.iOS {
       :global(.playkit-subtitles) {

--- a/src/styles/_captions.scss
+++ b/src/styles/_captions.scss
@@ -13,7 +13,7 @@
   }
   &.state-paused video::-webkit-media-text-track-container,
   &.hover video::-webkit-media-text-track-container {
-    max-height: calc(100% - 60px);
+    max-height: calc(100% - 50px);
   }
   &.fullscreen.iOS {
     video::-webkit-media-text-track-container {
@@ -26,14 +26,14 @@
     }
   }
   :global(.playkit-subtitles) {
-    top: 60px;
+    top: 50px;
     transform: translateY(0px);
     transition: ease-in 100ms;
   }
   &:not(.overlay-active) {
     &.state-paused :global(.playkit-subtitles),
     &.hover :global(.playkit-subtitles) {
-      transform: translateY(-60px);
+      transform: translateY(-50px);
     }
     &.fullscreen.iOS {
       :global(.playkit-subtitles) {


### PR DESCRIPTION
### Description of the Changes

Set the captions offset on hovering to `50px` instead of `60px`. 
Fixed also by https://github.com/kaltura/playkit-js/pull/270

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
