### PR TITLE
fix(FEC-9003): can't close share overlay on IE11

### DIFF
--- a/src/components/share/share.js
+++ b/src/components/share/share.js
@@ -34,6 +34,7 @@ const mapStateToProps = state => ({
  * @extends {BaseComponent}
  */
 class ShareControl extends BaseComponent {
+  _portal: any;
   /**
    * Creates an instance of ShareControl.
    * @param {Object} obj obj
@@ -90,11 +91,8 @@ class ShareControl extends BaseComponent {
     const portalSelector = `#${this.player.config.targetId} .overlay-portal`;
     return (
       <div className={[style.controlButtonContainer, style.controlShare].join(' ')}>
-        <button className={style.controlButton} onClick={() => this.toggleOverlay()} aria-label="Share">
-          <Icon type={IconType.Share} />
-        </button>
         {this.state.overlay ? (
-          <Portal into={portalSelector}>
+          <Portal into={portalSelector} ref={ref => (this._portal = ref)}>
             <ShareOverlay
               shareUrl={shareUrl}
               embedUrl={embedUrl}
@@ -104,7 +102,11 @@ class ShareControl extends BaseComponent {
               onClose={() => this.toggleOverlay()}
             />
           </Portal>
-        ) : null}
+        ) : (
+          <button className={style.controlButton} onClick={() => this.toggleOverlay()} aria-label="Share">
+            <Icon type={IconType.Share} />
+          </button>
+        )}
       </div>
     );
   }

--- a/src/components/smart-container/smart-container.js
+++ b/src/components/smart-container/smart-container.js
@@ -39,6 +39,7 @@ const mapStateToProps = state => ({
  * @extends {Component}
  */
 class SmartContainer extends Component {
+  _portal: any;
   /**
    * before component mounted, add player css class
    *
@@ -72,7 +73,7 @@ class SmartContainer extends Component {
   render(props: any): React$Element<any> {
     const portalSelector = `#${this.props.targetId} .overlay-portal`;
     return props.isMobile || [PLAYER_SIZE.SMALL, PLAYER_SIZE.EXTRA_SMALL].includes(this.props.playerSize) ? (
-      <Portal into={portalSelector}>
+      <Portal into={portalSelector} ref={ref => (this._portal = ref)}>
         <Overlay open onClose={() => props.onClose()}>
           <div className={style.title}>{props.title}</div>
           {props.children}


### PR DESCRIPTION
### Description of the Changes

See https://github.com/kaltura/playkit-js-ui/pull/95 as it is basically the same issue :-(
Also fixed it for smart container as it will now be rendered on desktops(and hence IE11) when player is very small.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
