### PR TITLE
fix(FEC-9556): menu remains open after selecting with mouse

### DIFF
--- a/src/components/menu/menu.js
+++ b/src/components/menu/menu.js
@@ -257,7 +257,10 @@ class MenuItem extends Component {
           }
         }}
         className={props.isSelected(props.data) ? [style.dropdownMenuItem, style.active].join(' ') : style.dropdownMenuItem}
-        onClick={() => this.props.onSelect(props.data)}
+        onClick={e => {
+          e.stopPropagation();
+          this.props.onSelect(props.data);
+        }}
         onKeyDown={e => {
           switch (e.keyCode) {
             case KeyMap.ENTER:


### PR DESCRIPTION
### Description of the Changes

due to a bug created in FEC-7202 - caused by moving the menu component as child of the dropdown component - both listeners were handled when selecting a menu item.
Added stopPropagation in the menu so the dropdown code will not be handled

solves FEC-9556

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
