### PR TITLE
fix(FEC-8273): overriding any focus outline - fix IE black screen issue

### DIFF
--- a/src/styles/_buttons.scss
+++ b/src/styles/_buttons.scss
@@ -47,4 +47,3 @@
   display: inline-block;
   padding: 2px;
 }
-

--- a/src/styles/_buttons.scss
+++ b/src/styles/_buttons.scss
@@ -9,6 +9,10 @@
   display: inline-block;
   padding: 0 24px;
 
+  &:focus {
+    outline: none;
+  }
+
   &.btn-block {
     display: block;
   }
@@ -44,8 +48,3 @@
   padding: 2px;
 }
 
-button{
-  &:focus{
-    outline: 1px solid $tab-focus-color;
-  }
-}

--- a/src/styles/_buttons.scss
+++ b/src/styles/_buttons.scss
@@ -43,3 +43,9 @@
   display: inline-block;
   padding: 2px;
 }
+
+button{
+  &:focus{
+    outline: 1px solid $tab-focus-color;
+  }
+}

--- a/src/styles/_buttons.scss
+++ b/src/styles/_buttons.scss
@@ -9,10 +9,6 @@
   display: inline-block;
   padding: 0 24px;
 
-  &:focus {
-    outline: none;
-  }
-
   &.btn-block {
     display: block;
   }
@@ -46,4 +42,12 @@
   background-color: rgba(0, 0, 0, 0.4);
   display: inline-block;
   padding: 2px;
+}
+
+.player {
+  button{
+    &:focus{
+      outline:none;
+    }
+  }
 }


### PR DESCRIPTION
### Description of the Changes

override the player button outline on focus to be none, so it won't be overridden by other CSS

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
