### PR TITLE
fix(FEC-8768): seeking back on ended doesn't work when casting

### DIFF
--- a/src/components/bottom-bar/bottom-bar.js
+++ b/src/components/bottom-bar/bottom-bar.js
@@ -5,8 +5,18 @@ import {bindActions} from '../../utils/bind-actions';
 import {actions} from '../../reducers/shell';
 import {connect} from 'preact-redux';
 
+/**
+ * mapping state to props
+ * @param {*} state - redux store state
+ * @returns {Object} - mapped state to this component
+ */
+const mapStateToProps = state => ({
+  isCasting: state.engine.isCasting,
+  isPlaybackEnded: state.engine.isPlaybackEnded
+});
+
 @connect(
-  null,
+  mapStateToProps,
   bindActions(actions)
 )
 /**
@@ -25,6 +35,9 @@ class BottomBar extends Component {
    * @memberof BottomBar
    */
   render(props: any): React$Element<any> {
+    if (props.isCasting && props.isPlaybackEnded) {
+      return undefined;
+    }
     return (
       <div
         className={style.bottomBar}

--- a/src/components/bottom-bar/bottom-bar.js
+++ b/src/components/bottom-bar/bottom-bar.js
@@ -31,10 +31,10 @@ class BottomBar extends Component {
    * render component
    *
    * @param {*} props - component props
-   * @returns {React$Element} - component element
+   * @returns {?React$Element} - component element
    * @memberof BottomBar
    */
-  render(props: any): React$Element<any> {
+  render(props: any): ?React$Element<any> {
     if (props.isCasting && props.isPlaybackEnded) {
       return undefined;
     }

--- a/src/components/cast-on-tv/cast-after-play.js
+++ b/src/components/cast-on-tv/cast-after-play.js
@@ -1,0 +1,105 @@
+//@flow
+import style from '../../styles/style.scss';
+import {h} from 'preact';
+import BaseComponent from '../base';
+import {connect} from 'preact-redux';
+import {IconType} from '../icon/index';
+import {Icon} from '../icon/icon';
+import {Localizer, Text} from 'preact-i18n';
+
+/**
+ * mapping state to props
+ * @param {*} state - redux store state
+ * @returns {Object} - mapped state to this component
+ */
+const mapStateToProps = state => ({
+  isPlaybackEnded: state.engine.isPlaybackEnded,
+  isCasting: state.engine.isCasting
+});
+
+@connect(
+  mapStateToProps,
+  null
+)
+/**
+ * CastAfterPlay component
+ *
+ * @class CastAfterPlay
+ * @example <CastAfterPlay player={this.player} />
+ * @extends {BaseComponent}
+ */
+class CastAfterPlay extends BaseComponent {
+  /**
+   * @static
+   * @type {Object} - Component default props
+   */
+  static defaultProps: Object = {
+    icon: IconType.CastBrand
+  };
+
+  /**
+   * Creates an instance of CastOverlay.
+   * @param {Object} obj obj
+   * @memberof CastAfterPlay
+   */
+  constructor(obj: Object) {
+    super({name: 'CastAfterPlay', player: obj.player});
+  }
+
+  /**
+   * on click call the stop casting API.
+   *
+   * @param {Event} e - click event
+   * @returns {void}
+   * @memberof CastAfterPlay
+   */
+  onClick(e: Event): void {
+    e.stopPropagation();
+    this.player.stopCasting();
+  }
+
+  /**
+   * after component did mount, show the cast after play button.
+   *
+   * @returns {void}
+   * @memberof CastAfterPlay
+   */
+  componentDidMount(): void {
+    setTimeout(() => {
+      this.setState({show: true});
+    }, 700);
+  }
+
+  /**
+   * render component
+   *
+   * @param {*} props - component props
+   * @returns {?React$Element} - component element
+   * @memberof CastAfterPlay
+   */
+  render(props: any): ?React$Element<any> {
+    if (!props.isCasting || !props.isPlaybackEnded) return undefined;
+    const rootStyle = [style.castOnTvButtonContainer];
+    if (this.state.show) {
+      rootStyle.push(style.showCastOnTv);
+    }
+    return (
+      <div>
+        <div className={rootStyle.join(' ')} onClick={e => this.onClick(e)}>
+          <a className={[style.btn, style.btnDarkTransparent, style.castOnTvButton].join(' ')}>
+            <div className={style.castOnTvIconContainer}>
+              <Icon type={props.icon} />
+            </div>
+            <Localizer>
+              <span>
+                <Text id="cast.disconnect_from_tv" />
+              </span>
+            </Localizer>
+          </a>
+        </div>
+      </div>
+    );
+  }
+}
+
+export {CastAfterPlay};

--- a/src/components/cast-on-tv/index.js
+++ b/src/components/cast-on-tv/index.js
@@ -1,1 +1,2 @@
 export {CastBeforePlay} from './cast-before-play';
+export {CastAfterPlay} from './cast-after-play';

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -41,7 +41,7 @@ export {Watermark} from './watermark';
 export {CastControl} from './cast';
 export {CastOverlay} from './cast-overlay';
 export {VrStereoToggleControl} from './vr-stereo-toggle';
-export {CastBeforePlay} from './cast-on-tv';
+export {CastBeforePlay, CastAfterPlay} from './cast-on-tv';
 export {PlaylistButton} from './playlist-button';
 export {PlaylistNextScreen} from './playlist-next-screen';
 export {PictureInPicture} from './picture-in-picture';

--- a/src/components/top-bar/_top-bar.scss
+++ b/src/components/top-bar/_top-bar.scss
@@ -30,6 +30,7 @@
   }
 }
 
+.player.casting .top-bar,
 .player.hover .top-bar,
 .player.state-paused .top-bar,
 .player.state-idle .top-bar,

--- a/src/components/top-bar/top-bar.js
+++ b/src/components/top-bar/top-bar.js
@@ -1,6 +1,19 @@
 //@flow
 import style from '../../styles/style.scss';
 import {h, Component} from 'preact';
+import {connect} from 'preact-redux';
+
+/**
+ * mapping state to props
+ * @param {*} state - redux store state
+ * @returns {Object} - mapped state to this component
+ */
+const mapStateToProps = state => ({
+  isCasting: state.engine.isCasting,
+  isPlaybackEnded: state.engine.isPlaybackEnded
+});
+
+@connect(mapStateToProps)
 
 /**
  * TopBar component
@@ -18,6 +31,9 @@ class TopBar extends Component {
    * @memberof TopBar
    */
   render(props: any): React$Element<any> {
+    if (props.isCasting && props.isPlaybackEnded) {
+      return undefined;
+    }
     return <div className={style.topBar}>{props.children}</div>;
   }
 }

--- a/src/components/top-bar/top-bar.js
+++ b/src/components/top-bar/top-bar.js
@@ -27,10 +27,10 @@ class TopBar extends Component {
    * render component
    *
    * @param {*} props - component props
-   * @returns {React$Element} - component element
+   * @returns {?React$Element} - component element
    * @memberof TopBar
    */
-  render(props: any): React$Element<any> {
+  render(props: any): ?React$Element<any> {
     if (props.isCasting && props.isPlaybackEnded) {
       return undefined;
     }


### PR DESCRIPTION
### Description of the Changes

* do not render `BottomBar` and `TopBar` when casting and the player is ended
* re-expose `CastAfterPlay` component for https://github.com/kaltura/playkit-js-cast-sender/pull/14
This reverts part of commit ae87bc9 
* add missing css rule for `TopBar` component
### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
