### PR TITLE
fix(FEC-10226): captions menu doesn't close with keyboard navigation in a small player

### DIFF
--- a/src/components/language/language.js
+++ b/src/components/language/language.js
@@ -147,7 +147,7 @@ class Language extends Component {
    * @returns {void}
    * @memberof Language
    */
-  onControlButtonClick(): void {
+  toggleSmartContainerOpen(): void {
     this.setState(prevState => {
       return {smartContainerOpen: !prevState.smartContainerOpen};
     });
@@ -213,7 +213,7 @@ class Language extends Component {
             aria-haspopup="true"
             aria-label={this.props.buttonLabel}
             className={this.state.smartContainerOpen ? [style.controlButton, style.active].join(' ') : style.controlButton}
-            onClick={() => this.onControlButtonClick()}>
+            onClick={() => this.toggleSmartContainerOpen()}>
             <Icon type={IconType.Language} />
           </Button>
         </Tooltip>
@@ -223,7 +223,7 @@ class Language extends Component {
           <SmartContainer
             targetId={this.props.player.config.targetId}
             title={<Text id="language.title" />}
-            onClose={() => this.onControlButtonClick()}>
+            onClose={() => this.toggleSmartContainerOpen()}>
             {audioOptions.length <= 1 ? (
               undefined
             ) : (
@@ -250,7 +250,7 @@ class Language extends Component {
               <AdvancedCaptionsAnchor
                 isPortal={this.props.isMobile || this.props.isSmallSize}
                 onMenuChosen={() => this.toggleCVAAOverlay()}
-                onClose={() => this.onControlButtonClick()}
+                onClose={() => this.toggleSmartContainerOpen()}
               />
             )}
           </SmartContainer>
@@ -260,7 +260,7 @@ class Language extends Component {
             <CVAAOverlay
               onClose={() => {
                 this.toggleCVAAOverlay();
-                this.onControlButtonClick();
+                this.toggleSmartContainerOpen();
               }}
             />,
             document.querySelector(portalSelector)

--- a/src/components/overlay/overlay.js
+++ b/src/components/overlay/overlay.js
@@ -67,6 +67,7 @@ class Overlay extends Component {
             onClick={() => props.onClose()}
             onKeyDown={e => {
               if (e.keyCode === KeyMap.ENTER) {
+                e.preventDefault();
                 props.onClose();
               }
             }}

--- a/src/utils/popup-keyboard-accessibility.js
+++ b/src/utils/popup-keyboard-accessibility.js
@@ -21,7 +21,6 @@ export const withKeyboardA11y: Function = (WrappedComponent: Component): typeof 
      * @memberof HOC
      */
     componentDidMount() {
-      this._previouslyActiveElement = document.activeElement;
       this.focusOnDefault();
     }
 
@@ -169,6 +168,7 @@ export const withKeyboardA11y: Function = (WrappedComponent: Component): typeof 
     focusOnDefault(): void {
       const defaultElement = this._defaultFocusedElement || (this._accessibleChildren.length && this._accessibleChildren[0]);
       if (defaultElement) {
+        this._previouslyActiveElement = document.activeElement;
         defaultElement.focus();
       }
     }


### PR DESCRIPTION

### Description of the Changes
Bug happens due to focus in the unmount of the KeyBoardAccessibility HOC which occurs before the key event bubbling is done.

- renamed onControlButtonClick to toggleSmartContaierOpen in language.js
- added preventDefault on the key 'enter' to fix the bug and avoid bubbling to the language toggle button
- fixed previouslyActiveElement so it stores only if an auto focus was done and not always - for example - in the languages the menus inside also kept the previous element (which is the same language toggle button) and when the languages were close the button was focused 4 times instead of once

### CheckLists

- [X] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [X] test are passing in local environment 
- [X] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
