### PR TITLE
fix(FEC-9555): in mobile devices portrait mode when countdown shows the player jumps to the left

### DIFF
--- a/src/components/playlist-countdown/playlist-countdown.js
+++ b/src/components/playlist-countdown/playlist-countdown.js
@@ -152,7 +152,7 @@ class PlaylistCountdown extends Component {
     }
 
     if (!prevState.shown && this.state.shown && this.focusElement) {
-      this.focusElement.focus();
+      this.focusElement.focus({preventScroll: true});
     }
 
     if (this.isShown !== this.state.shown) this.setState({shown: this.isShown});

--- a/src/components/playlist-countdown/playlist-countdown.js
+++ b/src/components/playlist-countdown/playlist-countdown.js
@@ -152,7 +152,8 @@ class PlaylistCountdown extends Component {
     }
 
     if (!prevState.shown && this.state.shown && this.focusElement) {
-      this.focusElement.focus({preventScroll: true});
+      // deprecated for now due to scrolling bug in portrait android
+      // this.focusElement.focus({preventScroll: true});
     }
 
     if (this.isShown !== this.state.shown) this.setState({shown: this.isShown});

--- a/src/components/playlist-countdown/playlist-countdown.js
+++ b/src/components/playlist-countdown/playlist-countdown.js
@@ -9,6 +9,7 @@ import {withPlayer} from '../player';
 import {withLogger} from 'components/logger';
 import {bindActions} from '../../utils/bind-actions';
 import {actions} from 'reducers/playlist';
+import {withEventManager} from 'event/with-event-manager';
 
 /**
  * mapping state to props
@@ -32,6 +33,7 @@ const COMPONENT_NAME = 'PlaylistCountdown';
   bindActions(actions)
 )
 @withPlayer
+@withEventManager
 @withLogger(COMPONENT_NAME)
 /**
  * PlaylistCountdown component
@@ -152,7 +154,12 @@ class PlaylistCountdown extends Component {
     }
 
     if (!prevState.shown && this.state.shown && this.focusElement) {
-      this.focusElement.focus();
+      this.props.eventManager.listen(this.focusElement, 'transitionend', e => {
+        if (e.propertyName === 'right') {
+          this.focusElement.focus();
+          this.props.eventManager.unlisten(this.focusElement, 'transitionend');
+        }
+      });
     }
 
     if (this.isShown !== this.state.shown) this.setState({shown: this.isShown});

--- a/src/components/playlist-countdown/playlist-countdown.js
+++ b/src/components/playlist-countdown/playlist-countdown.js
@@ -9,7 +9,6 @@ import {withPlayer} from '../player';
 import {withLogger} from 'components/logger';
 import {bindActions} from '../../utils/bind-actions';
 import {actions} from 'reducers/playlist';
-import {withEventManager} from 'event/with-event-manager';
 
 /**
  * mapping state to props
@@ -33,7 +32,6 @@ const COMPONENT_NAME = 'PlaylistCountdown';
   bindActions(actions)
 )
 @withPlayer
-@withEventManager
 @withLogger(COMPONENT_NAME)
 /**
  * PlaylistCountdown component
@@ -154,12 +152,7 @@ class PlaylistCountdown extends Component {
     }
 
     if (!prevState.shown && this.state.shown && this.focusElement) {
-      this.props.eventManager.listen(this.focusElement, 'transitionend', e => {
-        if (e.propertyName === 'right') {
-          this.focusElement.focus();
-          this.props.eventManager.unlisten(this.focusElement, 'transitionend');
-        }
-      });
+      this.focusElement.focus();
     }
 
     if (this.isShown !== this.state.shown) this.setState({shown: this.isShown});


### PR DESCRIPTION
### Description of the Changes

commenting out the auto focus
deprecating FEC-9479 for now
solves FEC-9555

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
