### PR TITLE
fix(FEC-8775): preplayback is not updated if play is requested before media is loaded

### DIFF
--- a/src/components/engine-connector/engine-connector.js
+++ b/src/components/engine-connector/engine-connector.js
@@ -41,6 +41,7 @@ class EngineConnector extends BaseComponent {
     this.eventManager.listen(this.player, this.player.Event.PLAYER_RESET, () => {
       this.props.updateCurrentTime(0);
       this.props.updateIsIdle(true);
+      this.props.updateIsPlaybackStarted(false);
     });
 
     this.eventManager.listen(this.player, this.player.Event.SOURCE_SELECTED, () => {
@@ -53,7 +54,7 @@ class EngineConnector extends BaseComponent {
     });
 
     this.eventManager.listen(this.player, this.player.Event.CHANGE_SOURCE_STARTED, () => {
-      this.props.updatePrePlayback(!this.player.config.playback.autoplay);
+      this.props.updatePrePlayback(!this.player.config.playback.autoplay && !this.props.engine.isPlaybackStarted);
       this.props.updateIsChangingSource(true);
       this.props.updateFallbackToMutedAutoPlay(false);
       this.props.updateAdBreak(false);
@@ -112,6 +113,7 @@ class EngineConnector extends BaseComponent {
 
     this.eventManager.listen(this.player, this.player.Event.PLAYBACK_START, () => {
       this.props.updatePrePlayback(false);
+      this.props.updateIsPlaybackStarted(true);
       this.props.updateLoadingSpinnerState(true);
     });
 

--- a/src/reducers/engine.js
+++ b/src/reducers/engine.js
@@ -13,6 +13,7 @@ export const types = {
   UPDATE_LAST_SEEK_POINT: `${component}/UPDATE_LAST_SEEK_POINT`,
   UPDATE_IS_CHANGING_SOURCE: `${component}/UPDATE_IS_CHANGING_SOURCE`,
   UPDATE_IS_ENDED: `${component}/UPDATE_IS_ENDED`,
+  UPDATE_IS_PLAYBACK_STARTED: `${component}/UPDATE_IS_PLAYBACK_STARTED`,
   UPDATE_IS_PLAYBACK_ENDED: `${component}/UPDATE_IS_PLAYBACK_ENDED`,
   UPDATE_CURRENT_TIME: `${component}/UPDATE_CURRENT_TIME`,
   UPDATE_DURATION: `${component}/UPDATE_DURATION`,
@@ -51,6 +52,7 @@ export const initialState = {
   isPaused: false,
   isSeeking: false,
   isEnded: false,
+  isPlaybackStarted: false,
   isPlaybackEnded: false,
   isChangingSource: false,
   prePlayback: true,
@@ -145,6 +147,12 @@ export default (state: Object = initialState, action: Object) => {
       return {
         ...state,
         isEnded: action.isEnded
+      };
+
+    case types.UPDATE_IS_PLAYBACK_STARTED:
+      return {
+        ...state,
+        isPlaybackStarted: action.isPlaybackStarted
       };
 
     case types.UPDATE_IS_PLAYBACK_ENDED:
@@ -347,6 +355,7 @@ export const actions = {
   updateIsSeeking: (isSeeking: boolean) => ({type: types.UPDATE_IS_SEEKING, isSeeking}),
   updateLastSeekPoint: (lastSeekPoint: number) => ({type: types.UPDATE_LAST_SEEK_POINT, lastSeekPoint}),
   updateIsEnded: (isEnded: boolean) => ({type: types.UPDATE_IS_ENDED, isEnded}),
+  updateIsPlaybackStarted: (isPlaybackStarted: boolean) => ({type: types.UPDATE_IS_PLAYBACK_STARTED, isPlaybackStarted}),
   updateIsPlaybackEnded: (isPlaybackEnded: boolean) => ({type: types.UPDATE_IS_PLAYBACK_ENDED, isPlaybackEnded}),
   updateCurrentTime: (currentTime: number) => ({type: types.UPDATE_CURRENT_TIME, currentTime}),
   updateDuration: (duration: number) => ({type: types.UPDATE_DURATION, duration}),


### PR DESCRIPTION
### Description of the Changes

if play is called on API of player before loadMedia ends then in player we cache the play and when engine loads we start playing.
In UI we set the prePlayback state on the source selected and it might come after the play and case the prePlayback state to be invalid.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
