### PR TITLE
fix(FEC-9399): enter didn't do anything on volume button

### DIFF
--- a/src/components/shell/shell.js
+++ b/src/components/shell/shell.js
@@ -147,7 +147,7 @@ class Shell extends Component {
    * @returns {void}
    * @memberof Shell
    */
-  onMouseDown(): void {
+  onMouseUp(): void {
     if (this.props.fallbackToMutedAutoPlay) {
       this.props.player.muted = false;
     }
@@ -373,7 +373,7 @@ class Shell extends Component {
         tabIndex="0"
         className={playerClasses}
         onTouchEnd={e => this.onTouchEnd(e)}
-        onMouseDown={() => this.onMouseDown()}
+        onMouseUp={() => this.onMouseUp()}
         onMouseOver={() => this.onMouseOver()}
         onMouseMove={() => this.onMouseMove()}
         onMouseLeave={event => this.onMouseLeave(event)}

--- a/src/components/unmute-indication/unmute-indication.js
+++ b/src/components/unmute-indication/unmute-indication.js
@@ -103,7 +103,7 @@ class UnmuteIndication extends Component {
           className={styleClass.join(' ')}
           onMouseOver={() => this.setState({iconOnly: false})}
           onMouseOut={() => this.setState({iconOnly: true})}
-          onMouseDown={() => (this.props.player.muted = !this.props.player.muted)}
+          onMouseUp={() => (this.props.player.muted = !this.props.player.muted)}
           onTouchEnd={e => e.stopImmediatePropagation()}
           onKeyDown={e => this._keyDownHandler(e)}>
           <a className={[style.btn, style.btnDarkTransparent, style.unmuteButton].join(' ')}>

--- a/src/components/volume/volume.js
+++ b/src/components/volume/volume.js
@@ -160,8 +160,6 @@ class Volume extends Component {
         changeVolume(Math.round(player.volume * 100) - KEYBOARD_DEFAULT_VOLUME_JUMP);
         break;
       case KeyMap.ENTER:
-        this.toggleMute();
-        break;
       case KeyMap.SPACE:
         this.toggleMute();
         break;

--- a/src/components/volume/volume.js
+++ b/src/components/volume/volume.js
@@ -162,6 +162,9 @@ class Volume extends Component {
       case KeyMap.ENTER:
         this.toggleMute();
         break;
+      case KeyMap.SPACE:
+        this.toggleMute();
+        break;
       default:
         this.setState({hover: false});
         break;

--- a/src/components/volume/volume.js
+++ b/src/components/volume/volume.js
@@ -159,6 +159,9 @@ class Volume extends Component {
       case KeyMap.DOWN:
         changeVolume(Math.round(player.volume * 100) - KEYBOARD_DEFAULT_VOLUME_JUMP);
         break;
+      case KeyMap.ENTER:
+        this.toggleMute();
+        break;
       default:
         this.setState({hover: false});
         break;
@@ -183,11 +186,11 @@ class Volume extends Component {
   /**
    * on volume control button Mouse Down, toggle mute in player and store state
    *
-   * @method onMouseDown
+   * @method toggleMute
    * @returns {void}
    * @memberof Volume
    */
-  onMouseDown(): void {
+  toggleMute(): void {
     const {player} = this.props;
     if (player.volume === 0) {
       this.props.logger.debug(`Toggle mute. Volume is 0, set mute to false & volume to 0.5`);
@@ -288,7 +291,7 @@ class Volume extends Component {
           tabIndex="0"
           aria-label="Volume"
           className={style.controlButton}
-          onMouseDown={() => this.onMouseDown()}
+          onMouseUp={() => this.toggleMute()}
           onTouchEnd={e => e.stopImmediatePropagation()}
           onKeyDown={e => this.onKeyDown(e)}>
           <Icon type={IconType.VolumeBase} />


### PR DESCRIPTION
### Description of the Changes

add behaviour of toggle mute on keyboard enter.
Implemented onMouseUp cause click on IMA skip button wasn't bubbled to shell. 

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
