### PR TITLE
feat(FEC-9029): unable to set the Smart Container titles

### DIFF
--- a/src/components/language/language.js
+++ b/src/components/language/language.js
@@ -169,7 +169,10 @@ class LanguageControl extends BaseComponent {
         {!this.state.smartContainerOpen || this.state.cvaaOverlay ? (
           undefined
         ) : (
-          <SmartContainer targetId={this.player.config.targetId} title="Language" onClose={() => this.onControlButtonClick()}>
+          <SmartContainer
+            targetId={this.player.config.targetId}
+            title={<Text id="smartContainer.language" />}
+            onClose={() => this.onControlButtonClick()}>
             {audioOptions.length <= 1 ? (
               undefined
             ) : (

--- a/src/components/language/language.js
+++ b/src/components/language/language.js
@@ -169,10 +169,7 @@ class LanguageControl extends BaseComponent {
         {!this.state.smartContainerOpen || this.state.cvaaOverlay ? (
           undefined
         ) : (
-          <SmartContainer
-            targetId={this.player.config.targetId}
-            title={<Text id="smartContainer.language" />}
-            onClose={() => this.onControlButtonClick()}>
+          <SmartContainer targetId={this.player.config.targetId} title={<Text id="language.title" />} onClose={() => this.onControlButtonClick()}>
             {audioOptions.length <= 1 ? (
               undefined
             ) : (

--- a/src/components/settings/settings.js
+++ b/src/components/settings/settings.js
@@ -217,10 +217,7 @@ class SettingsControl extends BaseComponent {
         {!this.state.smartContainerOpen ? (
           ''
         ) : (
-          <SmartContainer
-            targetId={this.player.config.targetId}
-            title={<Text id="smartContainer.settings" />}
-            onClose={() => this.onControlButtonClick()}>
+          <SmartContainer targetId={this.player.config.targetId} title={<Text id="settings.title" />} onClose={() => this.onControlButtonClick()}>
             {qualityOptions.length <= 1 ? (
               ''
             ) : (

--- a/src/components/settings/settings.js
+++ b/src/components/settings/settings.js
@@ -217,7 +217,7 @@ class SettingsControl extends BaseComponent {
         {!this.state.smartContainerOpen ? (
           ''
         ) : (
-          <SmartContainer targetId={this.player.config.targetId} title="Settings" onClose={() => this.onControlButtonClick()}>
+          <SmartContainer targetId={this.player.config.targetId} title={<Text id="smartContainer.settings" />} onClose={() => this.onControlButtonClick()}>
             {qualityOptions.length <= 1 ? (
               ''
             ) : (

--- a/src/components/settings/settings.js
+++ b/src/components/settings/settings.js
@@ -217,7 +217,10 @@ class SettingsControl extends BaseComponent {
         {!this.state.smartContainerOpen ? (
           ''
         ) : (
-          <SmartContainer targetId={this.player.config.targetId} title={<Text id="smartContainer.settings" />} onClose={() => this.onControlButtonClick()}>
+          <SmartContainer
+            targetId={this.player.config.targetId}
+            title={<Text id="smartContainer.settings" />}
+            onClose={() => this.onControlButtonClick()}>
             {qualityOptions.length <= 1 ? (
               ''
             ) : (

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -22,10 +22,12 @@
     "button": "Copy"
   },
   "settings": {
+    "title": "Settings",
     "quality": "Quality",
     "speed": "Speed"
   },
   "language": {
+    "title": "Language",
     "audio": "Audio",
     "captions": "Captions",
     "advanced_captions_settings": "Advanced captions settings"
@@ -84,9 +86,5 @@
   "pictureInPicture": {
     "overlay_text": "Playing in Picture In Picture mode",
     "overlay_button": "Play Here"
-  },
-  "smartContainer": {
-    "language": "Language",
-    "settings": "Settings"
   }
 }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -84,5 +84,9 @@
   "pictureInPicture": {
     "overlay_text": "Playing in Picture In Picture mode",
     "overlay_button": "Play Here"
+  },
+  "smartContainer": {
+    "language": "Language",
+    "settings": "Settings"
   }
 }


### PR DESCRIPTION
### Description of the Changes

Added the option to alter the Smart Container titles on`settings` and `languages`

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in the local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
