### PR TITLE
feat(FEC-9491): blur video when overlay active

### DIFF
--- a/src/components/video-player/_video-player.scss
+++ b/src/components/video-player/_video-player.scss
@@ -5,4 +5,7 @@
   width: 100%;
   height: 100%;
   background: black;
+  .overlay-active &{
+    filter: blur(5px);
+  }
 }


### PR DESCRIPTION
### Description of the Changes

added scss selector - when overlay is active blur video player

solves FEC-9491

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
