### PR TITLE
fix(FEC-8905): default drop-downs options in IE and Edge are not visible

### DIFF
--- a/src/components/smart-container/_smart-container.scss
+++ b/src/components/smart-container/_smart-container.scss
@@ -132,5 +132,14 @@
         }
       }
     }
+    &.IE,
+    &.Edge{
+      select{
+        option{
+          color: black;
+          background-color: white;
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
### Description of the Changes

changed the CSS for the options in IE / Edge. Currently, these menus only appear in the small version of the player.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
