### PR TITLE
fix(FEC-9513): endless spinner when auto play is failed

### DIFF
--- a/src/components/engine-connector/engine-connector.js
+++ b/src/components/engine-connector/engine-connector.js
@@ -209,6 +209,7 @@ class EngineConnector extends Component {
     eventManager.listen(player, player.Event.AD_STARTED, () => {
       this.props.updateLoadingSpinnerState(false);
       this.props.updateAdIsPlaying(true);
+      this.props.updatePrePlayback(false);
     });
 
     eventManager.listen(player, player.Event.AD_RESUMED, () => {


### PR DESCRIPTION
### Description of the Changes

Do `updatePrePlayback(false)` on `AD_STARTED`

Solves [FEC-9513](https://kaltura.atlassian.net/browse/FEC-9513)

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
