### PR TITLE
feat(FEC-8124): render player ads UI (also on mobile) unless configured else

### DIFF
--- a/src/components/top-bar/_top-bar.scss
+++ b/src/components/top-bar/_top-bar.scss
@@ -11,6 +11,7 @@
   position: absolute;
   top: 0;
   left: 0;
+  pointer-events: none;
 
   .left-controls {
     text-align: left;

--- a/src/ui-presets/ads.js
+++ b/src/ui-presets/ads.js
@@ -82,10 +82,9 @@ function getAdsUiCustomization(): Object {
  */
 function useDefaultAdsUi(props: any): boolean {
   try {
-    let isMobile = !!props.player.env.device.type;
     let adsRenderingSettings = props.player.config.plugins.ima.adsRenderingSettings;
     let useStyledLinearAds = adsRenderingSettings && adsRenderingSettings.useStyledLinearAds;
-    return isMobile || useStyledLinearAds;
+    return useStyledLinearAds;
   } catch (e) {
     return false;
   }


### PR DESCRIPTION
Render the default player view also on mobile
Added click-through css so the clicks will propagate to IMA

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
