### PR TITLE
fix(FEC-9592): css issue in tooltips in safari

### DIFF
--- a/src/components/tooltip/_tooltip.scss
+++ b/src/components/tooltip/_tooltip.scss
@@ -2,7 +2,6 @@
   position: relative;
   display: inline-block;
   .tooltip-label {
-    width: max-content;
     visibility: hidden;
     background-color: $tooltip-bg-color;
     color: $tooltip-color;


### PR DESCRIPTION
### Description of the Changes

removed unneeded css which ruined safari
solves FEC-9592

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
