### PR TITLE
fix(FEC-9648): space bar doesn't play video on pre-play button

### DIFF
--- a/src/components/pre-playback-play-overlay/pre-playback-play-overlay.js
+++ b/src/components/pre-playback-play-overlay/pre-playback-play-overlay.js
@@ -71,7 +71,7 @@ class PrePlaybackPlayOverlay extends Component {
     const labelText = props.isPlaybackEnded ? props.startOverText : props.playText;
     return (
       <div className={style.prePlaybackPlayOverlay} onMouseOver={e => e.stopPropagation()} onClick={() => this.handleClick()}>
-        <a
+        <button
           className={style.prePlaybackPlayButton}
           tabIndex="0"
           aria-label={labelText}
@@ -81,7 +81,7 @@ class PrePlaybackPlayOverlay extends Component {
             }
           }}>
           <Tooltip label={labelText}>{props.isPlaybackEnded ? <Icon type={IconType.StartOver} /> : <Icon type={IconType.Play} />}</Tooltip>
-        </a>
+        </button>
       </div>
     );
   }


### PR DESCRIPTION
### Description of the Changes

button tag has a default behavior to fire click event when space bar pressed so change anchor to button.

### CheckLists

- [X] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [X] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
