### PR TITLE
fix(FEC-8846): current caption disappear after changing its style in advanced settings

### DIFF
--- a/src/styles/_captions.scss
+++ b/src/styles/_captions.scss
@@ -34,7 +34,7 @@ $hovering-offset: 50px;
   }
   &.overlay-active {
     :global(.playkit-subtitles) {
-      display: none;
+      visibility: hidden;
     }
   }
   :global(.playkit-subtitles) {


### PR DESCRIPTION
When an overlay menu is shown (like the advanced captions menu), the subtitles div is hidden (`display: none`).

When the user changes the style of the captions, we recompute its style.  The computing considers the captions divs, which in this case has no dimensions since it has `display: none`.

Changed it to be `visibility: hidden`, so the div's dimensions will be kept while calculating the new style.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
