### PR TITLE
fix(FEC-9522): overlay background should be with 0.7 opacity

### DIFF
--- a/src/components/overlay/_overlay.scss
+++ b/src/components/overlay/_overlay.scss
@@ -27,7 +27,7 @@
     left: 0;
     width: 100%;
     height: 100%;
-    background-color: rgba(0, 0, 0, 0.42);
+    background-color: rgba(0, 0, 0, 0.7);
     z-index: 4;
     text-align: center;
     color: #fff;


### PR DESCRIPTION
### Description of the Changes

change background opacity in the scss

Solves FEC-9522

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
