### PR TITLE
fix: do not show countdown when it is longer than the playback duration

### DIFF
--- a/src/components/playlist-countdown/playlist-countdown.js
+++ b/src/components/playlist-countdown/playlist-countdown.js
@@ -133,7 +133,11 @@ class PlaylistCountdown extends BaseComponent {
 
     return (
       <div
-        className={this.state.timeToShow && !this.state.canceled ? [style.playlistCountdown] : [style.playlistCountdown, style.hidden].join(' ')}
+        className={
+          this.state.timeToShow && !this.state.canceled && countdown.duration < props.duration
+            ? [style.playlistCountdown]
+            : [style.playlistCountdown, style.hidden].join(' ')
+        }
         onClick={() => this.onClick()}>
         <div className={style.playlistCountdownPoster} style={`background-image: url(${props.playlist.next.sources.poster});`} />
         <div className={style.playlistCountdownContent}>


### PR DESCRIPTION
### Description of the Changes

prevent countdown for short playback

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
