### PR TITLE
fix(FEC-9413): when seeking the end of the 2nd entry the playlist skip the 3rd entry (last) and jumps to 1st

### DIFF
--- a/src/components/playlist-countdown/playlist-countdown.js
+++ b/src/components/playlist-countdown/playlist-countdown.js
@@ -134,7 +134,7 @@ class PlaylistCountdown extends Component {
    * @returns {boolean} shouldComponentUpdate
    */
   shouldComponentUpdate(nextProps: Object): boolean {
-    return !nextProps.isSeeking;
+    return !(nextProps.isSeeking || this.props.isPlaybackEnded);
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

Do not update the component by `props.currentTime` if it already updated by `props.isPlaybackEnded`

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
