### PR TITLE
fix(FEC-8885): smart menu doesn't open if no label is supplied

### DIFF
--- a/src/components/smart-container/smart-container-item.js
+++ b/src/components/smart-container/smart-container-item.js
@@ -21,7 +21,7 @@ class SmartContainerItem extends Component {
   render(props: any): React$Element<any> {
     return (
       <div className={[style.smartContainerItem, style.selectMenuItem].join(' ')}>
-        <label htmlFor={props.label.toLowerCase()}>
+        <label htmlFor={props.label && props.label.toLowerCase()}>
           {props.icon ? (
             <div className={style.labelIcon}>
               <Icon type={props.icon} />
@@ -31,7 +31,7 @@ class SmartContainerItem extends Component {
           )}
           {props.label}
         </label>
-        <DropDown name={props.label.toLowerCase()} onSelect={o => props.onSelect(o)} options={props.options} />
+        <DropDown name={props.label && props.label.toLowerCase()} onSelect={o => props.onSelect(o)} options={props.options} />
       </div>
     );
   }

--- a/src/components/smart-container/smart-container-item.js
+++ b/src/components/smart-container/smart-container-item.js
@@ -19,9 +19,10 @@ class SmartContainerItem extends Component {
    * @memberof SmartContainer
    */
   render(props: any): React$Element<any> {
+    const label = props.label && props.label.toLowerCase();
     return (
       <div className={[style.smartContainerItem, style.selectMenuItem].join(' ')}>
-        <label htmlFor={props.label && props.label.toLowerCase()}>
+        <label htmlFor={label}>
           {props.icon ? (
             <div className={style.labelIcon}>
               <Icon type={props.icon} />
@@ -31,7 +32,7 @@ class SmartContainerItem extends Component {
           )}
           {props.label}
         </label>
-        <DropDown name={props.label && props.label.toLowerCase()} onSelect={o => props.onSelect(o)} options={props.options} />
+        <DropDown name={label} onSelect={o => props.onSelect(o)} options={props.options} />
       </div>
     );
   }


### PR DESCRIPTION
### Description of the Changes

in case there is not label supplied (e.g. field does not exist in the localization), the label will return as null. added protection.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
