### PR TITLE
fix(FEC-9548): not enough blur on overlay

### DIFF
--- a/src/components/video-player/_video-player.scss
+++ b/src/components/video-player/_video-player.scss
@@ -6,6 +6,6 @@
   height: 100%;
   background: black;
   .overlay-active &{
-    filter: blur(5px);
+    filter: blur(16px);
   }
 }


### PR DESCRIPTION
### Description of the Changes

changed blur on video when in overlay from 5px to 16px

solves FEC-9548

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
