### PR TITLE
fix(FEC-8922): ima preset with useStyledLinearAds=true cuts the control bar in half

### DIFF
--- a/src/components/bottom-bar/_bottom-bar.scss
+++ b/src/components/bottom-bar/_bottom-bar.scss
@@ -55,6 +55,19 @@
 
 .player .on-top-ad .bottom-bar{
   width: auto;
+  background: transparent;
+}
+
+.player .fake-bottom-bar{
+  height: 45px;
+  width:100%;
+  pointer-events: none;
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.6) 100%);
+  margin-top: auto;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
 }
 
 .player.size-sm {

--- a/src/ui-presets/ads.js
+++ b/src/ui-presets/ads.js
@@ -37,6 +37,7 @@ export function adsUI(props: any): ?React$Element<any> {
             </TopBar>
           </div>
           <PlaybackControls player={props.player} />
+          <div className={style.fakeBottomBar} />
           <BottomBar>
             <div className={style.leftControls}>
               <PlaybackControls player={props.player} />


### PR DESCRIPTION
adding an element with the style of the bottom bar, only for background look and feel. All the clicks will go through it.

### Description of the Changes

Please add a detailed description of the change, whether it's an enhancement or a bugfix.
If the PR is related to an open issue please link to it.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
