### PR TITLE
fix(FEC-9534): changing the bitrate post completion of any content changes replay to play icon

### DIFF
--- a/src/components/engine-connector/engine-connector.js
+++ b/src/components/engine-connector/engine-connector.js
@@ -144,7 +144,9 @@ class EngineConnector extends Component {
     eventManager.listen(player, player.Event.SEEKED, () => {
       this.props.updateIsSeeking(false);
       this.props.updateLastSeekPoint(player.currentTime);
-      this.props.updateIsPlaybackEnded(false);
+      if (player.currentTime < Math.floor(player.duration)) {
+        this.props.updateIsPlaybackEnded(false);
+      }
     });
 
     eventManager.listen(player, player.Event.ENDED, () => {


### PR DESCRIPTION

### Description of the Changes

to fix hls behaviour which fires seek event on video quality change - if currenttime is at the duration then don't turn off the playback end.

solves FEC-9534

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
