### PR TITLE
fix(FEC-8650):  video continues in PiP window when full screen opened

### DIFF
--- a/src/components/fullscreen/fullscreen.js
+++ b/src/components/fullscreen/fullscreen.js
@@ -146,6 +146,9 @@ class FullscreenControl extends BaseComponent {
    * @memberof FullscreenControl
    */
   requestFullscreen(element: HTMLElement): boolean {
+    if (this.player.isInPictureInPicture()) {
+      this.player.exitPictureInPicture();
+    }
     if (typeof element.requestFullscreen === 'function') {
       element.requestFullscreen();
       return true;


### PR DESCRIPTION
### Description of the Changes

When entering full screen when PIP mode, the video element stays in PIP (on chrome).
Added a check (`isInPictureInPicture()`) before entering fullscreen in the UI.


### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
