### PR TITLE
fix: icons not shown on a white background

### DIFF
--- a/src/components/icon/icon.scss
+++ b/src/components/icon/icon.scss
@@ -128,6 +128,8 @@
   background-size: cover;
   background-repeat: no-repeat;
   background-position: 50% 50%;
+  -webkit-filter: drop-shadow(0px 0px 8px rgba(0,0,0,0.5));
+  filter: drop-shadow(0px 0px 8px rgba(0,0,0,0.5));
 }
 
 .icon-maximize {


### PR DESCRIPTION
### Description of the Changes

add drop-shadow to the player icons
![image](https://user-images.githubusercontent.com/17685520/51601332-b8ae2580-1f0c-11e9-8045-d0bc1d79c458.png)

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
