### PR TITLE
fix(FEC-8509): ima-enablePreloading causes the player spinning before the midroll

### DIFF
--- a/src/components/loading/loading.js
+++ b/src/components/loading/loading.js
@@ -65,10 +65,6 @@ class Loading extends BaseComponent {
       this.props.updateLoadingSpinnerState(true);
     });
 
-    this.eventManager.listen(this.player, this.player.Event.AD_LOADED, () => {
-      this.props.updateLoadingSpinnerState(true);
-    });
-
     this.eventManager.listen(this.player, this.player.Event.AD_STARTED, () => {
       if (this.props.adIsLinear) {
         this.props.updateLoadingSpinnerState(false);


### PR DESCRIPTION
### Description of the Changes

Do not show the spinner on `AD_LOADED`
Enables **FEC-9159**

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
