### PR TITLE
fix(FEC-8718): Google Translate multiplies the timestamp

### DIFF
--- a/src/components/time-display/time-display.js
+++ b/src/components/time-display/time-display.js
@@ -49,7 +49,7 @@ class TimeDisplay extends Component {
   render(props: any): React$Element<any> {
     return (
       <div className={style.timeDisplay}>
-        <span>{this.getTimeDisplay(props.currentTime, props.duration, props.format)}</span>
+        <span className="notranslate">{this.getTimeDisplay(props.currentTime, props.duration, props.format)}</span>
       </div>
     );
   }


### PR DESCRIPTION
### Description of the Changes

Added `notranslate` class in order to resolve the issue of the Google Translate DOM manipulation over the timeStamp span that causes it to multiply.

For more info please refer to these articles:

- https://stackoverflow.com/questions/9628507/how-can-i-tell-google-translate-to-not-translate-a-section-of-a-website

- https://cloud.google.com/translate/faq#technical_questions

### CheckLists

- [X] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [X] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
