### PR TITLE
fix(FEC-9511): the large play button gets stuck when auto play is failed

### DIFF
--- a/src/components/engine-connector/engine-connector.js
+++ b/src/components/engine-connector/engine-connector.js
@@ -121,6 +121,10 @@ class EngineConnector extends Component {
       this.props.updatePrePlayback(true);
     });
 
+    eventManager.listen(player, player.Event.FIRST_PLAY, () => {
+      this.props.updatePrePlayback(false);
+    });
+
     eventManager.listen(player, player.Event.PLAY, () => {
       this.props.updateIsPlaying(true);
       this.props.updateIsEnded(false);


### PR DESCRIPTION
### Description of the Changes

Do `updatePrePlayback(false)` on `FIRST_PLAY`

Solves [FEC-9511](https://kaltura.atlassian.net/browse/FEC-9511)

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
