### PR TITLE
fix(FEC-8926): Subtitles are hidden by the seek bar on none Safari browsers in iOS

### DIFF
--- a/src/styles/_captions.scss
+++ b/src/styles/_captions.scss
@@ -20,7 +20,7 @@ $hovering-offset: 50px;
       padding: 0 0 $hovering-offset 0;
     }
     &.Safari,
-    &.Mobile-Safari {
+    &.iOS {
       video::-webkit-media-text-track-container {
         padding: initial;
         max-height: calc(100% - #{$hovering-offset});


### PR DESCRIPTION


### Description of the Changes

Change the condition of the `Hover` control bar calculation from `Mobile-safari` to `iOS`

### CheckLists

- [V] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [V] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
