### PR TITLE
fix(FEC-9302): advanced captions high contrast a11y

### DIFF
--- a/src/components/cvaa-overlay/_cvaa-overlay.scss
+++ b/src/components/cvaa-overlay/_cvaa-overlay.scss
@@ -13,7 +13,7 @@
     margin: 0 12px;
     position: relative;
 
-    &:not(.custom){
+    &:not(.custom) {
       cursor: pointer;
     }
 
@@ -60,6 +60,9 @@
   }
   .custom-captions-applied {
     margin-top: 50px;
+    a {
+      color: #01accd;
+    }
   }
 
   .custom-caption-form {
@@ -117,6 +120,12 @@
   }
 }
 
-.font-size, .font-color, .font-family, .font-style, .font-opacity, .background-color, .background-opacity{
+.font-size,
+.font-color,
+.font-family,
+.font-style,
+.font-opacity,
+.background-color,
+.background-opacity {
   background: initial;
 }


### PR DESCRIPTION
### Description of the Changes

Updated "Edit captions" anchor color in the advanced captions window to support a11y requirements of high contrast

solves FEC-9302
### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
