### PR TITLE
fix(FEC-9006): invalid share CSS portal selector

### DIFF
--- a/src/components/share/share.js
+++ b/src/components/share/share.js
@@ -87,13 +87,14 @@ class ShareControl extends BaseComponent {
       return undefined;
     }
     const shareConfig = this._getMergedShareConfig();
+    const portalSelector = `#${this.player.config.targetId} .overlay-portal`;
     return (
       <div className={[style.controlButtonContainer, style.controlShare].join(' ')}>
         <button className={style.controlButton} onClick={() => this.toggleOverlay()} aria-label="Share">
           <Icon type={IconType.Share} />
         </button>
         {this.state.overlay ? (
-          <Portal into=".overlay-portal">
+          <Portal into={portalSelector}>
             <ShareOverlay
               shareUrl={shareUrl}
               embedUrl={embedUrl}


### PR DESCRIPTION
### Description of the Changes

The CSS selector was too general, added the player instance selector prefix to it

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
