### PR TITLE
fix(FEC-8852): closing pip window on Mac with Safari the video dose not return to the player

### DIFF
--- a/src/components/engine-connector/engine-connector.js
+++ b/src/components/engine-connector/engine-connector.js
@@ -275,6 +275,10 @@ class EngineConnector extends BaseComponent {
     this.eventManager.listen(this.player, this.player.Event.LEAVE_PICTURE_IN_PICTURE, () => {
       this.props.updateIsInPictureInPicture(false);
     });
+
+    this.eventManager.listen(this.player, this.player.Event.PRESENTATION_MODE_CHANGED, () => {
+      this.player.isInPictureInPicture() ? this.props.updateIsInPictureInPicture(true) : this.props.updateIsInPictureInPicture(false);
+    });
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

when closing the pip with the 'x' button on the window, safari fires a `PRESENTATION_MODE_CHANGED` event. 

listening to this event and checking if the player is in PIP mode or not.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
