### PR TITLE
fix(FEC-8980): size CSS class is incorrect if player is rendered when detached from DOM

### DIFF
--- a/src/components/shell/shell.js
+++ b/src/components/shell/shell.js
@@ -202,7 +202,7 @@ class Shell extends BaseComponent {
   componentDidMount() {
     this.props.updateIsMobile(!!this.player.env.device.type || this.props.forceTouchUI);
     this._onWindowResize();
-    this.eventManager.listen(window, 'resize', () => this._onWindowResize());
+    this.eventManager.listen(this.player, this.player.Event.RESIZE, () => this._onWindowResize());
     this.eventManager.listen(this.player, this.player.Event.FIRST_PLAY, () => this._onWindowResize());
   }
 


### PR DESCRIPTION
### Description of the Changes

the `getBoudingClientRect` returns width: 0 and height: 0 in this case, causing incorrect size class

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
