### PR TITLE
fix(FEC-10235): Play/Pause button is not accurately centered in small player

### DIFF
--- a/src/components/playback-controls/_playback-controls.scss
+++ b/src/components/playback-controls/_playback-controls.scss
@@ -4,15 +4,10 @@
   position: absolute;
   top: 50%;
   left: 50%;
-  margin-top: -32px;
-  margin-left: -51px;
-}
-
-.player.playlist {
-  .player-gui > .playback-controls,
-  .center-playback-controls {
-    margin-left: -153px;
-  }
+  transform: translate(-50%, -50%);
+  -webkit-transform: translate(-50%, -50%);
+  -ms-transform: translate(-50%, -50%);
+  white-space: nowrap;
 }
 
 .bottom-bar .playback-controls {

--- a/src/components/playback-controls/_playback-controls.scss
+++ b/src/components/playback-controls/_playback-controls.scss
@@ -5,13 +5,13 @@
   top: 50%;
   left: 50%;
   margin-top: -32px;
-  margin-left: -48px;
+  margin-left: -51px;
 }
 
 .player.playlist {
   .player-gui > .playback-controls,
   .center-playback-controls {
-    margin-left: -144px;
+    margin-left: -153px;
   }
 }
 

--- a/src/components/playback-controls/_playback-controls.scss
+++ b/src/components/playback-controls/_playback-controls.scss
@@ -4,15 +4,9 @@
   position: absolute;
   top: 50%;
   left: 50%;
-  margin-top: -32px;
-  margin-left: -51px;
-}
-
-.player.playlist {
-  .player-gui > .playback-controls,
-  .center-playback-controls {
-    margin-left: -153px;
-  }
+  transform: translate(-50%, -50%);
+  -webkit-transform: translate(-50%, -50%);
+  -ms-transform: translate(-50%, -50%);
 }
 
 .bottom-bar .playback-controls {
@@ -35,7 +29,7 @@
       &.hover {
         .player-gui > .playback-controls,
         .center-playback-controls {
-          display: block;
+          display: flex;
 
           .control-button {
             width: auto;

--- a/src/components/playback-controls/_playback-controls.scss
+++ b/src/components/playback-controls/_playback-controls.scss
@@ -4,9 +4,15 @@
   position: absolute;
   top: 50%;
   left: 50%;
-  transform: translate(-50%, -50%);
-  -webkit-transform: translate(-50%, -50%);
-  -ms-transform: translate(-50%, -50%);
+  margin-top: -32px;
+  margin-left: -51px;
+}
+
+.player.playlist {
+  .player-gui > .playback-controls,
+  .center-playback-controls {
+    margin-left: -153px;
+  }
 }
 
 .bottom-bar .playback-controls {
@@ -29,7 +35,7 @@
       &.hover {
         .player-gui > .playback-controls,
         .center-playback-controls {
-          display: flex;
+          display: block;
 
           .control-button {
             width: auto;


### PR DESCRIPTION
### Description of the Changes

Since #398. 
Use `transform: translate(-50%, -50%)` and `white-space: nowrap` insteadof hardcoded `margin`

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
