### PR TITLE
fix(FEC-7642): firefox speed selector keyboard shortcut doesnt work

### DIFF
--- a/src/ui-manager.js
+++ b/src/ui-manager.js
@@ -7,6 +7,7 @@ import {copyDeep} from './utils/copy-deep';
 import {mergeDeep} from './utils/merge-deep';
 import {LogLevel, getLogLevel, setLogLevel} from './utils/logger';
 import {EventType} from './event/event-type';
+import {setEnv} from './utils/key-map';
 
 import reducer from './store';
 import en_translations from './translations/en.json';
@@ -53,6 +54,7 @@ class UIManager {
     this._createStore(config);
     this.setConfig(config);
     this._setLocaleTranslations(config);
+    setEnv(this.player.env);
   }
 
   /**

--- a/src/utils/key-map.js
+++ b/src/utils/key-map.js
@@ -19,6 +19,15 @@ export const KeyMap: {[key: string]: number} = {
 };
 
 /**
+ * set env for keymap
+ * @param {Object} env - env object
+ * @returns {void}
+ */
+export function setEnv(env: Object): void {
+  KeyMap.SEMI_COLON = env.browser.name.toLowerCase() === 'firefox' ? 59 : 186;
+}
+
+/**
  * gets the key name for a certain key code
  * @param {number} keyCode - key code
  * @returns {string} - key name


### PR DESCRIPTION

### Description of the Changes

different key code in firefox for semi colon

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
