### PR TITLE
fix(FEC-9122): The replay icon is not aligned in LG TV

### DIFF
--- a/src/components/pre-playback-play-overlay/_pre-playback-play-overlay.scss
+++ b/src/components/pre-playback-play-overlay/_pre-playback-play-overlay.scss
@@ -15,6 +15,8 @@
     border: 2px solid rgba(255, 255, 255, 0.2);
     background-color: rgba(0, 0, 0, 0.5);
     transform: translate(-50%, -50%);
+    -webkit-transform: translate(-50%, -50%);
+    -ms-transform: translate(-50%, -50%);
     border-radius: 54px;
     padding: 20px;
     cursor: pointer;


### PR DESCRIPTION
### Description of the Changes

Add prefix for transform which doesn't fully support by some web browsers.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
