### PR TITLE
fix(FEC-9682): scss preprocessor is not encapsulating 'playkit-' prefix on video controls CSS

### DIFF
--- a/src/styles/_shell.scss
+++ b/src/styles/_shell.scss
@@ -30,6 +30,18 @@
   }
   video {
     width: 100%;
+    left: 0;
+
+    &::-webkit-media-controls-panel-container,
+    &::-webkit-media-controls {
+      display: none !important;
+      -webkit-appearance: none;
+    }
+
+    &::-webkit-media-controls-start-playback-button {
+      display: none !important;
+      -webkit-appearance: none;
+    }
   }
   .player-gui {
     opacity: 0;
@@ -86,17 +98,3 @@
   }
 }
 
-video {
-  left: 0;
-
-  &::-webkit-media-controls-panel-container,
-  &::-webkit-media-controls {
-    display: none !important;
-    -webkit-appearance: none;
-  }
-
-  &::-webkit-media-controls-start-playback-button {
-    display: none !important;
-    -webkit-appearance: none;
-  }
-}


### PR DESCRIPTION
### Description of the Changes

moved video css to be nested under player-playkit class
solves FEC-9682

### CheckLists

- [X] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [X] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
