### PR TITLE
fix: overlay indication wasn't fit for keyboard keys

### DIFF
--- a/src/components/volume/volume.js
+++ b/src/components/volume/volume.js
@@ -189,7 +189,7 @@ class Volume extends Component {
      * @returns {void}
      */
     const changeVolume = (newVolume: number) => {
-      if (newVolume > 100 || newVolume < 0) {
+      if (newVolume === player.volume || newVolume > 100 || newVolume < 0) {
         return;
       }
       player.muted = newVolume < KEYBOARD_DEFAULT_VOLUME_JUMP;

--- a/src/components/volume/volume.js
+++ b/src/components/volume/volume.js
@@ -221,7 +221,7 @@ class Volume extends Component {
       case KeyMap.M:
         if (!isAccessabilityHandler) {
           player.muted
-            ? this.props.updateOverlayActionIcon([IconType.VolumeBase, IconType.VolumeWave])
+            ? this.props.updateOverlayActionIcon([IconType.VolumeBase, IconType.VolumeWaves])
             : this.props.updateOverlayActionIcon([IconType.VolumeBase, IconType.VolumeMute]);
         }
         this.toggleMute();

--- a/src/components/volume/volume.js
+++ b/src/components/volume/volume.js
@@ -204,25 +204,25 @@ class Volume extends Component {
         } else {
           this.props.updateOverlayActionIcon([IconType.VolumeBase, IconType.VolumeWaves]);
         }
-        newVolume = Math.round(player.volume * 100) + KEYBOARD_DEFAULT_VOLUME_JUMP;
+        newVolume = Math.min(Math.round(player.volume * 100) + KEYBOARD_DEFAULT_VOLUME_JUMP, 100);
         changeVolume(newVolume);
         break;
       case KeyMap.DOWN:
-        newVolume = Math.round(player.volume * 100) - KEYBOARD_DEFAULT_VOLUME_JUMP;
+        newVolume = Math.max(Math.round(player.volume * 100) - KEYBOARD_DEFAULT_VOLUME_JUMP, 0);
         if (isAccessabilityHandler) {
           this.setState({hover: true});
         } else {
-          if (newVolume === 0) {
-            this.props.updateOverlayActionIcon([IconType.VolumeBase, IconType.VolumeMute]);
-          } else {
-            this.props.updateOverlayActionIcon([IconType.VolumeBase, IconType.VolumeWave]);
-          }
+          newVolume === 0
+            ? this.props.updateOverlayActionIcon([IconType.VolumeBase, IconType.VolumeMute])
+            : this.props.updateOverlayActionIcon([IconType.VolumeBase, IconType.VolumeWave]);
         }
         changeVolume(newVolume);
         break;
       case KeyMap.M:
         if (!isAccessabilityHandler) {
-          this.props.updateOverlayActionIcon([IconType.VolumeBase, IconType.VolumeMute]);
+          player.muted
+            ? this.props.updateOverlayActionIcon([IconType.VolumeBase, IconType.VolumeWave])
+            : this.props.updateOverlayActionIcon([IconType.VolumeBase, IconType.VolumeMute]);
         }
         this.toggleMute();
         break;


### PR DESCRIPTION
### Description of the Changes
 
Issue: overlay indications wasn't set correctly on M key and down arrow key.
Solution: fix the down arrow and muted key overlay indications to be compatible with player state.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
