### PR TITLE
fix(FEC-9402): x button not accessible with keyboard in overlays

### DIFF
--- a/src/components/overlay/overlay.js
+++ b/src/components/overlay/overlay.js
@@ -56,7 +56,16 @@ class Overlay extends Component {
     if (!props.permanent) {
       return (
         <Localizer>
-          <a onClick={() => props.onClose()} aria-label={<Text id="overlay.close" />} className={style.closeOverlay}>
+          <a
+            tabIndex="0"
+            onClick={() => props.onClose()}
+            onKeyDown={e => {
+              if (e.keyCode === KeyMap.ENTER) {
+                props.onClose();
+              }
+            }}
+            aria-label={<Text id="overlay.close" />}
+            className={style.closeOverlay}>
             <Icon type={IconType.Close} />
           </a>
         </Localizer>


### PR DESCRIPTION
### Description of the Changes

added tabindex 0 to the X anchor and keydown enter handling

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
