### PR TITLE
fix(FEC-9111): seekbar doesnt work in LG TV

### DIFF
--- a/src/components/seekbar/seekbar.js
+++ b/src/components/seekbar/seekbar.js
@@ -339,7 +339,14 @@ class SeekBarControl extends Component {
    * @private
    */
   _getTransformX(element: HTMLElement): number {
-    const transformValues = getComputedStyle(element).transform.match(/-?\d+/g);
+    const computedStyle = getComputedStyle(element);
+    const transform =
+      computedStyle.getPropertyValue('-webkit-transform') ||
+      computedStyle.getPropertyValue('-moz-transform') ||
+      computedStyle.getPropertyValue('-ms-transform') ||
+      computedStyle.getPropertyValue('-o-transform') ||
+      computedStyle.getPropertyValue('transform');
+    const transformValues = transform.match(/-?\d+/g);
     // [scaleX(),skewY(),skewX(),scaleY(),translateX(),translateY()]
     let translateXVal = 0;
     if (transformValues && transformValues.length > 0) {

--- a/src/components/seekbar/seekbar.js
+++ b/src/components/seekbar/seekbar.js
@@ -340,14 +340,15 @@ class SeekBarControl extends Component {
    */
   _getTransformX(element: HTMLElement): number {
     const computedStyle = getComputedStyle(element);
+    // [scaleX(),skewY(),skewX(),scaleY(),translateX(),translateY()]
     const transform =
+      computedStyle.getPropertyValue('transform') ||
       computedStyle.getPropertyValue('-webkit-transform') ||
       computedStyle.getPropertyValue('-moz-transform') ||
       computedStyle.getPropertyValue('-ms-transform') ||
-      computedStyle.getPropertyValue('-o-transform') ||
-      computedStyle.getPropertyValue('transform');
+      computedStyle.getPropertyValue('-o-transform');
+
     const transformValues = transform.match(/-?\d+/g);
-    // [scaleX(),skewY(),skewX(),scaleY(),translateX(),translateY()]
     let translateXVal = 0;
     if (transformValues && transformValues.length > 0) {
       translateXVal = parseFloat(transformValues[4]);


### PR DESCRIPTION
### Description of the Changes

seek doesnt work in LG TV. transform stored under browser prefix.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
