### PR TITLE
fix(FEC-10071): ad preset is missing the font family

### DIFF
--- a/src/styles/_shell.scss
+++ b/src/styles/_shell.scss
@@ -12,7 +12,8 @@
   user-select: none;
   -webkit-tap-highlight-color: transparent;
 
-  .playback-gui-wrapper {
+  .playback-gui-wrapper,
+  .ad-gui-wrapper {
     font-family: $font-family;
   }
 


### PR DESCRIPTION
### Description of the Changes

add the font-family to `ad-gui-wrapper` class (like `playback-gui-wrapper` has).

Solves FEC-10071

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
