### PR TITLE
fix(FEC-9493): ima - dragging to the end causes the midroll to play with replay button

### DIFF
--- a/src/components/play-pause/play-pause.js
+++ b/src/components/play-pause/play-pause.js
@@ -56,25 +56,16 @@ class PlayPause extends Component {
    */
   render(props: any): React$Element<any> | void {
     const controlButtonClass = this.props.isPlayingAdOrPlayback ? [style.controlButton, style.isPlaying].join(' ') : style.controlButton;
+    const isStartOver = props.isPlaybackEnded && !this.props.adBreak;
     return (
       <div className={[style.controlButtonContainer, style.controlPlayPause].join(' ')}>
         <Localizer>
           <button
             tabIndex="0"
-            aria-label={
-              <Text
-                id={
-                  props.isPlaybackEnded && !this.props.adBreak
-                    ? 'controls.startOver'
-                    : this.props.isPlayingAdOrPlayback
-                      ? 'controls.pause'
-                      : 'controls.play'
-                }
-              />
-            }
+            aria-label={<Text id={isStartOver ? 'controls.startOver' : this.props.isPlayingAdOrPlayback ? 'controls.pause' : 'controls.play'} />}
             className={controlButtonClass}
             onClick={() => this.togglePlayPause()}>
-            {props.isPlaybackEnded && !this.props.adBreak ? (
+            {isStartOver ? (
               <Icon type={IconType.StartOver} />
             ) : (
               <div>

--- a/src/components/play-pause/play-pause.js
+++ b/src/components/play-pause/play-pause.js
@@ -62,11 +62,19 @@ class PlayPause extends Component {
           <button
             tabIndex="0"
             aria-label={
-              <Text id={props.isPlaybackEnded ? 'controls.startOver' : this.props.isPlayingAdOrPlayback ? 'controls.pause' : 'controls.play'} />
+              <Text
+                id={
+                  props.isPlaybackEnded && !this.props.adBreak
+                    ? 'controls.startOver'
+                    : this.props.isPlayingAdOrPlayback
+                      ? 'controls.pause'
+                      : 'controls.play'
+                }
+              />
             }
             className={controlButtonClass}
             onClick={() => this.togglePlayPause()}>
-            {props.isPlaybackEnded ? (
+            {props.isPlaybackEnded && !this.props.adBreak ? (
               <Icon type={IconType.StartOver} />
             ) : (
               <div>


### PR DESCRIPTION
### Description of the Changes

**Issue:** ima plays the midroll on `ENDED` asynchronously, so `PLAYBACK_ENDED` fired before `AD_LOADED` and `AD_BREAK_START`.
**Solution:** Hide the replay button while ad break, even `isPlaybackEnded` prop is `true`

(This is for ima vmap. The same issue with ad layout fixed by https://github.com/kaltura/playkit-js/pull/416)

Solves [FEC-9493](https://kaltura.atlassian.net/browse/FEC-9493)

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
