### PR TITLE
fix(FEC-8450): after replay no control bar

### DIFF
--- a/src/components/engine-connector/engine-connector.js
+++ b/src/components/engine-connector/engine-connector.js
@@ -48,8 +48,6 @@ class EngineConnector extends BaseComponent {
         this.props.updateLoadingSpinnerState(true);
       } else {
         this.props.updateLoadingSpinnerState(false);
-        this.props.updatePrePlayback(true);
-        this.props.addPlayerClass(style.prePlayback);
       }
     });
 
@@ -63,6 +61,10 @@ class EngineConnector extends BaseComponent {
     this.eventManager.listen(this.player, this.player.Event.CHANGE_SOURCE_ENDED, () => {
       this.props.updatePlayerPoster(this.player.poster);
       this.props.updateIsIdle(false);
+      if (!this.player.config.playback.autoplay) {
+        this.props.updatePrePlayback(true);
+        this.props.addPlayerClass(style.prePlayback);
+      }
     });
 
     this.eventManager.listen(this.player, this.player.Event.PLAYER_STATE_CHANGED, e => {
@@ -97,7 +99,7 @@ class EngineConnector extends BaseComponent {
       this.props.updateMuted(this.player.muted);
     });
 
-    this.eventManager.listen(this.player, this.player.Event.PLAYING, () => {
+    this.eventManager.listen(this.player, this.player.Event.PLAY, () => {
       this.props.updateIsPlaying(true);
 
       if (this.props.engine.isEnded) {
@@ -219,7 +221,7 @@ class EngineConnector extends BaseComponent {
    * @memberof EngineConnector
    */
   render(): React$Element<any> {
-    return <span />;
+    return <span/>;
   }
 }
 

--- a/src/components/engine-connector/engine-connector.js
+++ b/src/components/engine-connector/engine-connector.js
@@ -221,7 +221,7 @@ class EngineConnector extends BaseComponent {
    * @memberof EngineConnector
    */
   render(): React$Element<any> {
-    return <span/>;
+    return <span />;
   }
 }
 

--- a/src/components/pre-playback-play-overlay/pre-playback-play-overlay.js
+++ b/src/components/pre-playback-play-overlay/pre-playback-play-overlay.js
@@ -78,7 +78,6 @@ class PrePlaybackPlayOverlay extends BaseComponent {
   componentWillUnmount() {
     super.componentWillUnmount();
     this._hidePrePlayback();
-    this.props.removePlayerClass(style.prePlayback);
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

1. Move the addPrePlayback logic to CHANGE_SOURCE_ENDED event.
2. update isEnded state on play instead on playing.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
