### PR TITLE
fix(FEC-10247): top bar element located in the middle instead of right side

### DIFF
--- a/src/components/share/share.js
+++ b/src/components/share/share.js
@@ -92,27 +92,25 @@ class Share extends Component {
     }
     const shareConfig = this._getMergedShareConfig();
     const portalSelector = `#${this.props.player.config.targetId} .overlay-portal`;
-    return (
-      <div>
-        {this.state.overlay ? (
-          createPortal(
-            <ShareOverlay
-              shareUrl={shareUrl}
-              embedUrl={embedUrl}
-              enableTimeOffset={enableTimeOffset}
-              socialNetworks={shareConfig}
-              player={this.props.player}
-              onClose={() => this.toggleOverlay()}
-            />,
-            document.querySelector(portalSelector)
-          )
-        ) : (
-          <Tooltip label={this.props.shareTxt} type={ToolTipType.BottomLeft}>
-            <Button aria-haspopup="true" className={style.controlButton} onClick={() => this.toggleOverlay()} aria-label={this.props.shareTxt}>
-              <Icon type={IconType.Share} />
-            </Button>
-          </Tooltip>
-        )}
+    return this.state.overlay ? (
+      createPortal(
+        <ShareOverlay
+          shareUrl={shareUrl}
+          embedUrl={embedUrl}
+          enableTimeOffset={enableTimeOffset}
+          socialNetworks={shareConfig}
+          player={this.props.player}
+          onClose={() => this.toggleOverlay()}
+        />,
+        document.querySelector(portalSelector)
+      )
+    ) : (
+      <div className={style.controlButtonContainer}>
+        <Tooltip label={this.props.shareTxt} type={ToolTipType.BottomLeft}>
+          <Button aria-haspopup="true" className={style.controlButton} onClick={() => this.toggleOverlay()} aria-label={this.props.shareTxt}>
+            <Icon type={IconType.Share} />
+          </Button>
+        </Tooltip>
       </div>
     );
   }

--- a/src/components/top-bar/_top-bar.scss
+++ b/src/components/top-bar/_top-bar.scss
@@ -1,12 +1,11 @@
 .player .top-bar {
   background: linear-gradient(0deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.6) 100%);
-  padding: 6px 16px;
+  padding: 14px 16px;
   color: #fff;
   opacity: 0;
   visibility: hidden;
   transition: 100ms opacity;
   width: 100%;
-  margin-top: auto;
   position: absolute;
   top: 0;
   left: 0;

--- a/src/components/top-bar/_top-bar.scss
+++ b/src/components/top-bar/_top-bar.scss
@@ -1,13 +1,12 @@
 .player .top-bar {
   background: linear-gradient(0deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.6) 100%);
-  padding: 14px 16px;
+  padding: 6px 16px;
   color: #fff;
   opacity: 0;
   visibility: hidden;
   transition: 100ms opacity;
-  display: flex;
-  justify-content: space-between;
   width: 100%;
+  margin-top: auto;
   position: absolute;
   top: 0;
   left: 0;
@@ -21,10 +20,12 @@
   }
 
   .left-controls {
+    float: left;
     text-align: left;
     min-width: 0;
   }
   .right-controls {
+    float: right;
     text-align: left;
 
     .control-button-container {


### PR DESCRIPTION
### Description of the Changes

1. Align the top-bar style with the bottom-bar (revert https://github.com/kaltura/playkit-js-ui/commit/02ad5f2b1eeac61d55607333fd62e8b111a0fdee#diff-8603f12b92b47205f68a068e1207dc7aL2 as cannot reproduce its undocumented issue)
2. add to share the missing `controlButtonContainer` class (seems it removed incorrectly in https://github.com/kaltura/playkit-js-ui/commit/935846043cbc6f8337496c515afddab56221359a#diff-10c74714b78c05c56abedc5895abdc5eL96)

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
