### PR TITLE
fix(FEC-9375): After unmute volume icon, the volume get unmuted and then returning to unmute state

### DIFF
--- a/src/components/volume/volume.js
+++ b/src/components/volume/volume.js
@@ -183,11 +183,11 @@ class Volume extends Component {
   /**
    * on volume control button click, toggle mute in player and store state
    *
-   * @method onVolumeControlButtonClick
+   * @method VolumeButtonClicked
    * @returns {void}
    * @memberof Volume
    */
-  onVolumeControlButtonClick(): void {
+  VolumeButtonClicked(): void {
     const {player} = this.props;
     if (player.volume == 0) {
       this.props.logger.debug(`Toggle mute. Volume is 0, set mute to false & volume to 0.5`);
@@ -198,6 +198,18 @@ class Volume extends Component {
       player.muted = !player.muted;
     }
     this.props.notifyClick();
+  }
+  /**
+   * on volume control button click on touch device, toggle mute in player and store state
+   *
+   * @method onVolumeButtonTouch
+   * @param {TouchEvent} e - event of touch end
+   * @returns {void}
+   * @memberof Volume
+   */
+  onVolumeButtonTouch(e: TouchEvent): void {
+    e.preventDefault();
+    this.VolumeButtonClicked();
   }
 
   /**
@@ -288,7 +300,8 @@ class Volume extends Component {
           tabIndex="0"
           aria-label="Volume"
           className={style.controlButton}
-          onClick={() => this.onVolumeControlButtonClick()}
+          onClick={() => this.VolumeButtonClicked()}
+          onTouchEnd={e => this.onVolumeButtonTouch(e)}
           onKeyDown={e => this.onVolumeControlKeyDown(e)}>
           <Icon type={IconType.VolumeBase} />
           <Icon type={IconType.VolumeWaves} />

--- a/src/components/volume/volume.js
+++ b/src/components/volume/volume.js
@@ -36,13 +36,13 @@ const COMPONENT_NAME = 'Volume';
 @withEventManager
 @withLogger(COMPONENT_NAME)
 @withEventDispatcher(COMPONENT_NAME)
-  /**
-   * Volume component
-   *
-   * @class Volume
-   * @example <Volume />
-   * @extends {Component}
-   */
+/**
+ * Volume component
+ *
+ * @class Volume
+ * @example <Volume />
+ * @extends {Component}
+ */
 class Volume extends Component {
   _volumeControlElement: HTMLElement;
   _volumeProgressBarElement: HTMLElement;

--- a/src/components/volume/volume.js
+++ b/src/components/volume/volume.js
@@ -36,13 +36,13 @@ const COMPONENT_NAME = 'Volume';
 @withEventManager
 @withLogger(COMPONENT_NAME)
 @withEventDispatcher(COMPONENT_NAME)
-/**
- * Volume component
- *
- * @class Volume
- * @example <Volume />
- * @extends {Component}
- */
+  /**
+   * Volume component
+   *
+   * @class Volume
+   * @example <Volume />
+   * @extends {Component}
+   */
 class Volume extends Component {
   _volumeControlElement: HTMLElement;
   _volumeProgressBarElement: HTMLElement;
@@ -183,11 +183,11 @@ class Volume extends Component {
   /**
    * on volume control button click, toggle mute in player and store state
    *
-   * @method VolumeButtonClicked
+   * @method onVolumeControlButtonClick
    * @returns {void}
    * @memberof Volume
    */
-  VolumeButtonClicked(): void {
+  onVolumeControlButtonClick(): void {
     const {player} = this.props;
     if (player.volume == 0) {
       this.props.logger.debug(`Toggle mute. Volume is 0, set mute to false & volume to 0.5`);
@@ -198,18 +198,6 @@ class Volume extends Component {
       player.muted = !player.muted;
     }
     this.props.notifyClick();
-  }
-  /**
-   * on volume control button click on touch device, toggle mute in player and store state
-   *
-   * @method onVolumeButtonTouch
-   * @param {TouchEvent} e - event of touch end
-   * @returns {void}
-   * @memberof Volume
-   */
-  onVolumeButtonTouch(e: TouchEvent): void {
-    e.preventDefault();
-    this.VolumeButtonClicked();
   }
 
   /**
@@ -300,8 +288,8 @@ class Volume extends Component {
           tabIndex="0"
           aria-label="Volume"
           className={style.controlButton}
-          onClick={() => this.VolumeButtonClicked()}
-          onTouchEnd={e => this.onVolumeButtonTouch(e)}
+          onClick={() => this.onVolumeControlButtonClick()}
+          onTouchEnd={e => e.stopImmediatePropagation()}
           onKeyDown={e => this.onVolumeControlKeyDown(e)}>
           <Icon type={IconType.VolumeBase} />
           <Icon type={IconType.VolumeWaves} />


### PR DESCRIPTION
### Description of the Changes

on every touch device it happened.
**issue** - `click` on volume happened after `touchend` on shell - on non-touch device it'll be `click` on volume component and then `click` on shell - the correct behaviour.
**solution** - add `touchend` event on volume button which will `stopImmediatePropagation` and shell won't get this event. as work in desktop, only `click` event will work 

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
