### PR TITLE
fix(FEC-8686): the playlist jumps to the last item (in case setting timeToShow)

### DIFF
--- a/src/components/engine-connector/engine-connector.js
+++ b/src/components/engine-connector/engine-connector.js
@@ -58,6 +58,7 @@ class EngineConnector extends BaseComponent {
       this.props.updateIsPlaying(false);
       this.props.updateIsEnded(false);
       this.props.updateIsPlaybackEnded(false);
+      this.props.updateCurrentTime(0);
       this.props.updateLastSeekPoint(0);
       if (this.props.engine.isCasting) {
         this.props.updateLoadingSpinnerState(true);


### PR DESCRIPTION
### Description of the Changes

**issue:** in some browsers the `currentTime` is not updated immediately in change media
**solution:** set `currentTime: 0` on `CHANGE_SOURCE_STARTED`

despite of https://github.com/kaltura/playkit-js-ui/pull/294, still need this fix for `timeToShow` settings which plays next before `PLAYBACK_ENDED` event. 

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
