### PR TITLE
fix(FEC-8802): Fullscreen event is not available on iOS after an Ad

### DIFF
--- a/src/components/fullscreen/fullscreen.js
+++ b/src/components/fullscreen/fullscreen.js
@@ -89,7 +89,11 @@ class FullscreenControl extends BaseComponent {
         this.eventManager.listen(this.player.getVideoElement(), 'webkitbeginfullscreen', () => this.fullscreenEnterHandler());
         this.eventManager.listen(this.player.getVideoElement(), 'webkitendfullscreen', () => this.fullscreenExitHandler());
       };
-      this.eventManager.listenOnce(this.player, this.player.Event.SOURCE_SELECTED, attachIosFullscreenListeners);
+      if (this.player.getVideoElement()) {
+        attachIosFullscreenListeners();
+      } else {
+        this.eventManager.listenOnce(this.player, this.player.Event.SOURCE_SELECTED, attachIosFullscreenListeners);
+      }
     }
   }
 


### PR DESCRIPTION
### Description of the Changes

Added an additional condition that will add the `attachIosFullscreenListeners()` method when the` `videoElement` is available. 

### CheckLists

- [V] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [V] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
