### PR TITLE
fix(FEC-8888): the playback paused when tap on "unmute" button on Android

### DIFF
--- a/src/components/unmute-indication/unmute-indication.js
+++ b/src/components/unmute-indication/unmute-indication.js
@@ -106,6 +106,7 @@ class UnmuteIndication extends BaseComponent {
           onMouseOver={() => this.setState({iconOnly: false})}
           onMouseOut={() => this.setState({iconOnly: true})}
           onClick={() => (this.player.muted = !this.player.muted)}
+          onTouchEnd={e => e.stopImmediatePropagation()}
           onKeyDown={e => this._keyDownHandler(e)}>
           <a className={[style.btn, style.btnDarkTransparent, style.unmuteButton].join(' ')}>
             <div className={style.unmuteIconContainer}>


### PR DESCRIPTION
### Description of the Changes
Stop the event from bubbling to the shell component.
The shell component listens to this event as well, and for some reason the unmute there causes the player to pause.
### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
