### PR TITLE
fix(FEC-9604): some texts were hard coded and not from localization json

### DIFF
--- a/src/components/seekbar/seekbar.js
+++ b/src/components/seekbar/seekbar.js
@@ -11,6 +11,7 @@ import {withPlayer} from '../player';
 import {withKeyboardEvent} from 'components/keyboard';
 import {actions as overlayIconActions} from 'reducers/overlay-action';
 import {IconType} from '../icon';
+import {withText} from 'preact-i18n';
 
 /**
  * mapping state to props
@@ -37,6 +38,8 @@ const KEYBOARD_DEFAULT_SEEK_JUMP: number = 5;
 )
 @withPlayer
 @withKeyboardEvent(COMPONENT_NAME)
+@withText({sliderAriaLabel: 'controls.seekBarSlider'})
+
 /**
  * SeekBar component
  *
@@ -588,7 +591,7 @@ class SeekBar extends Component {
         className={seekbarStyleClass.join(' ')}
         ref={c => (this._seekBarElement = c)}
         role="slider"
-        aria-label="Seek slider"
+        aria-label={props.sliderAriaLabel}
         aria-valuemin="0"
         aria-valuemax={Math.round(this.props.duration)}
         aria-valuenow={Math.round(this.props.currentTime)}

--- a/src/components/settings/settings.js
+++ b/src/components/settings/settings.js
@@ -39,7 +39,8 @@ const COMPONENT_NAME = 'Settings';
 @withText({
   qualityLabelText: 'settings.quality',
   speedLabelText: 'settings.speed',
-  buttonLabel: 'controls.settings'
+  buttonLabel: 'controls.settings',
+  speedNormalLabelText: 'settings.speedNormal'
 })
 @withPlayer
 @withEventManager
@@ -253,7 +254,7 @@ class Settings extends Component {
     const speedOptions = player.playbackRates.reduce((acc, speed) => {
       let speedOption = {
         value: speed,
-        label: speed === 1 ? 'Normal' : speed,
+        label: speed === 1 ? props.speedNormalLabelText : speed,
         active: false
       };
       if (speed === player.playbackRate) {

--- a/src/components/volume/volume.js
+++ b/src/components/volume/volume.js
@@ -393,7 +393,7 @@ class Volume extends Component {
           className={style.volumeControlBar}
           role="slider"
           aria-valuemin="0"
-          aria-valuemaz="100"
+          aria-valuemax="100"
           aria-valuenow={player.volume * 100}
           aria-valuetext={`${player.volume * 100}% volume ${player.muted ? 'muted' : ''}`}>
           <div className={style.bar} ref={c => (this._volumeProgressBarElement = c)} onMouseDown={() => this.onVolumeProgressBarMouseDown()}>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -16,7 +16,8 @@
     "prev": "Prev",
     "startOver": "Start over",
     "pictureInPicture": "Picture in picture",
-    "logo": "Logo"
+    "logo": "Logo",
+    "seekBarSlider": "Seek slider"
   },
   "unmute": {
     "unmute": "Unmute"
@@ -27,7 +28,8 @@
   "settings": {
     "title": "Settings",
     "quality": "Quality",
-    "speed": "Speed"
+    "speed": "Speed",
+    "speedNormal" : "Normal"
   },
   "language": {
     "title": "Language",


### PR DESCRIPTION
### Description of the Changes

Inspired by this PR - https://github.com/kaltura/playkit-js-ui/pull/417

seek bar aria label is hard coded
normal speed text in settings is hard coded
volume - typo in aria-valuemax (is written now aria-valuemaz by mistake)

solves FEC-9604

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
