### PR TITLE
fix(FEC-9423): Small view on desktop the pause icon remains on screen

### DIFF
--- a/src/components/shell/shell.js
+++ b/src/components/shell/shell.js
@@ -273,7 +273,7 @@ class Shell extends Component {
       !this.props.seekbarHoverActive &&
       !this.props.volumeHoverActive &&
       !this.props.smartContainerOpen &&
-      !this.props.player.paused
+      (!this.props.player.paused || this.props.adBreak)
     );
   }
 
@@ -318,7 +318,12 @@ class Shell extends Component {
   componentDidUpdate(prevProps: Object): void {
     // Update the hover state if the transition was from pre playback screen
     // or after an ad break
-    if ((!this.props.prePlayback && prevProps.prePlayback) || (!this.props.adBreak && prevProps.adBreak)) {
+    // or in ad break
+    if (
+      (!this.props.prePlayback && prevProps.prePlayback) ||
+      (!this.props.adBreak && prevProps.adBreak) ||
+      (this.props.adBreak && !prevProps.adBreak)
+    ) {
       this._updatePlayerHoverState();
     }
   }


### PR DESCRIPTION
### Description of the Changes

it'll work on ad which playing on same video tag cause we'll get the correct state of paused.
On different video tags we are getting the state of paused from the main video tag but ad is playing on second one and pause icon still showing so added state of adBreak for this situation.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
