### PR TITLE
fix(FEC-10326): customPreset breaks UI

### DIFF
--- a/src/components/shell/shell.js
+++ b/src/components/shell/shell.js
@@ -239,7 +239,6 @@ class Shell extends Component {
    */
   componentDidMount() {
     const {player, eventManager} = this.props;
-    this._onWindowResize();
     eventManager.listen(
       window,
       'resize',

--- a/src/components/shell/shell.js
+++ b/src/components/shell/shell.js
@@ -91,6 +91,18 @@ class Shell extends Component {
   _playerResizeWatcher: ResizeWatcher;
 
   /**
+   * Creates an instance of Shell.
+   * @param {Object} props object
+   * @memberof Shell
+   */
+  constructor(props: any) {
+    super(props);
+    const {forceTouchUI} = props;
+    const {isIPadOS, isTablet, isMobile} = props.player.env;
+    this.props.updateIsMobile(isIPadOS || isTablet || isMobile || forceTouchUI);
+  }
+
+  /**
    * on mouse over, add hover class (shows the player ui) and timeout of 3 seconds bt default or what pass as prop configuration to component
    *
    * @returns {void}
@@ -226,9 +238,7 @@ class Shell extends Component {
    * @memberof Shell
    */
   componentDidMount() {
-    const {player, forceTouchUI, eventManager} = this.props;
-    const {isIPadOS, isTablet, isMobile} = player.env;
-    this.props.updateIsMobile(isIPadOS || isTablet || isMobile || forceTouchUI);
+    const {player, eventManager} = this.props;
     this._onWindowResize();
     eventManager.listen(
       window,

--- a/src/components/shell/shell.js
+++ b/src/components/shell/shell.js
@@ -91,18 +91,6 @@ class Shell extends Component {
   _playerResizeWatcher: ResizeWatcher;
 
   /**
-   * Creates an instance of Shell.
-   * @param {Object} props object
-   * @memberof Shell
-   */
-  constructor(props: any) {
-    super(props);
-    const {forceTouchUI} = props;
-    const {isIPadOS, isTablet, isMobile} = props.player.env;
-    this.props.updateIsMobile(isIPadOS || isTablet || isMobile || forceTouchUI);
-  }
-
-  /**
    * on mouse over, add hover class (shows the player ui) and timeout of 3 seconds bt default or what pass as prop configuration to component
    *
    * @returns {void}
@@ -222,11 +210,13 @@ class Shell extends Component {
    * @memberof Shell
    */
   componentWillMount() {
-    const {player} = this.props;
+    const {player, forceTouchUI} = this.props;
     this._environmentClasses = [
       `${__CSS_MODULE_PREFIX__}-${player.env.os.name.replace(/ /g, '-')}`,
       `${__CSS_MODULE_PREFIX__}-${player.env.browser.name.replace(/ /g, '-')}`
     ];
+    const {isIPadOS, isTablet, isMobile} = player.env;
+    this.props.updateIsMobile(isIPadOS || isTablet || isMobile || forceTouchUI);
   }
 
   /**

--- a/src/utils/with-animation.js
+++ b/src/utils/with-animation.js
@@ -1,5 +1,5 @@
 //@flow
-import {h, Component} from 'preact';
+import {h, Component, createRef} from 'preact';
 import {withEventManager} from 'event/with-event-manager';
 
 /**
@@ -9,7 +9,7 @@ import {withEventManager} from 'event/with-event-manager';
 export const withAnimation: Function = (cssClass: string) => (WrappedComponent: Component): typeof Component =>
   withEventManager(
     class AnimationComponent extends Component {
-      element: HTMLElement;
+      ref = createRef();
 
       /**
        * When component is mounted create event manager instance.
@@ -18,8 +18,8 @@ export const withAnimation: Function = (cssClass: string) => (WrappedComponent: 
        * @memberof AnimationComponent
        */
       componentDidMount(): void {
-        this.props.eventManager.listen(this.element, 'animationend', () => {
-          this.element.classList.remove(cssClass);
+        this.props.eventManager.listen(this.ref.current, 'animationend', () => {
+          this.ref.current.classList.remove(cssClass);
         });
       }
       /**
@@ -29,17 +29,17 @@ export const withAnimation: Function = (cssClass: string) => (WrappedComponent: 
        * @memberof AnimationComponent
        */
       componentWillUnmount(): void {
-        this.element.classList.remove(cssClass);
+        this.ref.current.classList.remove(cssClass);
       }
 
       /**
        * adds the animation class
-       *
+       *innerRef
        * @returns {void}
        * @memberof AnimationComponent
        */
       animate(): void {
-        this.element.classList.add(cssClass);
+        this.ref.current.classList.add(cssClass);
       }
 
       /**
@@ -52,7 +52,7 @@ export const withAnimation: Function = (cssClass: string) => (WrappedComponent: 
         return (
           <WrappedComponent
             {...this.props}
-            innerRef={ref => (this.element = ref)}
+            innerRef={this.ref}
             animate={() => {
               this.animate();
             }}

--- a/src/utils/with-animation.js
+++ b/src/utils/with-animation.js
@@ -34,7 +34,6 @@ export const withAnimation: Function = (cssClass: string) => (WrappedComponent: 
 
       /**
        * adds the animation class
-       *innerRef
        * @returns {void}
        * @memberof AnimationComponent
        */


### PR DESCRIPTION
### Description of the Changes

The initial shell mounting is happening after external preset mounts and in tooltips we rely on the shell prop isMobile.
As this is one time decision we can update it in the initial state.

Also refactor our with animation innerRef to avoid passing new anonymous function every time

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
