### PR TITLE
fix(FEC-8799): video not unmuted by tapping on player or seek by dragging

### DIFF
--- a/src/components/shell/shell.js
+++ b/src/components/shell/shell.js
@@ -151,6 +151,9 @@ class Shell extends BaseComponent {
     if (this.props.prePlayback) {
       return;
     }
+    if (this.props.fallbackToMutedAutoPlay) {
+      this.player.muted = false;
+    }
     if (!this.state.hover) {
       e.stopPropagation();
     }


### PR DESCRIPTION
### Description of the Changes

handle `fallbackToMutedAutoPlay` in `onTouchEnd` also

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
