### PR TITLE
fix(FEC-8827): cast button is redundant and unreachable on replay

### DIFF
--- a/src/components/cast-on-tv/cast-before-play.js
+++ b/src/components/cast-on-tv/cast-before-play.js
@@ -81,7 +81,7 @@ class CastBeforePlay extends BaseComponent {
    */
   render(props: any): ?React$Element<any> {
     if (!props.isCastAvailable || props.loading) return undefined;
-    if (props.prePlayback || props.isPlaybackEnded) {
+    if (props.prePlayback) {
       const rootStyle = [style.castOnTvButtonContainer];
       if (this.state.show) {
         rootStyle.push(style.showCastOnTv);


### PR DESCRIPTION
### Description of the Changes

Do not show `cast-before-play` component on replay

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
