### PR TITLE
fix: stereo button is shown for non-vr content

### DIFF
--- a/src/components/vr-stereo-toggle/vr-stereo-toggle.js
+++ b/src/components/vr-stereo-toggle/vr-stereo-toggle.js
@@ -45,7 +45,7 @@ class VrStereoToggleControl extends BaseComponent {
    */
   static shouldRender(props: any): boolean {
     const componentConfig = props.config.components[this.displayName];
-    return !(Object.keys(componentConfig).length === 0 && componentConfig.constructor === Object);
+    return props.state.engine.isVr && !(Object.keys(componentConfig).length === 0 && componentConfig.constructor === Object);
   }
   /**
    * Creates an instance of VrStereoToggleControl.


### PR DESCRIPTION
### Description of the Changes

add `props.state.engine.isVr` condition  

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
