### PR TITLE
fix(FEC-8775): preplayback is not updated if play is requested before media is loaded

### DIFF
--- a/src/components/engine-connector/engine-connector.js
+++ b/src/components/engine-connector/engine-connector.js
@@ -112,7 +112,6 @@ class EngineConnector extends BaseComponent {
     });
 
     this.eventManager.listen(this.player, this.player.Event.PLAYBACK_START, () => {
-      this.props.updatePrePlayback(false);
       this.props.updateIsPlaybackStarted(true);
       this.props.updateLoadingSpinnerState(true);
     });
@@ -123,6 +122,7 @@ class EngineConnector extends BaseComponent {
 
     this.eventManager.listen(this.player, this.player.Event.PLAY, () => {
       this.props.updateIsPlaying(true);
+      this.props.updatePrePlayback(false);
       this.props.updateIsEnded(false);
       this.props.updateIsPaused(false);
       this.props.updateIsPlaybackEnded(false);


### PR DESCRIPTION
### Description of the Changes

Change the prePlayback state on PLAY instead of PLAYBACK_START

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
