### PR TITLE
feat(FEC-9479): focus on countdown without scrolling issue

### DIFF
--- a/src/components/playlist-countdown/_playlist-countdown.scss
+++ b/src/components/playlist-countdown/_playlist-countdown.scss
@@ -1,5 +1,5 @@
 .player {
-  .playlist-countdown-yOffset {
+  .playlistCountdownYOffset {
     transform: translateY(0px);
     transition: transform ease-in 100ms;
     width: 100%;
@@ -115,7 +115,7 @@
     &.state-paused,
     &.state-idle,
     &.hover {
-      .playlist-countdown-yOffset {
+      .playlistCountdownYOffset {
         transform: translateY(-50px);
       }
     }

--- a/src/components/playlist-countdown/_playlist-countdown.scss
+++ b/src/components/playlist-countdown/_playlist-countdown.scss
@@ -1,5 +1,10 @@
 .player {
-
+  .playlistCountdownYOffset {
+    transform: translateY(0px);
+    transition: transform ease-in 100ms;
+    width: 100%;
+    height: 100%;
+  }
   .playlist-countdown {
     font-family: $font-family;
     height: 72px;
@@ -7,12 +12,13 @@
     bottom: 0;
     right: 0;
     margin: 16px;
-    transform: translateY(0px);
-    transition: transform ease-in 100ms, right 500ms 500ms, opacity 400ms, bottom 300ms;
+    transform: translateX(0px);
+    transition: transform 500ms 500ms, opacity 400ms, bottom 300ms;
     cursor: pointer;
 
     &.hidden {
-      right: -160px;
+      transform: translateX(160px);
+      transition: opacity 0ms;
       pointer-events: none;
       opacity: 0;
       .playlist-countdown-content-placeholder {
@@ -109,7 +115,7 @@
     &.state-paused,
     &.state-idle,
     &.hover {
-      .playlist-countdown {
+      .playlistCountdownYOffset {
         transform: translateY(-50px);
       }
     }
@@ -127,9 +133,7 @@
         width: 152px;
 
         .playlist-countdown-content-background {
-
           .playlist-countdown-content {
-
             .playlist-countdown-text {
               padding: 8px;
 
@@ -168,7 +172,6 @@
           border-radius: 2px;
 
           .playlist-countdown-content {
-
             .playlist-countdown-text {
               width: 90%;
               padding: 3px 0 0 4px;

--- a/src/components/playlist-countdown/_playlist-countdown.scss
+++ b/src/components/playlist-countdown/_playlist-countdown.scss
@@ -1,10 +1,5 @@
 .player {
-  .playlistCountdownYOffset {
-    transform: translateY(0px);
-    transition: transform ease-in 100ms;
-    width: 100%;
-    height: 100%;
-  }
+
   .playlist-countdown {
     font-family: $font-family;
     height: 72px;
@@ -12,13 +7,12 @@
     bottom: 0;
     right: 0;
     margin: 16px;
-    transform: translateX(0px);
-    transition: transform 500ms 500ms, opacity 400ms, bottom 300ms;
+    transform: translateY(0px);
+    transition: transform ease-in 100ms, right 500ms 500ms, opacity 400ms, bottom 300ms;
     cursor: pointer;
 
     &.hidden {
-      transform: translateX(160px);
-      transition: opacity 0ms;
+      right: -160px;
       pointer-events: none;
       opacity: 0;
       .playlist-countdown-content-placeholder {
@@ -115,7 +109,7 @@
     &.state-paused,
     &.state-idle,
     &.hover {
-      .playlistCountdownYOffset {
+      .playlist-countdown {
         transform: translateY(-50px);
       }
     }
@@ -133,7 +127,9 @@
         width: 152px;
 
         .playlist-countdown-content-background {
+
           .playlist-countdown-content {
+
             .playlist-countdown-text {
               padding: 8px;
 
@@ -172,6 +168,7 @@
           border-radius: 2px;
 
           .playlist-countdown-content {
+
             .playlist-countdown-text {
               width: 90%;
               padding: 3px 0 0 4px;

--- a/src/components/playlist-countdown/_playlist-countdown.scss
+++ b/src/components/playlist-countdown/_playlist-countdown.scss
@@ -1,11 +1,8 @@
 @keyframes slideIn {
   0% {
-    right: 0px;
-  }
-  10%{
     right: -160px;
   }
-  50%{
+  50% {
     right: -160px;
   }
   100% {
@@ -25,7 +22,6 @@
     cursor: pointer;
 
     &.slideIn{
-      right: 0px;
       animation: slideIn 1000ms
     }
 

--- a/src/components/playlist-countdown/_playlist-countdown.scss
+++ b/src/components/playlist-countdown/_playlist-countdown.scss
@@ -1,5 +1,18 @@
+@keyframes slideIn {
+  0% {
+    right: 0px;
+  }
+  10%{
+    right: -160px;
+  }
+  50%{
+    right: -160px;
+  }
+  100% {
+    right: 0;
+  }
+}
 .player {
-
   .playlist-countdown {
     font-family: $font-family;
     height: 72px;
@@ -8,11 +21,16 @@
     right: 0;
     margin: 16px;
     transform: translateY(0px);
-    transition: transform ease-in 100ms, right 500ms 500ms, opacity 400ms, bottom 300ms;
+    transition: transform ease-in 100ms, opacity 400ms, bottom 300ms;
     cursor: pointer;
 
+    &.slideIn{
+      right: 0px;
+      animation: slideIn 1000ms
+    }
+
     &.hidden {
-      right: -160px;
+      transition: opacity 50ms;
       pointer-events: none;
       opacity: 0;
       .playlist-countdown-content-placeholder {

--- a/src/components/playlist-countdown/_playlist-countdown.scss
+++ b/src/components/playlist-countdown/_playlist-countdown.scss
@@ -1,5 +1,5 @@
 .player {
-  .playlistCountdownYOffset {
+  .playlist-countdown-yOffset {
     transform: translateY(0px);
     transition: transform ease-in 100ms;
     width: 100%;
@@ -115,7 +115,7 @@
     &.state-paused,
     &.state-idle,
     &.hover {
-      .playlistCountdownYOffset {
+      .playlist-countdown-yOffset {
         transform: translateY(-50px);
       }
     }

--- a/src/components/playlist-countdown/_playlist-countdown.scss
+++ b/src/components/playlist-countdown/_playlist-countdown.scss
@@ -2,9 +2,6 @@
   0% {
     right: -160px;
   }
-  50% {
-    right: -160px;
-  }
   100% {
     right: 0;
   }
@@ -14,15 +11,16 @@
     font-family: $font-family;
     height: 72px;
     position: absolute;
-    bottom: 0;
     right: 0;
+    bottom: 0;
     margin: 16px;
     transform: translateY(0px);
     transition: transform ease-in 100ms, opacity 400ms, bottom 300ms;
     cursor: pointer;
 
     &.slideIn{
-      animation: slideIn 1000ms
+      right: -160px;
+      animation: slideIn 500ms 500ms forwards;
     }
 
     &.hidden {

--- a/src/components/playlist-countdown/_playlist-countdown.scss
+++ b/src/components/playlist-countdown/_playlist-countdown.scss
@@ -26,7 +26,6 @@
     }
 
     &.hidden {
-      transition: opacity 50ms;
       pointer-events: none;
       opacity: 0;
       .playlist-countdown-content-placeholder {

--- a/src/components/playlist-countdown/playlist-countdown.js
+++ b/src/components/playlist-countdown/playlist-countdown.js
@@ -152,7 +152,7 @@ class PlaylistCountdown extends Component {
     }
 
     if (!prevState.shown && this.state.shown && this.focusElement) {
-      this.focusElement.focus({preventScroll: true});
+      this.focusElement.focus();
     }
 
     if (this.isShown !== this.state.shown) this.setState({shown: this.isShown});

--- a/src/components/playlist-countdown/playlist-countdown.js
+++ b/src/components/playlist-countdown/playlist-countdown.js
@@ -152,7 +152,7 @@ class PlaylistCountdown extends Component {
     }
 
     if (!prevState.shown && this.state.shown && this.focusElement) {
-      this.focusElement.focus();
+      this.focusElement.focus({preventScroll: true});
     }
 
     if (this.isShown !== this.state.shown) this.setState({shown: this.isShown});

--- a/src/components/playlist-countdown/playlist-countdown.js
+++ b/src/components/playlist-countdown/playlist-countdown.js
@@ -152,8 +152,7 @@ class PlaylistCountdown extends Component {
     }
 
     if (!prevState.shown && this.state.shown && this.focusElement) {
-      // deprecated for now due to scrolling bug in portrait android
-      // this.focusElement.focus({preventScroll: true});
+      this.focusElement.focus();
     }
 
     if (this.isShown !== this.state.shown) this.setState({shown: this.isShown});
@@ -195,6 +194,8 @@ class PlaylistCountdown extends Component {
       className.push(style.hidden);
     } else if (this.isCanceled) {
       className.push(style.canceled);
+    } else {
+      className.push(style.slideIn);
     }
 
     return (

--- a/src/components/playlist-countdown/playlist-countdown.js
+++ b/src/components/playlist-countdown/playlist-countdown.js
@@ -152,7 +152,8 @@ class PlaylistCountdown extends Component {
     }
 
     if (!prevState.shown && this.state.shown && this.focusElement) {
-      this.focusElement.focus({preventScroll: true});
+      // deprecated for now due to scrolling bug in portrait android
+      // this.focusElement.focus({preventScroll: true});
     }
 
     if (this.isShown !== this.state.shown) this.setState({shown: this.isShown});
@@ -197,55 +198,53 @@ class PlaylistCountdown extends Component {
     }
 
     return (
-      <div className={className.join(' ')}>
-        <div
-          className={style.playlistCountdownYOffset}
-          role="button"
-          aria-labelledby="playlistCountdownTextId"
-          ref={el => (this.focusElement = el)}
-          tabIndex={this.isShown ? 0 : -1}
-          onKeyDown={e => {
-            switch (e.keyCode) {
-              case KeyMap.ENTER:
-                this.onClick();
-                break;
-              case KeyMap.ESC:
-                this.cancelNext(e);
-                break;
-            }
-          }}
-          onClick={() => this.onClick()}>
-          <div className={style.playlistCountdownPoster} style={`background-image: url(${next.sources.poster});`} />
-          <div className={style.playlistCountdownContentPlaceholder}>
-            <div className={style.playlistCountdownContentBackground}>
-              <div className={style.playlistCountdownContent}>
-                <Localizer>
-                  <div id="playlistCountdownTextId" className={style.playlistCountdownText}>
-                    <div className={style.playlistCountdownTextTitle}>
-                      <Text id="playlist.up_next" />
-                    </div>
-                    <div className={style.playlistCountdownTextName}>{`${next.sources.metadata ? next.sources.metadata.name : ''}`}</div>
+      <div
+        role="button"
+        aria-labelledby="playlistCountdownTextId"
+        ref={el => (this.focusElement = el)}
+        tabIndex={this.isShown ? 0 : -1}
+        className={className.join(' ')}
+        onKeyDown={e => {
+          switch (e.keyCode) {
+            case KeyMap.ENTER:
+              this.onClick();
+              break;
+            case KeyMap.ESC:
+              this.cancelNext(e);
+              break;
+          }
+        }}
+        onClick={() => this.onClick()}>
+        <div className={style.playlistCountdownPoster} style={`background-image: url(${next.sources.poster});`} />
+        <div className={style.playlistCountdownContentPlaceholder}>
+          <div className={style.playlistCountdownContentBackground}>
+            <div className={style.playlistCountdownContent}>
+              <Localizer>
+                <div id="playlistCountdownTextId" className={style.playlistCountdownText}>
+                  <div className={style.playlistCountdownTextTitle}>
+                    <Text id="playlist.up_next" />
                   </div>
+                  <div className={style.playlistCountdownTextName}>{`${next.sources.metadata ? next.sources.metadata.name : ''}`}</div>
+                </div>
+              </Localizer>
+              <div className={[style.controlButtonContainer, style.playlistCountdownCancel].join(' ')}>
+                <Localizer>
+                  <button
+                    tabIndex={this.isShown ? 0 : -1}
+                    aria-label={<Text id="playlist.cancel" />}
+                    className={[style.controlButton, style.playlistCountdownCancelButton].join(' ')}
+                    onClick={e => this.cancelNext(e)}
+                    onKeyDown={e => {
+                      if (e.keyCode === KeyMap.ENTER) {
+                        this.cancelNext(e);
+                      }
+                    }}>
+                    <Icon type={IconType.Close} />
+                  </button>
                 </Localizer>
-                <div className={[style.controlButtonContainer, style.playlistCountdownCancel].join(' ')}>
-                  <Localizer>
-                    <button
-                      tabIndex={this.isShown ? 0 : -1}
-                      aria-label={<Text id="playlist.cancel" />}
-                      className={[style.controlButton, style.playlistCountdownCancelButton].join(' ')}
-                      onClick={e => this.cancelNext(e)}
-                      onKeyDown={e => {
-                        if (e.keyCode === KeyMap.ENTER) {
-                          this.cancelNext(e);
-                        }
-                      }}>
-                      <Icon type={IconType.Close} />
-                    </button>
-                  </Localizer>
-                </div>
-                <div className={style.playlistCountdownIndicatorBar}>
-                  <div className={style.playlistCountdownIndicatorProgress} style={{width: progressWidth}} />
-                </div>
+              </div>
+              <div className={style.playlistCountdownIndicatorBar}>
+                <div className={style.playlistCountdownIndicatorProgress} style={{width: progressWidth}} />
               </div>
             </div>
           </div>

--- a/src/components/playlist-countdown/playlist-countdown.js
+++ b/src/components/playlist-countdown/playlist-countdown.js
@@ -152,8 +152,7 @@ class PlaylistCountdown extends Component {
     }
 
     if (!prevState.shown && this.state.shown && this.focusElement) {
-      // deprecated for now due to scrolling bug in portrait android
-      // this.focusElement.focus({preventScroll: true});
+      this.focusElement.focus({preventScroll: true});
     }
 
     if (this.isShown !== this.state.shown) this.setState({shown: this.isShown});
@@ -198,53 +197,55 @@ class PlaylistCountdown extends Component {
     }
 
     return (
-      <div
-        role="button"
-        aria-labelledby="playlistCountdownTextId"
-        ref={el => (this.focusElement = el)}
-        tabIndex={this.isShown ? 0 : -1}
-        className={className.join(' ')}
-        onKeyDown={e => {
-          switch (e.keyCode) {
-            case KeyMap.ENTER:
-              this.onClick();
-              break;
-            case KeyMap.ESC:
-              this.cancelNext(e);
-              break;
-          }
-        }}
-        onClick={() => this.onClick()}>
-        <div className={style.playlistCountdownPoster} style={`background-image: url(${next.sources.poster});`} />
-        <div className={style.playlistCountdownContentPlaceholder}>
-          <div className={style.playlistCountdownContentBackground}>
-            <div className={style.playlistCountdownContent}>
-              <Localizer>
-                <div id="playlistCountdownTextId" className={style.playlistCountdownText}>
-                  <div className={style.playlistCountdownTextTitle}>
-                    <Text id="playlist.up_next" />
-                  </div>
-                  <div className={style.playlistCountdownTextName}>{`${next.sources.metadata ? next.sources.metadata.name : ''}`}</div>
-                </div>
-              </Localizer>
-              <div className={[style.controlButtonContainer, style.playlistCountdownCancel].join(' ')}>
+      <div className={className.join(' ')}>
+        <div
+          className={style.playlistCountdownYOffset}
+          role="button"
+          aria-labelledby="playlistCountdownTextId"
+          ref={el => (this.focusElement = el)}
+          tabIndex={this.isShown ? 0 : -1}
+          onKeyDown={e => {
+            switch (e.keyCode) {
+              case KeyMap.ENTER:
+                this.onClick();
+                break;
+              case KeyMap.ESC:
+                this.cancelNext(e);
+                break;
+            }
+          }}
+          onClick={() => this.onClick()}>
+          <div className={style.playlistCountdownPoster} style={`background-image: url(${next.sources.poster});`} />
+          <div className={style.playlistCountdownContentPlaceholder}>
+            <div className={style.playlistCountdownContentBackground}>
+              <div className={style.playlistCountdownContent}>
                 <Localizer>
-                  <button
-                    tabIndex={this.isShown ? 0 : -1}
-                    aria-label={<Text id="playlist.cancel" />}
-                    className={[style.controlButton, style.playlistCountdownCancelButton].join(' ')}
-                    onClick={e => this.cancelNext(e)}
-                    onKeyDown={e => {
-                      if (e.keyCode === KeyMap.ENTER) {
-                        this.cancelNext(e);
-                      }
-                    }}>
-                    <Icon type={IconType.Close} />
-                  </button>
+                  <div id="playlistCountdownTextId" className={style.playlistCountdownText}>
+                    <div className={style.playlistCountdownTextTitle}>
+                      <Text id="playlist.up_next" />
+                    </div>
+                    <div className={style.playlistCountdownTextName}>{`${next.sources.metadata ? next.sources.metadata.name : ''}`}</div>
+                  </div>
                 </Localizer>
-              </div>
-              <div className={style.playlistCountdownIndicatorBar}>
-                <div className={style.playlistCountdownIndicatorProgress} style={{width: progressWidth}} />
+                <div className={[style.controlButtonContainer, style.playlistCountdownCancel].join(' ')}>
+                  <Localizer>
+                    <button
+                      tabIndex={this.isShown ? 0 : -1}
+                      aria-label={<Text id="playlist.cancel" />}
+                      className={[style.controlButton, style.playlistCountdownCancelButton].join(' ')}
+                      onClick={e => this.cancelNext(e)}
+                      onKeyDown={e => {
+                        if (e.keyCode === KeyMap.ENTER) {
+                          this.cancelNext(e);
+                        }
+                      }}>
+                      <Icon type={IconType.Close} />
+                    </button>
+                  </Localizer>
+                </div>
+                <div className={style.playlistCountdownIndicatorBar}>
+                  <div className={style.playlistCountdownIndicatorProgress} style={{width: progressWidth}} />
+                </div>
               </div>
             </div>
           </div>

--- a/src/components/playlist-countdown/playlist-countdown.js
+++ b/src/components/playlist-countdown/playlist-countdown.js
@@ -44,6 +44,7 @@ const COMPONENT_NAME = 'PlaylistCountdown';
  */
 class PlaylistCountdown extends Component {
   focusElement: HTMLElement;
+  next: any;
 
   /**
    * constructor
@@ -201,10 +202,11 @@ class PlaylistCountdown extends Component {
     if (!this._shouldRender(props)) {
       return undefined;
     }
-    const next = props.playlist.next;
-    if (!(next && next.sources)) {
+    if (!(props.playlist.next && props.playlist.next)) {
       return undefined;
     }
+    this.next = !this.next || this.isShown ? props.playlist.next : this.next;
+
     const countdown = this.props.player.playlist.countdown;
     const timeToShow = this._getTimeToShow();
     const progressTime = props.currentTime - timeToShow;
@@ -238,7 +240,7 @@ class PlaylistCountdown extends Component {
           }
         }}
         onClick={() => this.onClick()}>
-        <div className={style.playlistCountdownPoster} style={`background-image: url(${next.sources.poster});`} />
+        <div className={style.playlistCountdownPoster} style={`background-image: url(${this.next.sources.poster});`} />
         <div className={style.playlistCountdownContentPlaceholder}>
           <div className={style.playlistCountdownContentBackground}>
             <div className={style.playlistCountdownContent}>
@@ -247,7 +249,7 @@ class PlaylistCountdown extends Component {
                   <div className={style.playlistCountdownTextTitle}>
                     <Text id="playlist.up_next" />
                   </div>
-                  <div className={style.playlistCountdownTextName}>{`${next.sources.metadata ? next.sources.metadata.name : ''}`}</div>
+                  <div className={style.playlistCountdownTextName}>{`${this.next.sources.metadata ? this.next.sources.metadata.name : ''}`}</div>
                 </div>
               </Localizer>
               <div className={[style.controlButtonContainer, style.playlistCountdownCancel].join(' ')}>

--- a/src/components/playlist-countdown/playlist-countdown.js
+++ b/src/components/playlist-countdown/playlist-countdown.js
@@ -205,7 +205,7 @@ class PlaylistCountdown extends Component {
     if (!this._shouldRender(props)) {
       return undefined;
     }
-    if (!(props.playlist.next && props.playlist.next && this.nextShown)) {
+    if (!(props.playlist.next && props.playlist.next.sources && this.nextShown)) {
       return undefined;
     }
 

--- a/src/components/playlist-countdown/playlist-countdown.js
+++ b/src/components/playlist-countdown/playlist-countdown.js
@@ -44,7 +44,7 @@ const COMPONENT_NAME = 'PlaylistCountdown';
  */
 class PlaylistCountdown extends Component {
   focusElement: HTMLElement;
-  next: any;
+  nextShown: any;
 
   /**
    * constructor
@@ -56,6 +56,7 @@ class PlaylistCountdown extends Component {
     super(props);
     this.setState({focusable: false});
   }
+
   /**
    * should render component
    * @param {*} props - component props
@@ -199,13 +200,14 @@ class PlaylistCountdown extends Component {
    * @memberof PlaylistCountdown
    */
   render(props: any): React$Element<any> | void {
+    this.isShown && (this.nextShown = props.playlist.next);
+
     if (!this._shouldRender(props)) {
       return undefined;
     }
-    if (!(props.playlist.next && props.playlist.next)) {
+    if (!(props.playlist.next && props.playlist.next && this.nextShown)) {
       return undefined;
     }
-    this.next = !this.next || this.isShown ? props.playlist.next : this.next;
 
     const countdown = this.props.player.playlist.countdown;
     const timeToShow = this._getTimeToShow();
@@ -240,7 +242,7 @@ class PlaylistCountdown extends Component {
           }
         }}
         onClick={() => this.onClick()}>
-        <div className={style.playlistCountdownPoster} style={`background-image: url(${this.next.sources.poster});`} />
+        <div className={style.playlistCountdownPoster} style={`background-image: url(${this.nextShown.sources.poster});`} />
         <div className={style.playlistCountdownContentPlaceholder}>
           <div className={style.playlistCountdownContentBackground}>
             <div className={style.playlistCountdownContent}>
@@ -249,7 +251,9 @@ class PlaylistCountdown extends Component {
                   <div className={style.playlistCountdownTextTitle}>
                     <Text id="playlist.up_next" />
                   </div>
-                  <div className={style.playlistCountdownTextName}>{`${this.next.sources.metadata ? this.next.sources.metadata.name : ''}`}</div>
+                  <div className={style.playlistCountdownTextName}>{`${
+                    this.nextShown.sources.metadata ? this.nextShown.sources.metadata.name : ''
+                  }`}</div>
                 </div>
               </Localizer>
               <div className={[style.controlButtonContainer, style.playlistCountdownCancel].join(' ')}>


### PR DESCRIPTION
### Description of the Changes
Separated the slide from right as an animation and added a listener to animationend to autofocus and to make the component accessible.
In addition, components "next" will be updated only when shown to avoid seeing the next video of playlist when fading out.

solves FEC-9479

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
