### PR TITLE
fix(FEC-8717): the dropdown is cut on large amount of options

### DIFF
--- a/src/components/menu/menu.js
+++ b/src/components/menu/menu.js
@@ -87,11 +87,17 @@ class Menu extends Component {
     const menuElementRect = this._menuElement.getBoundingClientRect();
     const playerContainerRect = this.props.playerClientRect;
 
+    // The menu is first rendered above its label.
+    // top / bottom are determined from the top of the view port, if the menus top edge is lower than the top of the
+    // player it means that menu.top is bigger than player.top.
     if (menuElementRect.top >= playerContainerRect.top) {
       return [style.top, style.left];
     } else if (menuElementRect.bottom + menuElementRect.height < playerContainerRect.bottom) {
+      // menu.bottom + menu.height is the value of the bottom edge of the menu if its rendered below the label.
       return [style.bottom, style.left];
     } else {
+      // If we cannot render it on top of the label or below it, we will reduce the height of the menu to be
+      // 80% of the player height and put it at the bottom of the player.
       this._menuElement.style.maxHeight = playerContainerRect.height * 0.8 + 'px';
       return [style.stickBottom, style.left];
     }

--- a/src/components/menu/menu.js
+++ b/src/components/menu/menu.js
@@ -88,10 +88,17 @@ class Menu extends Component {
     const playerContainerRect = this.props.playerClientRect;
     const offsetBottom = playerContainerRect.bottom - menuElementRect.bottom;
     const height = offsetBottom + menuElementRect.height;
-    if (height > playerContainerRect.height) {
+    if (height < playerContainerRect.height) {
+      // if it can be on top of the drop down
+      return [style.top, style.left];
+    } else if (menuElementRect.bottom - menuElementRect.height > offsetBottom) {
+      // if it can be below that drop down
       return [style.bottom, style.left];
+    } else {
+      // if the menu's height is bigger than the player's height - stick it to the bottom of the player
+      this._menuElement.style.maxHeight = playerContainerRect.height * 0.8 + 'px';
+      return [style.stickBottom, style.left];
     }
-    return [style.top, style.left];
   }
 
   /**

--- a/src/components/menu/menu.js
+++ b/src/components/menu/menu.js
@@ -87,7 +87,7 @@ class Menu extends Component {
     const menuElementRect = this._menuElement.getBoundingClientRect();
     const playerContainerRect = this.props.playerClientRect;
 
-    if (menuElementRect.top > playerContainerRect.top) {
+    if (menuElementRect.top >= playerContainerRect.top) {
       return [style.top, style.left];
     } else if (menuElementRect.bottom + menuElementRect.height < playerContainerRect.bottom) {
       return [style.bottom, style.left];

--- a/src/components/menu/menu.js
+++ b/src/components/menu/menu.js
@@ -86,16 +86,12 @@ class Menu extends Component {
   getPosition(): Array<string> {
     const menuElementRect = this._menuElement.getBoundingClientRect();
     const playerContainerRect = this.props.playerClientRect;
-    const offsetBottom = playerContainerRect.bottom - menuElementRect.bottom;
-    const height = offsetBottom + menuElementRect.height;
-    if (height < playerContainerRect.height) {
-      // if it can be on top of the drop down
+
+    if (menuElementRect.top > playerContainerRect.top) {
       return [style.top, style.left];
-    } else if (menuElementRect.bottom - menuElementRect.height > offsetBottom) {
-      // if it can be below that drop down
+    } else if (menuElementRect.bottom + menuElementRect.height < playerContainerRect.bottom) {
       return [style.bottom, style.left];
     } else {
-      // if the menu's height is bigger than the player's height - stick it to the bottom of the player
       this._menuElement.style.maxHeight = playerContainerRect.height * 0.8 + 'px';
       return [style.stickBottom, style.left];
     }

--- a/src/styles/_dropdown.scss
+++ b/src/styles/_dropdown.scss
@@ -73,8 +73,8 @@
     right: 0;
   }
   &.stick-bottom{
-    top: -60px;
-    margin: 10px 0;
+    bottom: -95px;
+    margin: 5px 0;
   }
 
   .dropdown-menu-item {

--- a/src/styles/_dropdown.scss
+++ b/src/styles/_dropdown.scss
@@ -72,6 +72,10 @@
   &.left {
     right: 0;
   }
+  &.stick-bottom{
+    top: -60px;
+    margin: 10px 0;
+  }
 
   .dropdown-menu-item {
     padding: 2px 10px 2px 16px;

--- a/src/ui-presets/ads.js
+++ b/src/ui-presets/ads.js
@@ -29,6 +29,13 @@ export function adsUI(props: any): ?React$Element<any> {
         <div className={style.playerGui} id="player-gui">
           <UnmuteIndication player={props.player} hasTopBar />
         </div>
+        <div>
+          <TopBar>
+            <div className={style.leftControls}>
+              <AdNotice />
+            </div>
+          </TopBar>
+        </div>
       </div>
     );
   }
@@ -82,9 +89,10 @@ function getAdsUiCustomization(): Object {
  */
 function useDefaultAdsUi(props: any): boolean {
   try {
+    let isMobile = !!props.player.env.device.type;
     let adsRenderingSettings = props.player.config.plugins.ima.adsRenderingSettings;
     let useStyledLinearAds = adsRenderingSettings && adsRenderingSettings.useStyledLinearAds;
-    return useStyledLinearAds;
+    return isMobile || useStyledLinearAds;
   } catch (e) {
     return false;
   }


### PR DESCRIPTION
adding a third option to the menu position.
1. Limit the menu height to 80% of the player height. (`0.8*playerHeight`)
2. Position the menu above the bottom of the player.
3. When it's the lowest menu (e.g. captions) - it is indeed almost at the bottom. if its the upper menu (audio) then it will be more up because the menu position is absolute to the `Dropdown` component.

Before:
<img width="622" alt="screen shot 2019-01-29 at 13 54 37" src="https://user-images.githubusercontent.com/31587052/51906839-d298ae00-23cd-11e9-8b17-97868ecba8a2.png">

After: 
<img width="619" alt="screen shot 2019-01-29 at 12 47 56" src="https://user-images.githubusercontent.com/31587052/51906540-00c9be00-23cd-11e9-92b6-18f1ef0bfc11.png">

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated