### PR TITLE
fix(FEC-8671): sometimes the playlist skip to the next item immediately, with no countdown - safari

### DIFF
--- a/src/components/engine-connector/engine-connector.js
+++ b/src/components/engine-connector/engine-connector.js
@@ -116,7 +116,12 @@ class EngineConnector extends BaseComponent {
       this.props.updateIsPaused(true);
     });
 
+    this.eventManager.listen(this.player, this.player.Event.SEEKING, () => {
+      this.props.updateIsSeeking(true);
+    });
+
     this.eventManager.listen(this.player, this.player.Event.SEEKED, () => {
+      this.props.updateIsSeeking(false);
       this.props.updateLastSeekPoint(this.player.currentTime);
     });
 

--- a/src/components/playlist-countdown/playlist-countdown.js
+++ b/src/components/playlist-countdown/playlist-countdown.js
@@ -17,6 +17,7 @@ const mapStateToProps = state => ({
   currentTime: state.engine.currentTime,
   duration: state.engine.duration,
   lastSeekPoint: state.engine.lastSeekPoint,
+  isSeeking: state.engine.isSeeking,
   isEnded: state.engine.isEnded
 });
 
@@ -118,6 +119,16 @@ class PlaylistCountdown extends BaseComponent {
   }
 
   /**
+   * should component update handler
+   *
+   * @param {Object} nextProps - the props that will replace the current props
+   * @returns {boolean} shouldComponentUpdate
+   */
+  shouldComponentUpdate(nextProps: Object): boolean {
+    return !nextProps.isSeeking;
+  }
+
+  /**
    * render component
    *
    * @param {*} props - component props
@@ -130,6 +141,9 @@ class PlaylistCountdown extends BaseComponent {
     const progressTime = props.currentTime - timeToShow;
     const progressDuration = Math.min(countdown.duration, props.duration - timeToShow);
     const progressWidth = `${progressTime > 0 ? (progressTime / progressDuration) * 100 : 0}%`;
+    if (!props.playlist.next) {
+      return undefined;
+    }
 
     return (
       <div

--- a/src/reducers/engine.js
+++ b/src/reducers/engine.js
@@ -8,6 +8,7 @@ export const types = {
   UPDATE_PLAYER_STATE: `${component}/UPDATE_PLAYER_STATE`,
   UPDATE_IS_PLAYING: `${component}/UPDATE_IS_PLAYING`,
   UPDATE_IS_PAUSED: `${component}/UPDATE_IS_PAUSED`,
+  UPDATE_IS_SEEKING: `${component}/UPDATE_IS_SEEKING`,
   UPDATE_LAST_SEEK_POINT: `${component}/UPDATE_LAST_SEEK_POINT`,
   UPDATE_IS_CHANGING_SOURCE: `${component}/UPDATE_IS_CHANGING_SOURCE`,
   UPDATE_IS_ENDED: `${component}/UPDATE_IS_ENDED`,
@@ -46,6 +47,7 @@ export const initialState = {
   isIdle: false,
   isPlaying: false,
   isPaused: false,
+  isSeeking: false,
   isEnded: false,
   isChangingSource: false,
   metadataLoaded: false,
@@ -115,6 +117,12 @@ export default (state: Object = initialState, action: Object) => {
       return {
         ...state,
         isPaused: action.isPaused
+      };
+
+    case types.UPDATE_IS_SEEKING:
+      return {
+        ...state,
+        isSeeking: action.isSeeking
       };
 
     case types.UPDATE_LAST_SEEK_POINT:
@@ -319,6 +327,7 @@ export const actions = {
   }),
   updateIsPlaying: (isPlaying: boolean) => ({type: types.UPDATE_IS_PLAYING, isPlaying}),
   updateIsPaused: (isPaused: boolean) => ({type: types.UPDATE_IS_PAUSED, isPaused}),
+  updateIsSeeking: (isSeeking: boolean) => ({type: types.UPDATE_IS_SEEKING, isSeeking}),
   updateLastSeekPoint: (lastSeekPoint: number) => ({type: types.UPDATE_LAST_SEEK_POINT, lastSeekPoint}),
   updateIsEnded: (isEnded: boolean) => ({type: types.UPDATE_IS_ENDED, isEnded}),
   updateCurrentTime: (currentTime: number) => ({type: types.UPDATE_CURRENT_TIME, currentTime}),


### PR DESCRIPTION
### Description of the Changes

**issue:** when seeking `currentTime` could be updated before `SEEKED` event (before `lastSeekPoint` updated)
**solution:** do not update the countdown component while seeking 

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
