### PR TITLE
feat(FEC-9613): allow application to disable double-click to fullscreen

### DIFF
--- a/flow-typed/types/components-config.js
+++ b/flow-typed/types/components-config.js
@@ -2,5 +2,8 @@
 declare type ComponentsConfig = {
   seekbar?: SeekbarConfig,
   watermark?: WatermarkConfig,
-  share?: ShareConfig
+  share?: ShareConfig,
+  vrStereo?: VrStereoConfig,
+  logo?: LogoConfig,
+  fullscreen?: FullscreenConfig
 };

--- a/flow-typed/types/fullscreen-config.js
+++ b/flow-typed/types/fullscreen-config.js
@@ -1,0 +1,4 @@
+// @flow
+declare type FullscreenConfig = {
+  disableByDoubleClick: boolean
+};

--- a/flow-typed/types/fullscreen-config.js
+++ b/flow-typed/types/fullscreen-config.js
@@ -1,4 +1,4 @@
 // @flow
 declare type FullscreenConfig = {
-  disableByDoubleClick: boolean
+  disableDoubleClick: boolean
 };

--- a/flow-typed/types/logo-config.js
+++ b/flow-typed/types/logo-config.js
@@ -1,0 +1,6 @@
+// @flow
+declare type LogoConfig = {
+  text: string,
+  url: string,
+  img: string
+};

--- a/flow-typed/types/vr-stereo-config.js
+++ b/flow-typed/types/vr-stereo-config.js
@@ -1,0 +1,4 @@
+// @flow
+declare type VrStereoConfig = {
+  vrStereoMode: boolean
+};

--- a/src/components/overlay-action/overlay-action.js
+++ b/src/components/overlay-action/overlay-action.js
@@ -182,8 +182,8 @@ class OverlayAction extends Component {
     if (this.props.isSmartContainerOpen) {
       return;
     }
-    const {disableByDoubleClick} = this.props.fullscreenConfig;
-    if (!disableByDoubleClick) {
+    const {disableDoubleClick} = this.props.fullscreenConfig;
+    if (!disableDoubleClick) {
       const now = Date.now();
       if (now - this._firstClickTime < PLAY_PAUSE_BUFFER_TIME) {
         this.cancelClickTimeout();

--- a/src/components/overlay-action/overlay-action.js
+++ b/src/components/overlay-action/overlay-action.js
@@ -21,7 +21,8 @@ const mapStateToProps = state => ({
   iconType: state.overlayAction.iconType,
   playerHover: state.shell.playerHover,
   isMobile: state.shell.isMobile,
-  isSmartContainerOpen: state.shell.smartContainerOpen
+  isSmartContainerOpen: state.shell.smartContainerOpen,
+  fullscreenConfig: state.config.components.fullscreen
 });
 
 /**
@@ -181,21 +182,24 @@ class OverlayAction extends Component {
     if (this.props.isSmartContainerOpen) {
       return;
     }
-    const now = Date.now();
-    if (now - this._firstClickTime < PLAY_PAUSE_BUFFER_TIME) {
-      this.cancelClickTimeout();
-      this.toggleFullscreen();
-      return;
-    }
-    if (now - this._firstClickTime < DOUBLE_CLICK_MAX_BUFFER_TIME) {
-      this.cancelClickTimeout();
-      this.togglePlayPause();
-      this.toggleFullscreen();
-      this._firstClickTime = 0;
-      return;
-    }
+    const {disableByDoubleClick} = this.props.fullscreenConfig;
+    if (!disableByDoubleClick) {
+      const now = Date.now();
+      if (now - this._firstClickTime < PLAY_PAUSE_BUFFER_TIME) {
+        this.cancelClickTimeout();
+        this.toggleFullscreen();
+        return;
+      }
+      if (now - this._firstClickTime < DOUBLE_CLICK_MAX_BUFFER_TIME) {
+        this.cancelClickTimeout();
+        this.togglePlayPause();
+        this.toggleFullscreen();
+        this._firstClickTime = 0;
+        return;
+      }
 
-    this._firstClickTime = now;
+      this._firstClickTime = now;
+    }
     this._clickTimeout = setTimeout(() => {
       this._clickTimeout = null;
       this.togglePlayPause();

--- a/src/reducers/config.js
+++ b/src/reducers/config.js
@@ -14,7 +14,8 @@ export const initialState = {
     seekbar: {},
     vrStereo: {},
     share: {},
-    logo: {}
+    logo: {},
+    fullscreen: {}
   }
 };
 


### PR DESCRIPTION
### Description of the Changes

* add `ui.components.fullscreen.disableDoubleClick` config and use it in the overlay-action component
* add missing component config types

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
