### PR TITLE
fix(FEC-9004): share copy link doesn't work on iOS

### DIFF
--- a/src/components/share-overlay/share-overlay.js
+++ b/src/components/share-overlay/share-overlay.js
@@ -79,11 +79,16 @@ const ShareUrl = (props: Object): React$Element<any> => {
    * on success, set success internal component state for 2 seconds
    *
    * @param {HTMLInputElement} inputElement - start from input element
+   * @param {boolean} isIos - if UA is on iOS device
    * @returns {void}
    * @memberof ShareOverlay
    */
-  const copyUrl = (inputElement: HTMLInputElement) => {
-    inputElement.select();
+  const copyUrl = (inputElement: HTMLInputElement, isIos: boolean) => {
+    if (isIos) {
+      inputElement.setSelectionRange(0, 9999);
+    } else {
+      inputElement.select();
+    }
     document.execCommand('copy');
     inputElement.blur();
   };
@@ -94,7 +99,7 @@ const ShareUrl = (props: Object): React$Element<any> => {
         <input type="text" ref={c => (_ref = c)} className={style.formControl} value={props.shareUrl} readOnly />
         <Icon type={IconType.Link} />
       </div>
-      {props.copy && <CopyButton copy={() => copyUrl(_ref)} />}
+      {props.copy && <CopyButton copy={() => copyUrl(_ref, props.isIos)} />}
     </div>
   );
 };
@@ -270,7 +275,7 @@ class ShareOverlay extends BaseComponent {
             </button>
           </div>
           <div className={style.linkOptionsContainer}>
-            <ShareUrl shareUrl={this.getShareUrl()} copy={true} />
+            <ShareUrl shareUrl={this.getShareUrl()} copy={true} isIos={this.player.env.os.name === 'iOS'} />
             {this.props.enableTimeOffset ? (
               <VideoStartOptions
                 startFrom={this.state.startFrom}
@@ -298,7 +303,7 @@ class ShareOverlay extends BaseComponent {
       <div className={this.state.view === shareOverlayView.EmbedOptions ? 'overlay-screen active' : 'overlay-screen'}>
         <div className={style.title}>{props.title}</div>
         <div className={style.linkOptionsContainer}>
-          <ShareUrl shareUrl={props.shareUrl} copy={true} />
+          <ShareUrl shareUrl={props.shareUrl} copy={true} isIos={this.player.env.os.name === 'iOS'} />
           {this.props.enableTimeOffset ? (
             <VideoStartOptions
               startFrom={this.state.startFrom}

--- a/src/components/share-overlay/share-overlay.js
+++ b/src/components/share-overlay/share-overlay.js
@@ -159,6 +159,7 @@ class ShareOverlay extends BaseComponent {
    * @memberof ShareOverlay
    */
   componentWillMount() {
+    this.isIos = this.player.env.os.name === 'iOS';
     this.setState({
       view: shareOverlayView.Main,
       startFrom: false,
@@ -275,7 +276,7 @@ class ShareOverlay extends BaseComponent {
             </button>
           </div>
           <div className={style.linkOptionsContainer}>
-            <ShareUrl shareUrl={this.getShareUrl()} copy={true} isIos={this.player.env.os.name === 'iOS'} />
+            <ShareUrl shareUrl={this.getShareUrl()} copy={true} isIos={this.isIos} />
             {this.props.enableTimeOffset ? (
               <VideoStartOptions
                 startFrom={this.state.startFrom}
@@ -303,7 +304,7 @@ class ShareOverlay extends BaseComponent {
       <div className={this.state.view === shareOverlayView.EmbedOptions ? 'overlay-screen active' : 'overlay-screen'}>
         <div className={style.title}>{props.title}</div>
         <div className={style.linkOptionsContainer}>
-          <ShareUrl shareUrl={props.shareUrl} copy={true} isIos={this.player.env.os.name === 'iOS'} />
+          <ShareUrl shareUrl={props.shareUrl} copy={true} isIos={this.isIos} />
           {this.props.enableTimeOffset ? (
             <VideoStartOptions
               startFrom={this.state.startFrom}


### PR DESCRIPTION
### Description of the Changes

on iOS it is required to use `setSelectionRange` to select an input.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
