### PR TITLE
fix: icon style is duplicate

### DIFF
--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -28,7 +28,6 @@
 @import '../components/ad-skip/ad-skip';
 @import '../components/ad-notice/ad-notice';
 @import '../components/live-tag/live-tag';
-@import '../components/icon/icon';
 @import '../components/unmute-indication/unmute-indication';
 @import '../components/error-overlay/error-overlay';
 @import '../components/slider/slider';


### PR DESCRIPTION
<img width="1919" alt="screen shot 2019-01-23 at 4 18 32 pm" src="https://user-images.githubusercontent.com/17685520/51612793-d8ecdd00-1f2a-11e9-8092-c6203ac25e3d.png">

### Description of the Changes
remove `components/icon` import as it already imported via the components

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
