### PR TITLE
fix(FEC-10227): advanced captions setting window cut when opened in floating player

### DIFF
--- a/src/components/overlay/_overlay.scss
+++ b/src/components/overlay/_overlay.scss
@@ -8,7 +8,7 @@
 }
 
 .overlay {
-  position: relative;
+  position: absolute;
   width: 100%;
   height: 100%;
   display: none;

--- a/src/components/overlay/overlay.js
+++ b/src/components/overlay/overlay.js
@@ -32,8 +32,8 @@ class Overlay extends Component {
    * @returns {void}
    * @memberof Overlay
    */
-  componentWillMount(): void {
-    this.props.addPlayerClass(style.overlayActive);
+  componentDidMount(): void {
+    setTimeout(() => this.props.addPlayerClass(style.overlayActive));
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

**Issue:** When the player is small (<= `480px`), both language menu and cvaa are opened as an overlay in the `overlay-portal`. This causes 2 issues: 
1. `overlay.position: relative` is inappropriate (pushes the bottom side panel up)
2. `componentDidUnmount` of the language menu is running after `componentDidMount` of the cvaa, and removing a necessary player class (`overlay-active`. so`overlay-portal.pointer-event` remains `none`)

**Solution:** 
1. change to `overlay.position: absolute`
2. delay the `componentDidMount` by timeout

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
