### PR TITLE
fix(FEC-9433): timer on seek preview displayed as NaN:NaN:NaN

### DIFF
--- a/src/components/seekbar/seekbar.js
+++ b/src/components/seekbar/seekbar.js
@@ -343,7 +343,7 @@ class SeekBar extends Component {
    * @memberof SeekBar
    */
   getTime(e: any): number {
-    let xPosition = e.clientX || (e.changedTouches && e.changedTouches[0] && e.changedTouches[0].clientX);
+    let xPosition = e.clientX || (e.changedTouches && e.changedTouches[0] && e.changedTouches[0].clientX) || 0;
     let time =
       this.props.duration *
       ((xPosition - this._seekBarElement.offsetLeft - this.getOffset(this.props.playerElement).left) / this._seekBarElement.clientWidth);

--- a/src/components/seekbar/seekbar.js
+++ b/src/components/seekbar/seekbar.js
@@ -343,7 +343,7 @@ class SeekBar extends Component {
    * @memberof SeekBar
    */
   getTime(e: any): number {
-    let xPosition = e.clientX || (e.changedTouches && e.changedTouches[0] && e.changedTouches[0].clientX) || 0;
+    let xPosition = typeof e.clientX === 'number' ? e.clientX : e.changedTouches && e.changedTouches[0] && e.changedTouches[0].clientX;
     let time =
       this.props.duration *
       ((xPosition - this._seekBarElement.offsetLeft - this.getOffset(this.props.playerElement).left) / this._seekBarElement.clientWidth);


### PR DESCRIPTION
### Description of the Changes

when dragging scrubber to 0 it fell back to e.changedTouches which was undefined.
Changed the logic to first use e.clientX if is a number (zero included)

Fixes FEC-9433

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
