### PR TITLE
fix(FEC-9601): when pressing key enter on play button there is no exit from fallback state

### DIFF
--- a/src/components/shell/shell.js
+++ b/src/components/shell/shell.js
@@ -150,12 +150,15 @@ class Shell extends Component {
    * @memberof Shell
    */
   onMouseUp(): void {
-    if (this.props.fallbackToMutedAutoPlay) {
-      this.props.player.muted = false;
-    }
+    this.unMuteFallback();
     this.props.notifyClick();
   }
 
+  unMuteFallback(): void {
+    if (this.props.fallbackToMutedAutoPlay) {
+      this.props.player.muted = false;
+    }
+  }
   /**
    * on touch end handler
    * @param {TouchEvent} e - touch event
@@ -186,6 +189,10 @@ class Shell extends Component {
     if (!this.state.nav && e.keyCode === KeyMap.TAB) {
       this.setState({nav: true});
       this.props.updatePlayerNavState(true);
+    }
+
+    if (this.state.nav && (e.keyCode === KeyMap.ENTER || e.keyCode === KeyMap.SPACE)) {
+      this.unMuteFallback();
     }
   }
 

--- a/src/components/shell/shell.js
+++ b/src/components/shell/shell.js
@@ -154,6 +154,12 @@ class Shell extends Component {
     this.props.notifyClick();
   }
 
+  /**
+   * if the ui is in fallback to muted autoplay mode, unmute the player
+   *
+   * @returns {void}
+   * @memberof Shell
+   */
   unMuteFallback(): void {
     if (this.props.fallbackToMutedAutoPlay) {
       this.props.player.muted = false;


### PR DESCRIPTION
### Description of the Changes

caused by the fix done in FEC-9376.

onClick was changed to mouseup. “Enter” or “Space” on Button elements trigger onClick and therefore now don’t effect the unmute. added handling in key down

solves FEC-9601

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
