### PR TITLE
fix(FEC-8286): adding click indication to the state

### DIFF
--- a/src/components/engine-connector/engine-connector.js
+++ b/src/components/engine-connector/engine-connector.js
@@ -97,6 +97,9 @@ class EngineConnector extends BaseComponent {
 
     this.eventManager.listen(this.player, this.player.Event.MUTE_CHANGE, () => {
       this.props.updateMuted(this.player.muted);
+      if (this.props.engine.fallbackToMutedAutoPlay) {
+        this.props.updateFallbackToMutedAutoPlay(this.player.muted);
+      }
     });
 
     this.eventManager.listen(this.player, this.player.Event.PLAY, () => {

--- a/src/components/shell/shell.js
+++ b/src/components/shell/shell.js
@@ -132,20 +132,10 @@ class Shell extends BaseComponent {
    * @memberof Shell
    */
   onClick(): void {
-    this._maybeUpdateMutedAutoplay();
-    this.notifyClick();
-  }
-
-  /**
-   * checks & updates the fallback to muted autoplay prop
-   * @returns {void}
-   * @memberof Shell
-   */
-  _maybeUpdateMutedAutoplay(): void {
     if (this.props.fallbackToMutedAutoPlay) {
       this.player.muted = false;
-      this.props.updateFallbackToMutedAutoPlay(false);
     }
+    this.notifyClick();
   }
 
   /**
@@ -175,9 +165,6 @@ class Shell extends BaseComponent {
     if (!this.state.nav && e.keyCode === KeyMap.TAB) {
       this.setState({nav: true});
       this.props.updatePlayerNavState(true);
-    }
-    if (e.keyCode === KeyMap.ENTER) {
-      this._maybeUpdateMutedAutoplay();
     }
   }
 

--- a/src/components/shell/shell.js
+++ b/src/components/shell/shell.js
@@ -132,11 +132,20 @@ class Shell extends BaseComponent {
    * @memberof Shell
    */
   onClick(): void {
+    this._maybeUpdateMutedAutoplay();
+    this.notifyClick();
+  }
+
+  /**
+   * checks & updates the fallback to muted autoplay prop
+   * @returns {void}
+   * @memberof Shell
+   */
+  _maybeUpdateMutedAutoplay(): void {
     if (this.props.fallbackToMutedAutoPlay) {
       this.player.muted = false;
       this.props.updateFallbackToMutedAutoPlay(false);
     }
-    this.notifyClick();
   }
 
   /**
@@ -166,6 +175,9 @@ class Shell extends BaseComponent {
     if (!this.state.nav && e.keyCode === KeyMap.TAB) {
       this.setState({nav: true});
       this.props.updatePlayerNavState(true);
+    }
+    if (e.keyCode === KeyMap.ENTER) {
+      this._maybeUpdateMutedAutoplay();
     }
   }
 

--- a/src/components/unmute-indication/unmute-indication.js
+++ b/src/components/unmute-indication/unmute-indication.js
@@ -92,6 +92,7 @@ class UnmuteIndication extends BaseComponent {
   _keyDownHandler(e: KeyboardEvent): void {
     if (e.keyCode === KeyMap.ENTER) {
       this.player.muted = !this.player.muted;
+      this.setState({clicked: true});
     }
   }
 
@@ -103,7 +104,7 @@ class UnmuteIndication extends BaseComponent {
    * @memberof UnmuteIndication
    */
   render(props: any): ?React$Element<any> {
-    if (!this.props.fallbackToMutedAutoPlay || !this.isPlayingAdOrPlayback()) return undefined;
+    if (!this.props.fallbackToMutedAutoPlay || !this.isPlayingAdOrPlayback() || this.state.clicked) return undefined;
 
     const styleClass = [style.unmuteButtonContainer];
     if (props.hasTopBar) styleClass.push(style.hasTopBar);

--- a/src/components/unmute-indication/unmute-indication.js
+++ b/src/components/unmute-indication/unmute-indication.js
@@ -92,7 +92,6 @@ class UnmuteIndication extends BaseComponent {
   _keyDownHandler(e: KeyboardEvent): void {
     if (e.keyCode === KeyMap.ENTER) {
       this.player.muted = !this.player.muted;
-      this.setState({clicked: true});
     }
   }
 
@@ -104,7 +103,7 @@ class UnmuteIndication extends BaseComponent {
    * @memberof UnmuteIndication
    */
   render(props: any): ?React$Element<any> {
-    if (!this.props.fallbackToMutedAutoPlay || !this.isPlayingAdOrPlayback() || this.state.clicked) return undefined;
+    if (!this.props.fallbackToMutedAutoPlay || !this.isPlayingAdOrPlayback()) return undefined;
 
     const styleClass = [style.unmuteButtonContainer];
     if (props.hasTopBar) styleClass.push(style.hasTopBar);


### PR DESCRIPTION
### Description of the Changes

when clicking on the unmute indication with the keyboard, it does not disappear.

when clicking with the mouse it does - that's because we have (mouse) click handlers in the UI that makes it happen. 

added a 'clicked' state that saves it, if it was clicked, and re-render accordingly.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
