### PR TITLE
fix: learn more doesn't clickable on mobile

### DIFF
--- a/src/ui-presets/ads.js
+++ b/src/ui-presets/ads.js
@@ -29,7 +29,7 @@ function AdsUI(props: any): ?React$Element<any> {
         <Loading player={props.player} />
         <div className={style.playerGui} id="player-gui">
           <UnmuteIndication player={props.player} hasTopBar />
-          <TopBar>
+          <TopBar disabled={true}>
             <div className={style.leftControls}>{isBumper(props) ? undefined : <AdNotice />}</div>
           </TopBar>
         </div>


### PR DESCRIPTION
### Description of the Changes

add missing disable on TopBar for ads ui

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
