### PR TITLE
fix(FEC-9980): custom preset controls are continuously blinking on hovering the bottom bar

### DIFF
--- a/src/components/shell/shell.js
+++ b/src/components/shell/shell.js
@@ -101,9 +101,6 @@ class Shell extends Component {
       this.setState({nav: false});
       this.props.updatePlayerNavState(false);
     }
-    if (!this.props.bottomBarHoverActive) {
-      this._updatePlayerHoverState();
-    }
   }
 
   /**
@@ -412,6 +409,7 @@ class Shell extends Component {
         className={playerClasses}
         onTouchEnd={e => this.onTouchEnd(e)}
         onMouseUp={() => this.onMouseUp()}
+        onMouseOver={() => this.onMouseOver()}
         onMouseMove={() => this.onMouseMove()}
         onMouseLeave={event => this.onMouseLeave(event)}
         onKeyDown={e => this.onKeyDown(e)}>

--- a/src/components/shell/shell.js
+++ b/src/components/shell/shell.js
@@ -412,7 +412,6 @@ class Shell extends Component {
         className={playerClasses}
         onTouchEnd={e => this.onTouchEnd(e)}
         onMouseUp={() => this.onMouseUp()}
-        onMouseOver={() => this.onMouseOver()}
         onMouseMove={() => this.onMouseMove()}
         onMouseLeave={event => this.onMouseLeave(event)}
         onKeyDown={e => this.onKeyDown(e)}>


### PR DESCRIPTION
### Description of the Changes

**Problem**: Once the hovering timeout is done the shell is updating the store with `playerHover:false` which causes a renderer, but at this time the mouse is still hovering the shell so in `onMouseOver` the shell is updating the store with `playerHover:true`, and so on for ever...
(This reproduce in the preact version 8.x (current) only when custom preset is set, but in preactX even with our default presets)

**Solution**: remove the state update from `onMouseOver` as it's redundant since `onMouseMove`

Solves: FEC-9980

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
