### PR TITLE
fix(FEC-9333): when playing a playlist and closing the countdown window, the next entry starts automatically

### DIFF
--- a/src/components/playlist-countdown/playlist-countdown.js
+++ b/src/components/playlist-countdown/playlist-countdown.js
@@ -113,17 +113,20 @@ class PlaylistCountdown extends Component {
 
   /**
    * component did update handler
-
+   *
+   * @param {Object} prevProps - previous component props
    * @returns {void}
    */
-  componentDidUpdate() {
-    const timeToShow = this._getTimeToShow();
-    const countdown = this.props.player.playlist.countdown;
-    if (
-      !this.state.canceled &&
-      (this.props.isPlaybackEnded || (this.props.currentTime >= timeToShow + countdown.duration && this.props.currentTime < this.props.duration))
-    ) {
-      this.props.player.playlist.playNext();
+  componentDidUpdate(prevProps: Object): void {
+    if (this._shouldRender(prevProps)) {
+      const timeToShow = this._getTimeToShow();
+      const countdown = this.props.player.playlist.countdown;
+      if (
+        !this.state.canceled &&
+        (this.props.isPlaybackEnded || (this.props.currentTime >= timeToShow + countdown.duration && this.props.currentTime < this.props.duration))
+      ) {
+        this.props.player.playlist.playNext();
+      }
     }
   }
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,8 +1,11 @@
+export * as backdrop from './backdrop';
 export * as config from './config';
 export * as cvaa from './cvaa';
 export * as engine from './engine';
+export * as getters from './getters';
 export * as loading from './loading';
 export * as overlayAction from './overlay-action';
+export * as playlist from './playlist';
 export * as seekbar from './seekbar';
 export * as setting from './settings';
 export * as share from './share';

--- a/src/reducers/playlist.js
+++ b/src/reducers/playlist.js
@@ -1,0 +1,28 @@
+//@flow
+export const types = {
+  UPDATE_PLAYLIST_COUNTDOWN_CANCELED: 'playlist-countdown/UPDATE_PLAYLIST_COUNTDOWN_CANCELED'
+};
+
+export const initialState = {
+  countdownCanceled: false
+};
+
+export default (state: Object = initialState, action: Object) => {
+  switch (action.type) {
+    case types.UPDATE_PLAYLIST_COUNTDOWN_CANCELED:
+      return {
+        ...state,
+        countdownCanceled: action.countdownCanceled
+      };
+
+    default:
+      return state;
+  }
+};
+
+export const actions = {
+  updatePlaylistCountdownCanceled: (countdownCanceled: boolean) => ({
+    type: types.UPDATE_PLAYLIST_COUNTDOWN_CANCELED,
+    countdownCanceled
+  })
+};

--- a/src/store.js
+++ b/src/store.js
@@ -11,6 +11,7 @@ import cvaa from './reducers/cvaa';
 import settings from './reducers/settings';
 import overlayAction from './reducers/overlay-action';
 import backdrop from './reducers/backdrop';
+import playlist from 'reducers/playlist';
 
 const reducer = combineReducers({
   config,
@@ -23,7 +24,8 @@ const reducer = combineReducers({
   cvaa,
   settings,
   overlayAction,
-  backdrop
+  backdrop,
+  playlist
 });
 
 export default reducer;


### PR DESCRIPTION
### Description of the Changes

move the `canceled` to own reduced since `this.state` is reset when switching to ad

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
