### PR TITLE
fix(FEC-7969): when there is an http error in IE11, the error page is not displaying session ID

### DIFF
--- a/src/components/error-overlay/_error-overlay.scss
+++ b/src/components/error-overlay/_error-overlay.scss
@@ -47,6 +47,7 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    flex: 1 1 auto;
   }
 
   .control-button-container {

--- a/src/components/error-overlay/_error-overlay.scss
+++ b/src/components/error-overlay/_error-overlay.scss
@@ -47,7 +47,6 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    flex: 1;
   }
 
   .control-button-container {


### PR DESCRIPTION
### Description of the Changes

The css combination on the session div on ie11 caused it to be not visibile.
Fixed as recommended here - https://makandracards.com/makandra/54644-do-not-use-flex-1-or-flex-basis-0-inside-flex-direction-column-when-you-need-to-support-ie11
Solves FEC-7969

### CheckLists

- [X] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [X] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
