### PR TITLE
fix(FEC-8939): language and settings menu dose not fit player size under 480px

### DIFF
--- a/src/components/overlay/_overlay.scss
+++ b/src/components/overlay/_overlay.scss
@@ -78,20 +78,21 @@
   }
 }
 
-.player.size-sm {
-  .overlay {
-    .overlay-contents {
-      padding: 16px 24px;
-    }
-
-    .close-overlay {
-      top: 15px;
-      right: 24px;
-    }
-    .title {
-      font-size: 16px;
-      line-height: 19px;
-      margin-bottom: 24px;
+.player {
+  &.size-sm, &.size-xs {
+    .overlay {
+      .overlay-contents {
+        padding: 16px 24px;
+      }
+      .close-overlay {
+        top: 15px;
+        right: 24px;
+      }
+      .title {
+        font-size: 20px;
+        line-height: 19px;
+        margin-bottom: 24px;
+      }
     }
   }
 }


### PR DESCRIPTION
### Description of the Changes

change headline size small player settings overlay

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
