### PR TITLE
fix(FEC-10018): in Hindi language, the mute/unmute label is top instead of left

### DIFF
--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -2,7 +2,7 @@
 import style from '../../styles/style.scss';
 import {h, Component, toChildArray} from 'preact';
 import {connect} from 'react-redux';
-const PLAYER_MARGIN = 10;
+const PLAYER_MARGIN = 5;
 
 /**
  * mapping state to props


### PR DESCRIPTION
### Description of the Changes

In hindi the letters are higher than English. When put on "left" the tooltip exceeded the bottom and was considered "out of bounds".
Reduced the "safety" margin so this will remain valid also in Hindi

Solves FEC-10018

### CheckLists

- [X] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [X] test are passing in local environment 
- [X] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
