### PR TITLE
fix(FEC-9011): share button dose not work on end screen

### DIFF
--- a/src/components/share/share.scss
+++ b/src/components/share/share.scss
@@ -4,9 +4,10 @@
     right: 10px;
     top: 10px;
     display: none;
+    z-index: 1;
   }
 
-  &.hover, &.state-paused {
+  &.hover, &.state-paused, &.state-idle {
     .control-button-container.control-share{
       display: inline-block;
     }


### PR DESCRIPTION
### Description of the Changes

on end screen the pre playback overlay hides entire video area.
Use same `hack` as control bar and add z-index: 1
Also added CSS rule to keep button always visible like control bar and not on hover.
I general we need to find something less hacky then z-index dependency between pre-playback overlay and end screen visible controls. will open a separate ticket.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
