### PR TITLE
docs:(FEC-9655): incorrect key for advertisement in the documentation

### DIFF
--- a/docs/translations.md
+++ b/docs/translations.md
@@ -49,7 +49,7 @@ A sample English dictionary may look like:
     "retry": "Retry"
   },
   "ads": {
-    "advertisement": "Advertisement",
+    "ad_notice": "Advertisement",
     "learn_more": "Learn more",
     "skip_ad": "Skip ad",
     "skip_in": "Skip in"
@@ -72,7 +72,7 @@ A sample English dictionary may look like:
 }
 ```
 
-For complete translation reference see [here](../translations/en.json).
+For complete translation reference see [here](/translations//en.i18n.json).
 
 Default locale is English.
 

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -72,7 +72,7 @@ A sample English dictionary may look like:
 }
 ```
 
-For complete translation reference see [here](/translations//en.i18n.json).
+For complete translation reference see [here](/translations/en.i18n.json).
 
 Default locale is English.
 


### PR DESCRIPTION
### Description of the Changes

* Change `advertisement` to `ad_notice`
* Fix the `en.i18n.json` link

Solves FEC-9655

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
