### PR TITLE
fix(FEC-8948): play/pause icons (in middle player) are not changing according to player size

### DIFF
--- a/src/components/pre-playback-play-overlay/_pre-playback-play-overlay.scss
+++ b/src/components/pre-playback-play-overlay/_pre-playback-play-overlay.scss
@@ -14,7 +14,7 @@
     width: 108px;
     border: 2px solid rgba(255, 255, 255, 0.2);
     background-color: rgba(0, 0, 0, 0.5);
-    margin: -54px 0 0 -54px;
+    transform: translate(-50%, -50%);
     border-radius: 54px;
     padding: 20px;
     cursor: pointer;
@@ -43,7 +43,6 @@
       width: 75px;
       height: 75px;
       padding: 12px;
-      margin: -35px 0 0 -42px;
     }
   }
   &.size-xs {
@@ -51,7 +50,6 @@
       width: 85px;
       height: 85px;
       padding: 15px;
-      margin: -38px 0 0 -49px;
     }
   }
 }

--- a/src/components/pre-playback-play-overlay/_pre-playback-play-overlay.scss
+++ b/src/components/pre-playback-play-overlay/_pre-playback-play-overlay.scss
@@ -36,3 +36,22 @@
     display: none;
   }
 }
+
+.player{
+  &.size-ty {
+    .pre-playback-play-button {
+      width: 75px;
+      height: 75px;
+      padding: 12px;
+      margin: -35px 0 0 -42px;
+    }
+  }
+  &.size-xs {
+    .pre-playback-play-button{
+      width: 85px;
+      height: 85px;
+      padding: 15px;
+      margin: -38px 0 0 -49px;
+    }
+  }
+}


### PR DESCRIPTION
### Description of the Changes

adding small player breakpoint for the pre-playback button as well.
<img width="265" alt="small preplayback 280px" src="https://user-images.githubusercontent.com/31587052/53882204-5a518800-401e-11e9-98ec-927dee60e048.png">

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
