### PR TITLE
fix: replay button is missing after postroll

### DIFF
--- a/src/components/engine-connector/engine-connector.js
+++ b/src/components/engine-connector/engine-connector.js
@@ -95,7 +95,6 @@ class EngineConnector extends BaseComponent {
       this.props.updateIsLive(this.player.isLive());
       this.props.updateIsDvr(this.player.isDvr());
       this.props.updatePlayerPoster(this.player.poster);
-      this.props.updateIsEnded(false);
     });
 
     this.eventManager.listen(this.player, this.player.Event.VOLUME_CHANGE, () => {
@@ -121,6 +120,8 @@ class EngineConnector extends BaseComponent {
 
     this.eventManager.listen(this.player, this.player.Event.ENDED, () => {
       this.props.updateIsEnded(true);
+      this.props.updateIsPlaying(false);
+      this.props.updateIsPaused(true);
     });
 
     this.eventManager.listen(this.player, this.player.Event.TRACKS_CHANGED, () => {
@@ -151,7 +152,6 @@ class EngineConnector extends BaseComponent {
     this.eventManager.listen(this.player, this.player.Event.AD_BREAK_START, () => {
       this.props.updateHasError(false);
       this.props.updateAdBreak(true);
-      this.props.updateIsEnded(false);
     });
 
     this.eventManager.listen(this.player, this.player.Event.AD_BREAK_END, () => {

--- a/src/reducers/getters.js
+++ b/src/reducers/getters.js
@@ -5,5 +5,5 @@
  * @returns {boolean} - Whether the player is playing ad or content.
  */
 export const isPlayingAdOrPlayback = (state: Object) => {
-  return !state.isEnded && ((state.adBreak && state.adIsPlaying) || (!state.adBreak && state.isPlaying));
+  return (state.adBreak && state.adIsPlaying) || (!state.adBreak && state.isPlaying);
 };


### PR DESCRIPTION
### Description of the Changes

1. Rollback the addition of isEnded to isPlayingAdOrPlayback that caused the issue.
2. Add updates to isPlaying and isPaused on ENDED event.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
