### PR TITLE
fix(FEC-8937): UI icons rendered oddly in iOS

### DIFF
--- a/src/components/icon/icon.scss
+++ b/src/components/icon/icon.scss
@@ -126,8 +126,6 @@
   background-size: cover;
   background-repeat: no-repeat;
   background-position: 50% 50%;
-  -webkit-filter: drop-shadow(0px 0px 8px rgba(0,0,0,0.5));
-  filter: drop-shadow(0px 0px 8px rgba(0,0,0,0.5));
 }
 
 .icon-maximize {

--- a/src/components/playback-controls/_playback-controls.scss
+++ b/src/components/playback-controls/_playback-controls.scss
@@ -38,6 +38,8 @@
             width: auto;
             height: auto;
             padding: 0 16px;
+            -webkit-filter: drop-shadow(0px 0px 8px rgba(0,0,0,0.5));
+            filter: drop-shadow(0px 0px 8px rgba(0,0,0,0.5));
           }
           .icon {
             width: 64px;


### PR DESCRIPTION
drop-shadow css was moved from icons.scss to playback-controls.scss in a manner that the css is now applied only on the middle playback icons

