### PR TITLE
fix(FEC-8903): when loading a player with display: none, the player size class is set to small

### DIFF
--- a/src/components/shell/shell.js
+++ b/src/components/shell/shell.js
@@ -199,6 +199,7 @@ class Shell extends BaseComponent {
     this.props.updateIsMobile(!!this.player.env.device.type || this.props.forceTouchUI);
     this._onWindowResize();
     this.eventManager.listen(window, 'resize', () => this._onWindowResize());
+    this.eventManager.listen(this.player, this.player.Event.PLAYING, () => this._onWindowResize());
   }
 
   /**

--- a/src/components/shell/shell.js
+++ b/src/components/shell/shell.js
@@ -199,7 +199,7 @@ class Shell extends BaseComponent {
     this.props.updateIsMobile(!!this.player.env.device.type || this.props.forceTouchUI);
     this._onWindowResize();
     this.eventManager.listen(window, 'resize', () => this._onWindowResize());
-    this.eventManager.listen(this.player, this.player.Event.PLAYING, () => this._onWindowResize());
+    this.eventManager.listen(this.player, this.player.Event.FIRST_PLAY, () => this._onWindowResize());
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

Besides checking for dimension on resize events, check for dimensions on `FIRST_PLAY` event.

this way, if the player is hidden before (with dispaly: none e.g) it will be rendered with it's real width and height when it is playing. 

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
