### PR TITLE
fix(FEC-9391): volume bar doesn't open by pressing on up/down arrows

### DIFF
--- a/src/components/volume/volume.js
+++ b/src/components/volume/volume.js
@@ -137,7 +137,7 @@ class Volume extends Component {
    * @memberof Volume
    */
   onVolumeControlKeyDown(e: KeyboardEvent): void {
-    const {player} = this.state;
+    const {player} = this.props;
     /**
      * Change volume operations.
      * @param {number} newVolume - The new volume.


### PR DESCRIPTION
### Description of the Changes
When focused on the volume button - up / down should open the volume bar and control the volume. player was undefined - fixed

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
