### PR TITLE
feat(FEC-8868): mobile ads preset

### DIFF
--- a/src/components/bottom-bar/_bottom-bar.scss
+++ b/src/components/bottom-bar/_bottom-bar.scss
@@ -53,6 +53,10 @@
   visibility: hidden;
 }
 
+.player .on-top-ad .bottom-bar{
+  width: auto;
+}
+
 .player.size-sm {
   .bottom-bar {
     padding: 6px 8px;

--- a/src/components/smart-container/_smart-container.scss
+++ b/src/components/smart-container/_smart-container.scss
@@ -132,14 +132,5 @@
         }
       }
     }
-    &.IE,
-    &.Edge{
-      select{
-        option{
-          color: black;
-          background-color: white;
-        }
-      }
-    }
   }
 }

--- a/src/components/smart-container/_smart-container.scss
+++ b/src/components/smart-container/_smart-container.scss
@@ -132,5 +132,14 @@
         }
       }
     }
+    &.IE,
+    &.Edge{
+      select{
+        option{
+          color: black;
+          background-color: white;
+        }
+      }
+    }
   }
 }

--- a/src/ui-presets/ads.js
+++ b/src/ui-presets/ads.js
@@ -24,17 +24,29 @@ import {PlaybackControls} from '../components/playback-controls';
 export function adsUI(props: any): ?React$Element<any> {
   if (useDefaultAdsUi(props)) {
     return (
-      <div className={style.adGuiWrapper}>
+      <div className={[style.adGuiWrapper, style.onTopAd].join(' ')}>
+        <KeyboardControl player={props.player} config={props.config} />
         <Loading player={props.player} />
         <div className={style.playerGui} id="player-gui">
           <UnmuteIndication player={props.player} hasTopBar />
-        </div>
-        <div>
-          <TopBar>
+          <div>
+            <TopBar>
+              <div className={style.leftControls}>
+                <AdNotice />
+              </div>
+            </TopBar>
+          </div>
+          <PlaybackControls player={props.player} />
+          <BottomBar>
             <div className={style.leftControls}>
-              <AdNotice />
+              <PlaybackControls player={props.player} />
+              <TimeDisplayAdsContainer />
             </div>
-          </TopBar>
+            <div className={style.leftControls}>
+              <VolumeControl player={props.player} />
+              <FullscreenControl player={props.player} />
+            </div>
+          </BottomBar>
         </div>
       </div>
     );
@@ -89,10 +101,9 @@ function getAdsUiCustomization(): Object {
  */
 function useDefaultAdsUi(props: any): boolean {
   try {
-    let isMobile = !!props.player.env.device.type;
     let adsRenderingSettings = props.player.config.plugins.ima.adsRenderingSettings;
     let useStyledLinearAds = adsRenderingSettings && adsRenderingSettings.useStyledLinearAds;
-    return isMobile || useStyledLinearAds;
+    return useStyledLinearAds;
   } catch (e) {
     return false;
   }

--- a/src/ui-presets/ads.js
+++ b/src/ui-presets/ads.js
@@ -41,8 +41,6 @@ export function adsUI(props: any): ?React$Element<any> {
             <div className={style.leftControls}>
               <PlaybackControls player={props.player} />
               <TimeDisplayAdsContainer />
-            </div>
-            <div className={style.leftControls}>
               <VolumeControl player={props.player} />
               <FullscreenControl player={props.player} />
             </div>


### PR DESCRIPTION
Description of the Changes

Added fullscreen and volume controls to the IMA mobile preset.
moved everything to the left, so it won't clash with IMA's skip button.
Render the default player view also on mobile

References:
https://github.com/kaltura/playkit-js-ui/pull/334

![unknown](https://user-images.githubusercontent.com/31587052/52536050-6c614300-2d5e-11e9-93b4-cd400610ee78.png)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
