### PR TITLE
fix(FEC-8581): playlist by config, no playlist buttons in first video

### DIFF
--- a/src/components/engine-connector/engine-connector.js
+++ b/src/components/engine-connector/engine-connector.js
@@ -245,8 +245,10 @@ class EngineConnector extends BaseComponent {
       this.props.updateIsCastAvailable(available);
     });
 
-    this.eventManager.listen(this.player, this.player.Event.Playlist.PLAYLIST_ITEM_CHANGED, () => {
-      this.props.updatePlaylist({next: this.player.playlist.next, prev: this.player.playlist.prev});
+    this.eventManager.listen(this.player, this.player.Event.Playlist.PLAYLIST_LOADED, e => {
+      this.eventManager.listen(this.player, this.player.Event.Playlist.PLAYLIST_ITEM_CHANGED, () => {
+        this.props.updatePlaylist({next: e.payload.playlist.next, prev: e.payload.playlist.prev});
+      });
     });
   }
 


### PR DESCRIPTION
### Description of the Changes

**issue:** when the playlist is by config, the first items selected synchronous, while the playlist construction, so in this moment `this.player.playlist` is `undefined`.
**solution:** read the next/prev from the playlist which passed as the payload of `PLAYLIST_LOADED` event 

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
