### PR TITLE
fix(FEC-9390): keyboard focus outline not working in menus in test page

### DIFF
--- a/src/styles/_shell.scss
+++ b/src/styles/_shell.scss
@@ -66,7 +66,7 @@
 .player.nav {
 * {
     &:focus {
-      outline: 1px solid $tab-focus-color;
+      outline: 1px solid $tab-focus-color !important;
     }
   }
 }


### PR DESCRIPTION
### Description of the Changes

added !important to override "reboot" bootstrap css

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
