### PR TITLE
fix(FEC-9657): 'Auto' quality option is hardcoded and not translatable

### DIFF
--- a/src/components/settings/settings.js
+++ b/src/components/settings/settings.js
@@ -40,7 +40,8 @@ const COMPONENT_NAME = 'Settings';
   qualityLabelText: 'settings.quality',
   speedLabelText: 'settings.speed',
   buttonLabel: 'controls.settings',
-  speedNormalLabelText: 'settings.speedNormal'
+  speedNormalLabelText: 'settings.speedNormal',
+  qualityAutoLabelText: 'settings.qualityAuto'
 })
 @withPlayer
 @withEventManager
@@ -151,6 +152,7 @@ class Settings extends Component {
         break;
     }
   }
+
   /**
    * event listener for clicking outside handler.
    *
@@ -278,7 +280,7 @@ class Settings extends Component {
     // Progressive playback doesn't support auto
     if (qualityOptions.length > 1 && player.streamType !== 'progressive') {
       qualityOptions.unshift({
-        label: 'Auto',
+        label: this.props.qualityAutoLabelText,
         active: player.isAdaptiveBitrateEnabled(),
         value: 'auto'
       });

--- a/translations/de.i18n.json
+++ b/translations/de.i18n.json
@@ -30,7 +30,8 @@
       "title": "Einstellungen",
       "quality": "Qualität",
       "speed": "Geschwindigkeit",
-      "speedNormal": "Normal"
+      "speedNormal": "Normal",
+      "qualityAuto": "Auto"
     },
     "language": {
       "title": "Sprache",

--- a/translations/en.i18n.json
+++ b/translations/en.i18n.json
@@ -30,7 +30,8 @@
       "title": "Settings",
       "quality": "Quality",
       "speed": "Speed",
-      "speedNormal": "Normal"
+      "speedNormal": "Normal",
+      "qualityAuto": "Auto"
     },
     "language": {
       "title": "Language",


### PR DESCRIPTION
### Description of the Changes

add `Auto` to `en.i18n.json` and `de.i18n.json`

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
