### PR TITLE
fix(FEC-8652): 'open full screen' icon changed to 'exit full screen' icon when entering picture in picture on iPad

### DIFF
--- a/src/components/fullscreen/fullscreen.js
+++ b/src/components/fullscreen/fullscreen.js
@@ -123,8 +123,10 @@ class FullscreenControl extends BaseComponent {
    * @memberof FullscreenControl
    */
   fullscreenEnterHandler(): void {
-    this.player.notifyEnterFullscreen();
-    this.props.updateFullscreen(true);
+    if (!this.player.isInPictureInPicture()) {
+      this.player.notifyEnterFullscreen();
+      this.props.updateFullscreen(true);
+    }
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

issue: when entering PIP the fullscreen icon is changed to 'exit from full screen'. this happens because Safari raises a `webkitbeginfullscreen` when it enters picture-in-picture mode.

solution: before going to full screen, check if we are already in PIP.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
