### PR TITLE
fix(FEC-10268): bottom bar displayed before Play button clicked when preload=auto

### DIFF
--- a/src/components/pre-playback-play-overlay/_pre-playback-play-overlay.scss
+++ b/src/components/pre-playback-play-overlay/_pre-playback-play-overlay.scss
@@ -32,6 +32,14 @@
   }
 }
 
+.pre-playback {
+  .bottom-bar,
+  .top-bar {
+    opacity: 0 !important;
+    display: none;
+  }
+}
+
 .player{
   &.size-ty {
     .pre-playback-play-button {

--- a/src/components/pre-playback-play-overlay/_pre-playback-play-overlay.scss
+++ b/src/components/pre-playback-play-overlay/_pre-playback-play-overlay.scss
@@ -35,7 +35,7 @@
 .pre-playback {
   .bottom-bar,
   .top-bar {
-    opacity: 0 !important;
+    opacity: 0;
     display: none;
   }
 }


### PR DESCRIPTION
### Description of the Changes

hide the bars on pre-playback (as we [did](https://github.com/kaltura/playkit-js-ui/pull/434/files#diff-01d3987c1557ce6ee3ae265e7580484cL35) for `player-gui`)

Solves FEC-10268

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
