### PR TITLE
fix(FEC-9010): share button shows on preplay screen

### DIFF
--- a/src/ui-presets/live.js
+++ b/src/ui-presets/live.js
@@ -38,7 +38,8 @@ export function liveUI(props: any): React$Element<any> {
       <Loading player={props.player} />
       <div className={style.playerGui} id="player-gui">
         <OverlayPortal />
-        <UnmuteIndication />
+        <UnmuteIndication player={props.player} />
+        <ShareControl player={props.player} />
         <OverlayAction player={props.player} />
         <PlaybackControls player={props.player} />
         <BottomBar>
@@ -59,7 +60,6 @@ export function liveUI(props: any): React$Element<any> {
         </BottomBar>
       </div>
       {Watermark.shouldRender(props) ? <Watermark player={props.player} /> : undefined}
-      <ShareControl player={props.player} />
       <PrePlaybackPlayOverlay player={props.player} />
       <CastBeforePlay player={props.player} />
       <PictureInPictureOverlay player={props.player} />

--- a/src/ui-presets/live.js
+++ b/src/ui-presets/live.js
@@ -39,9 +39,9 @@ export function liveUI(props: any): React$Element<any> {
       <div className={style.playerGui} id="player-gui">
         <OverlayPortal />
         <UnmuteIndication player={props.player} />
-        <ShareControl player={props.player} />
         <OverlayAction player={props.player} />
         <PlaybackControls player={props.player} />
+        <ShareControl player={props.player} />
         <BottomBar>
           <SeekBarLivePlaybackContainer showFramePreview showTimeBubble player={props.player} playerContainer={props.playerContainer} />
           <div className={style.leftControls}>

--- a/src/ui-presets/playback.js
+++ b/src/ui-presets/playback.js
@@ -42,9 +42,9 @@ export function playbackUI(props: any): React$Element<any> {
       <div className={style.playerGui} id="player-gui">
         <OverlayPortal />
         <UnmuteIndication player={props.player} />
-        <ShareControl player={props.player} />
         <OverlayAction player={props.player} />
         <PlaybackControls player={props.player} />
+        <ShareControl player={props.player} />
         {PlaylistNextScreen.shouldRender(props) ? <PlaylistNextScreen player={props.player} /> : undefined}
         <BottomBar>
           <SeekBarPlaybackContainer showFramePreview showTimeBubble player={props.player} playerContainer={props.playerContainer} />

--- a/src/ui-presets/playback.js
+++ b/src/ui-presets/playback.js
@@ -42,6 +42,7 @@ export function playbackUI(props: any): React$Element<any> {
       <div className={style.playerGui} id="player-gui">
         <OverlayPortal />
         <UnmuteIndication player={props.player} />
+        <ShareControl player={props.player} />
         <OverlayAction player={props.player} />
         <PlaybackControls player={props.player} />
         {PlaylistNextScreen.shouldRender(props) ? <PlaylistNextScreen player={props.player} /> : undefined}
@@ -64,7 +65,6 @@ export function playbackUI(props: any): React$Element<any> {
         </BottomBar>
       </div>
       {Watermark.shouldRender(props) ? <Watermark player={props.player} /> : undefined}
-      <ShareControl player={props.player} />
       {PlaylistCountdown.shouldRender(props) ? <PlaylistCountdown player={props.player} /> : undefined}
       <PrePlaybackPlayOverlay player={props.player} />
       <CastBeforePlay player={props.player} />


### PR DESCRIPTION
### Description of the Changes

The share component is placed outside of the `player-gui` so player state display modes don't apply to it.
Moving it to be under `player-gui` will ensure it shows like the rest of the controls.
Also added reference to `player` in Live preset for `UnmuteIndication` component which was missing.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
