### PR TITLE
fix(FEC-8651): picture in picture icon is missing in safari

### DIFF
--- a/src/components/engine-connector/engine-connector.js
+++ b/src/components/engine-connector/engine-connector.js
@@ -83,6 +83,7 @@ class EngineConnector extends BaseComponent {
 
     this.eventManager.listen(this.player, this.player.Event.LOADED_DATA, () => {
       this.props.updateDuration(this.player.duration);
+      this.props.updatePictureInPictureSupport(this.player.isPictureInPictureSupported());
     });
 
     this.eventManager.listen(this.player, this.player.Event.LOADED_METADATA, () => {
@@ -91,7 +92,6 @@ class EngineConnector extends BaseComponent {
       this.props.updateIsLive(this.player.isLive());
       this.props.updateIsDvr(this.player.isDvr());
       this.props.updatePlayerPoster(this.player.poster);
-      this.props.updatePictureInPictureSupport(this.player.isPictureInPictureSupported());
     });
 
     this.eventManager.listen(this.player, this.player.Event.VOLUME_CHANGE, () => {


### PR DESCRIPTION
Moving the update of `ispictureinpicturesupported` attribute to `'loadeddata'`

### Description of the Changes

Please add a detailed description of the change, weather it's an enhancement or a bugfix.
If the PR is related to an open issue please link to it.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
