### PR TITLE
fix: remove unused props

### DIFF
--- a/src/components/keyboard/keyboard.js
+++ b/src/components/keyboard/keyboard.js
@@ -17,10 +17,6 @@ import {isPlayingAdOrPlayback} from '../../reducers/getters';
 const mapStateToProps = state => ({
   isPlayingAdOrPlayback: isPlayingAdOrPlayback(state.engine),
   playerNav: state.shell.playerNav,
-  isPlaying: state.engine.isPlaying,
-  isEnded: state.engine.isEnded,
-  adBreak: state.engine.adBreak,
-  adIsPlaying: state.engine.adIsPlaying,
   textTracks: state.engine.textTracks
 });
 

--- a/src/components/overlay-action/overlay-action.js
+++ b/src/components/overlay-action/overlay-action.js
@@ -18,11 +18,8 @@ const mapStateToProps = state => ({
   isPlayingAdOrPlayback: isPlayingAdOrPlayback(state.engine),
   iconType: state.overlayAction.iconType,
   isPlaying: state.engine.isPlaying,
-  adBreak: state.engine.adBreak,
-  adIsPlaying: state.engine.adIsPlaying,
   playerHover: state.shell.playerHover,
-  isMobile: state.shell.isMobile,
-  isEnded: state.engine.isEnded
+  isMobile: state.shell.isMobile
 });
 
 /**

--- a/src/components/play-pause/play-pause.js
+++ b/src/components/play-pause/play-pause.js
@@ -17,7 +17,6 @@ const mapStateToProps = state => ({
   isPlayingAdOrPlayback: isPlayingAdOrPlayback(state.engine),
   isPlaying: state.engine.isPlaying,
   adBreak: state.engine.adBreak,
-  adIsPlaying: state.engine.adIsPlaying,
   isEnded: state.engine.isEnded
 });
 

--- a/src/components/unmute-indication/unmute-indication.js
+++ b/src/components/unmute-indication/unmute-indication.js
@@ -22,11 +22,7 @@ export const MUTED_AUTOPLAY_ICON_ONLY_DEFAULT_TIMEOUT = 3000;
  */
 const mapStateToProps = state => ({
   isPlayingAdOrPlayback: isPlayingAdOrPlayback(state.engine),
-  fallbackToMutedAutoPlay: state.engine.fallbackToMutedAutoPlay,
-  isPlaying: state.engine.isPlaying,
-  adBreak: state.engine.adBreak,
-  adIsPlaying: state.engine.adIsPlaying,
-  isEnded: state.engine.isEnded
+  fallbackToMutedAutoPlay: state.engine.fallbackToMutedAutoPlay
 });
 
 @connect(


### PR DESCRIPTION
### Description of the Changes

After moving isPlayingAdOrPlayback to act as a store getter, there are props left which are not needed anymore in certain components.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
