### PR TITLE
fix(FEC-8866): 'skip ad' button is covered by the control bar on mobile devices

### DIFF
--- a/src/ui-presets/ads.js
+++ b/src/ui-presets/ads.js
@@ -29,6 +29,13 @@ export function adsUI(props: any): ?React$Element<any> {
         <div className={style.playerGui} id="player-gui">
           <UnmuteIndication player={props.player} hasTopBar />
         </div>
+        <div>
+          <TopBar>
+            <div className={style.leftControls}>
+              <AdNotice />
+            </div>
+          </TopBar>
+        </div>
       </div>
     );
   }
@@ -82,9 +89,10 @@ function getAdsUiCustomization(): Object {
  */
 function useDefaultAdsUi(props: any): boolean {
   try {
+    let isMobile = !!props.player.env.device.type;
     let adsRenderingSettings = props.player.config.plugins.ima.adsRenderingSettings;
     let useStyledLinearAds = adsRenderingSettings && adsRenderingSettings.useStyledLinearAds;
-    return useStyledLinearAds;
+    return isMobile || useStyledLinearAds;
   } catch (e) {
     return false;
   }


### PR DESCRIPTION
Revert to using a different layout on mobile.
Using different layout on mobile
Adding the `adNotice` tag (`id='advertisement'`)

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
