### PR TITLE
fix(FEC-10052): the bottom toolbar not hiding after return from background on mobile devices

### DIFF
--- a/src/components/shell/shell.js
+++ b/src/components/shell/shell.js
@@ -354,6 +354,7 @@ class Shell extends Component {
     // or after an ad break
     // or in ad break
     if (
+      (this.props.currentState === 'playing' && prevProps.currentState === 'paused') ||
       (!this.props.prePlayback && prevProps.prePlayback) ||
       (!this.props.adBreak && prevProps.adBreak) ||
       (this.props.adBreak && !prevProps.adBreak)

--- a/src/components/shell/shell.js
+++ b/src/components/shell/shell.js
@@ -351,6 +351,7 @@ class Shell extends Component {
    */
   componentDidUpdate(prevProps: Object): void {
     // Update the hover state if the transition was from pre playback screen
+    // or from paused to playing
     // or after an ad break
     // or in ad break
     if (


### PR DESCRIPTION
### Description of the Changes

Always update the hover state after player transition from paused to playing, whether it's caused by returning from background on mobile or by an API call.


### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
