### PR TITLE
fix(FEC-9428): playlist countdown screen displayed for 1-2 sec after the player loaded

### DIFF
--- a/src/components/playlist-countdown/playlist-countdown.js
+++ b/src/components/playlist-countdown/playlist-countdown.js
@@ -135,7 +135,7 @@ class PlaylistCountdown extends Component {
    * @returns {boolean} shouldComponentUpdate
    */
   shouldComponentUpdate(nextProps: Object): boolean {
-    return !!(this.props.duration && !nextProps.isSeeking && !this.props.isPlaybackEnded);
+    return this.props.duration > 0 && !nextProps.isSeeking && !this.props.isPlaybackEnded;
   }
 
   /**

--- a/src/components/playlist-countdown/playlist-countdown.js
+++ b/src/components/playlist-countdown/playlist-countdown.js
@@ -135,7 +135,7 @@ class PlaylistCountdown extends Component {
    * @returns {boolean} shouldComponentUpdate
    */
   shouldComponentUpdate(nextProps: Object): boolean {
-    return !(nextProps.isSeeking || this.props.isPlaybackEnded);
+    return !!(this.props.duration && !nextProps.isSeeking && !this.props.isPlaybackEnded);
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

do not render the component when no duration exists (while loading)

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
