### PR TITLE
fix(FEC-8669): countdown skips the postroll

### DIFF
--- a/src/components/engine-connector/engine-connector.js
+++ b/src/components/engine-connector/engine-connector.js
@@ -57,8 +57,8 @@ class EngineConnector extends BaseComponent {
       this.props.updateAdIsPlaying(false);
       this.props.updateIsPlaying(false);
       this.props.updateIsEnded(false);
+      this.props.updateIsPlaybackEnded(false);
       this.props.updateLastSeekPoint(0);
-      this.props.updateCurrentTime(0);
       if (this.props.engine.isCasting) {
         this.props.updateLoadingSpinnerState(true);
       }
@@ -109,6 +109,7 @@ class EngineConnector extends BaseComponent {
     this.eventManager.listen(this.player, this.player.Event.PLAY, () => {
       this.props.updateIsPlaying(true);
       this.props.updateIsEnded(false);
+      this.props.updateIsPlaybackEnded(false);
     });
 
     this.eventManager.listen(this.player, this.player.Event.PAUSE, () => {
@@ -124,6 +125,10 @@ class EngineConnector extends BaseComponent {
       this.props.updateIsEnded(true);
       this.props.updateIsPlaying(false);
       this.props.updateIsPaused(true);
+    });
+
+    this.eventManager.listen(this.player, this.player.Event.PLAYBACK_ENDED, () => {
+      this.props.updateIsPlaybackEnded(true);
     });
 
     this.eventManager.listen(this.player, this.player.Event.TRACKS_CHANGED, () => {

--- a/src/components/playlist-countdown/playlist-countdown.js
+++ b/src/components/playlist-countdown/playlist-countdown.js
@@ -17,7 +17,7 @@ const mapStateToProps = state => ({
   currentTime: state.engine.currentTime,
   duration: state.engine.duration,
   lastSeekPoint: state.engine.lastSeekPoint,
-  isEnded: state.engine.isEnded
+  isPlaybackEnded: state.engine.isPlaybackEnded
 });
 
 @connect(mapStateToProps)
@@ -109,9 +109,7 @@ class PlaylistCountdown extends BaseComponent {
     const countdown = this.player.playlist.countdown;
     if (
       !this.state.canceled &&
-      (this.props.isEnded ||
-        this.props.currentTime >= timeToShow + countdown.duration ||
-        (this.props.duration && this.props.currentTime >= this.props.duration))
+      (this.props.isPlaybackEnded || (this.props.currentTime >= timeToShow + countdown.duration && this.props.currentTime < this.props.duration))
     ) {
       this.player.playlist.playNext();
     }

--- a/src/reducers/engine.js
+++ b/src/reducers/engine.js
@@ -11,6 +11,7 @@ export const types = {
   UPDATE_LAST_SEEK_POINT: `${component}/UPDATE_LAST_SEEK_POINT`,
   UPDATE_IS_CHANGING_SOURCE: `${component}/UPDATE_IS_CHANGING_SOURCE`,
   UPDATE_IS_ENDED: `${component}/UPDATE_IS_ENDED`,
+  UPDATE_IS_PLAYBACK_ENDED: `${component}/UPDATE_IS_PLAYBACK_ENDED`,
   UPDATE_CURRENT_TIME: `${component}/UPDATE_CURRENT_TIME`,
   UPDATE_DURATION: `${component}/UPDATE_DURATION`,
   UPDATE_VOLUME: `${component}/UPDATE_VOLUME`,
@@ -47,6 +48,7 @@ export const initialState = {
   isPlaying: false,
   isPaused: false,
   isEnded: false,
+  isPlaybackEnded: false,
   isChangingSource: false,
   metadataLoaded: false,
   playerState: {
@@ -127,6 +129,12 @@ export default (state: Object = initialState, action: Object) => {
       return {
         ...state,
         isEnded: action.isEnded
+      };
+
+    case types.UPDATE_IS_PLAYBACK_ENDED:
+      return {
+        ...state,
+        isPlaybackEnded: action.isPlaybackEnded
       };
 
     case types.UPDATE_CURRENT_TIME:
@@ -321,6 +329,7 @@ export const actions = {
   updateIsPaused: (isPaused: boolean) => ({type: types.UPDATE_IS_PAUSED, isPaused}),
   updateLastSeekPoint: (lastSeekPoint: number) => ({type: types.UPDATE_LAST_SEEK_POINT, lastSeekPoint}),
   updateIsEnded: (isEnded: boolean) => ({type: types.UPDATE_IS_ENDED, isEnded}),
+  updateIsPlaybackEnded: (isPlaybackEnded: boolean) => ({type: types.UPDATE_IS_PLAYBACK_ENDED, isPlaybackEnded}),
   updateCurrentTime: (currentTime: number) => ({type: types.UPDATE_CURRENT_TIME, currentTime}),
   updateDuration: (duration: number) => ({type: types.UPDATE_DURATION, duration}),
   updateVolume: (volume: number) => ({type: types.UPDATE_VOLUME, volume}),


### PR DESCRIPTION
### Description of the Changes

* listen to `PLAYBACK_ENDED` instead of `ENDED`
* revert https://github.com/kaltura/playkit-js-ui/pull/291 since it not needed any more

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
