### PR TITLE
fix(FEC-9521): countdown is stuck open after next video started

### DIFF
--- a/src/components/playlist-countdown/playlist-countdown.js
+++ b/src/components/playlist-countdown/playlist-countdown.js
@@ -42,7 +42,8 @@ const COMPONENT_NAME = 'PlaylistCountdown';
  */
 class PlaylistCountdown extends Component {
   focusElement: HTMLElement;
-
+  isHidden: boolean = true;
+  isCanceled: boolean = false;
   /**
    * should render component
    * @param {*} props - component props
@@ -107,6 +108,9 @@ class PlaylistCountdown extends Component {
       this.setState({timeToShow: false});
       this.props.updatePlaylistCountdownCanceled(false);
     }
+
+    this.isHidden = !this.state.timeToShow || nextProps.player.playlist.countdown.duration >= nextProps.duration;
+    this.isCanceled = nextProps.countdownCanceled;
   }
 
   /**
@@ -132,6 +136,9 @@ class PlaylistCountdown extends Component {
     if (!prevState.show && this.state.show && this.focusElement) {
       this.focusElement.focus();
     }
+
+    this.setState({show: !this.isHidden && !this.isCanceled});
+
   }
 
   /**
@@ -165,13 +172,10 @@ class PlaylistCountdown extends Component {
     const progressDuration = Math.min(countdown.duration, props.duration - timeToShow);
     const progressWidth = `${progressTime > 0 ? (progressTime / progressDuration) * 104 : 0}%`;
     const className = [style.playlistCountdown];
-    const isHidden = !this.state.timeToShow || countdown.duration >= props.duration;
-    const isCanceled = this.props.countdownCanceled;
-    this.setState({show: !isHidden && !isCanceled});
 
-    if (isHidden) {
+    if (this.isHidden) {
       className.push(style.hidden);
-    } else if (isCanceled) {
+    } else if (this.isCanceled) {
       className.push(style.canceled);
     }
 
@@ -180,7 +184,7 @@ class PlaylistCountdown extends Component {
         role="button"
         aria-labelledby="playlistCountdownTextId"
         ref={el => (this.focusElement = el)}
-        tabIndex={isHidden || isCanceled ? -1 : 0}
+        tabIndex={this.isHidden || this.isCanceled ? -1 : 0}
         className={className.join(' ')}
         onKeyDown={e => {
           switch (e.keyCode) {
@@ -208,7 +212,7 @@ class PlaylistCountdown extends Component {
               <div className={[style.controlButtonContainer, style.playlistCountdownCancel].join(' ')}>
                 <Localizer>
                   <button
-                    tabIndex={isHidden || isCanceled ? -1 : 0}
+                    tabIndex={this.isHidden || this.isCanceled ? -1 : 0}
                     aria-label={<Text id="playlist.cancel" />}
                     className={[style.controlButton, style.playlistCountdownCancelButton].join(' ')}
                     onClick={e => this.cancelNext(e)}

--- a/src/components/playlist-countdown/playlist-countdown.js
+++ b/src/components/playlist-countdown/playlist-countdown.js
@@ -42,8 +42,6 @@ const COMPONENT_NAME = 'PlaylistCountdown';
  */
 class PlaylistCountdown extends Component {
   focusElement: HTMLElement;
-  isHidden: boolean = true;
-  isCanceled: boolean = false;
   /**
    * should render component
    * @param {*} props - component props
@@ -108,11 +106,31 @@ class PlaylistCountdown extends Component {
       this.setState({timeToShow: false});
       this.props.updatePlaylistCountdownCanceled(false);
     }
-
-    this.isHidden = !this.state.timeToShow || nextProps.player.playlist.countdown.duration >= nextProps.duration;
-    this.isCanceled = nextProps.countdownCanceled;
   }
 
+  /**
+   * checks if the component is hidden
+   * @returns {boolean} - is component hidden
+   */
+  get isHidden(): boolean {
+    return !this.state.timeToShow || this.props.player.playlist.countdown.duration >= this.props.duration;
+  }
+
+  /**
+   * checks if the component is canceled
+   * @returns {boolean} - is component canceled
+   */
+  get isCanceled(): boolean {
+    return this.props.countdownCanceled;
+  }
+
+  /**
+   * checks if the component is shown
+   * @returns {boolean} - is component shown
+   */
+  get isShown(): boolean {
+    return !this.isHidden && !this.isCanceled;
+  }
   /**
    * component did update handler
    *
@@ -133,12 +151,11 @@ class PlaylistCountdown extends Component {
       }
     }
 
-    if (!prevState.show && this.state.show && this.focusElement) {
+    if (!prevState.shown && this.state.shown && this.focusElement) {
       this.focusElement.focus();
     }
 
-    this.setState({show: !this.isHidden && !this.isCanceled});
-
+    if (this.isShown !== this.state.shown) this.setState({shown: this.isShown});
   }
 
   /**
@@ -184,7 +201,7 @@ class PlaylistCountdown extends Component {
         role="button"
         aria-labelledby="playlistCountdownTextId"
         ref={el => (this.focusElement = el)}
-        tabIndex={this.isHidden || this.isCanceled ? -1 : 0}
+        tabIndex={this.isShown ? 0 : -1}
         className={className.join(' ')}
         onKeyDown={e => {
           switch (e.keyCode) {
@@ -212,7 +229,7 @@ class PlaylistCountdown extends Component {
               <div className={[style.controlButtonContainer, style.playlistCountdownCancel].join(' ')}>
                 <Localizer>
                   <button
-                    tabIndex={this.isHidden || this.isCanceled ? -1 : 0}
+                    tabIndex={this.isShown ? 0 : -1}
                     aria-label={<Text id="playlist.cancel" />}
                     className={[style.controlButton, style.playlistCountdownCancelButton].join(' ')}
                     onClick={e => this.cancelNext(e)}


### PR DESCRIPTION
### Description of the Changes

removed setState inside the render function as this causes unexpected behaviour and is considered bad practice. moved to componentDidUpdate

solves FEC-9521

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
