### PR TITLE
fix(FEC-8565): bottom bar is not clickable when the loading overlay is displayed

### DIFF
--- a/src/components/loading/_loading.scss
+++ b/src/components/loading/_loading.scss
@@ -25,11 +25,8 @@
 
 .loading-backdrop {
   position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-color: rgba(0, 0, 0, 0.3);
+  top: 50%;
+  left: 50%;
   transition: 100ms opacity;
   opacity: 0;
   z-index: 5;


### PR DESCRIPTION
### Description of the Changes

Reduced spinner overlay height, so the bottom bar will be clickable.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
