### PR TITLE
fix(FEC-9014): ios non native full screen seekbar hide the captions

### DIFF
--- a/src/styles/_captions.scss
+++ b/src/styles/_captions.scss
@@ -26,6 +26,13 @@ $hovering-offset: 50px;
         max-height: calc(100% - #{$hovering-offset});
       }
     }
+    &.fullscreen.iOS {
+        video::-webkit-media-text-track-display{
+        transform: translateY(-$hovering-offset);
+        -webkit-transform: translateY(-$hovering-offset);
+        -ms-transform: translateY(-$hovering-offset);
+      }
+    }
   }
   &.fullscreen.iOS {
     video::-webkit-media-text-track-container {


### PR DESCRIPTION
### Description of the Changes

fix css rule for native caption on ios for non native fullscreen mode

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
