### PR TITLE
fix(FEC-9471): slider progress bar exceeds 100%

### DIFF
--- a/src/components/live-tag/live-tag.js
+++ b/src/components/live-tag/live-tag.js
@@ -35,13 +35,13 @@ const COMPONENT_NAME = 'LiveTag';
  */
 class LiveTag extends Component {
   /**
-   * returns a boolean to detect if player is on live edge with buffer of 1 second
+   * returns a boolean to detect if player is on live edge
    *
    * @returns {boolean} - is player on live edge
    * @memberof LiveTag
    */
   isOnLiveEdge(): boolean {
-    return this.props.currentTime >= this.props.duration - 1;
+    return this.props.player.isOnLiveEdge();
   }
 
   /**

--- a/src/components/seekbar-live-playback-container/seekbar-live-playback-container.js
+++ b/src/components/seekbar-live-playback-container/seekbar-live-playback-container.js
@@ -78,7 +78,7 @@ class SeekBarLivePlaybackContainer extends Component {
         updateCurrentTime={data => this.props.updateCurrentTime(data)}
         isDvr={this.props.isDvr}
         currentTime={this.props.currentTime}
-        duration={this.props.player.isOnLiveEdge() ? this.props.currentTime : this.props.duration}
+        duration={this.props.player.isOnLiveEdge() ? this.props.currentTime : Math.max(this.props.duration, this.props.currentTime)}
         isDraggingActive={this.props.isDraggingActive}
         isMobile={this.props.isMobile}
         notifyChange={payload => this.props.notifyChange(payload)}

--- a/src/components/seekbar-live-playback-container/seekbar-live-playback-container.js
+++ b/src/components/seekbar-live-playback-container/seekbar-live-playback-container.js
@@ -72,7 +72,8 @@ class SeekBarLivePlaybackContainer extends Component {
         playerElement={this.props.playerContainer}
         showTimeBubble={this.props.showTimeBubble}
         changeCurrentTime={time => {
-          if (!this.props.player.isOnLiveEdge() || time < this.duration) {
+          // avoiding exiting live edge by mistake in case currenttime is just a bit smaller than duration
+          if (!(this.props.player.isOnLiveEdge() && time === this.duration)) {
             this.props.player.currentTime = time;
           }
         }}

--- a/src/components/seekbar-live-playback-container/seekbar-live-playback-container.js
+++ b/src/components/seekbar-live-playback-container/seekbar-live-playback-container.js
@@ -71,19 +71,32 @@ class SeekBarLivePlaybackContainer extends Component {
       <SeekBar
         playerElement={this.props.playerContainer}
         showTimeBubble={this.props.showTimeBubble}
-        changeCurrentTime={time => (this.props.player.currentTime = time)}
+        changeCurrentTime={time => {
+          if (!this.props.player.isOnLiveEdge() || time < this.duration) {
+            this.props.player.currentTime = time;
+          }
+        }}
         playerPoster={this.props.poster}
         updateSeekbarDraggingStatus={data => this.props.updateSeekbarDraggingStatus(data)}
         updateSeekbarHoverActive={data => this.props.updateSeekbarHoverActive(data)}
         updateCurrentTime={data => this.props.updateCurrentTime(data)}
         isDvr={this.props.isDvr}
         currentTime={this.props.currentTime}
-        duration={this.props.player.isOnLiveEdge() ? this.props.currentTime : Math.max(this.props.duration, this.props.currentTime)}
+        duration={this.duration}
         isDraggingActive={this.props.isDraggingActive}
         isMobile={this.props.isMobile}
         notifyChange={payload => this.props.notifyChange(payload)}
       />
     );
+  }
+
+  /**
+   *
+   * @returns {number} - the duration of the video to show
+   * @memberof SeekBarLivePlaybackContainer
+   */
+  get duration(): number {
+    return this.props.player.isOnLiveEdge() ? this.props.currentTime : Math.max(this.props.duration, this.props.currentTime);
   }
 }
 

--- a/src/components/seekbar-live-playback-container/seekbar-live-playback-container.js
+++ b/src/components/seekbar-live-playback-container/seekbar-live-playback-container.js
@@ -78,7 +78,7 @@ class SeekBarLivePlaybackContainer extends Component {
         updateCurrentTime={data => this.props.updateCurrentTime(data)}
         isDvr={this.props.isDvr}
         currentTime={this.props.currentTime}
-        duration={this.props.duration}
+        duration={this.props.player.isOnLiveEdge() ? this.props.currentTime : this.props.duration}
         isDraggingActive={this.props.isDraggingActive}
         isMobile={this.props.isMobile}
         notifyChange={payload => this.props.notifyChange(payload)}

--- a/src/components/seekbar/seekbar.js
+++ b/src/components/seekbar/seekbar.js
@@ -208,7 +208,7 @@ class SeekBar extends Component {
      * @returns {void}
      */
     const seek = (from: number, to: number) => {
-      player.currentTime = to;
+      this.props.changeCurrentTime(to);
       this.updateSeekBarProgress(player.currentTime, this.props.duration, true);
       this.props.notifyChange({
         from: from,
@@ -222,7 +222,7 @@ class SeekBar extends Component {
         seek(player.currentTime, newTime);
         break;
       case KeyMap.RIGHT:
-        newTime = player.currentTime + KEYBOARD_DEFAULT_SEEK_JUMP > player.duration ? player.duration : player.currentTime + 5;
+        newTime = player.currentTime + KEYBOARD_DEFAULT_SEEK_JUMP > this.props.duration ? this.props.duration : player.currentTime + 5;
         seek(player.currentTime, newTime);
         break;
     }
@@ -361,9 +361,9 @@ class SeekBar extends Component {
    */
   getBufferedPercent(): number {
     const {player} = this.props;
-    if (player.duration > 0 && player.buffered.length > 0) {
+    if (this.props.duration > 0 && player.buffered.length > 0) {
       const buffered = player.isLive() ? player.buffered.end(0) - player.getStartTimeOfDvrWindow() : player.buffered.end(0);
-      const bufferedPercent = (buffered / player.duration) * 100;
+      const bufferedPercent = (buffered / this.props.duration) * 100;
       return bufferedPercent < 100 ? bufferedPercent : 100;
     }
     return 0;


### PR DESCRIPTION
### Description of the Changes

liveedge is not calculated anymore by a threshold but received from the player
In addition - when in live edge the progress bar duration is the current time

solves FEC-9471

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
