### PR TITLE
fix(FEC-10472): spinner doesn't show up

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -13,12 +13,6 @@
     "@babel/plugin-transform-property-mutators",
     "@babel/plugin-proposal-object-rest-spread",
     [
-      "@babel/plugin-transform-spread",
-      {
-        "loose": true
-      }
-    ],
-    [
       "@babel/plugin-proposal-decorators",
       {
         "legacy": true

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "@babel/plugin-transform-modules-commonjs": "^7.10.4",
     "@babel/plugin-transform-property-mutators": "^7.10.4",
     "@babel/plugin-transform-react-jsx": "^7.10.4",
-    "@babel/plugin-transform-spread": "^7.10.4",
     "@babel/preset-env": "^7.10.4",
     "@babel/preset-flow": "^7.10.4",
     "@babel/register": "^7.10.5",

--- a/src/components/smart-container/smart-container.js
+++ b/src/components/smart-container/smart-container.js
@@ -123,15 +123,12 @@ class SmartContainer extends Component {
   renderChildren(props: any): React$Element<any> {
     const children = toChildArray(props.children).map(child => {
       if (child) {
-        return cloneElement(
-          child,
-          {
-            pushRef: ref => {
-              props.addAccessibleChild(ref);
-            }
+        return cloneElement(child, {
+          pushRef: ref => {
+            props.addAccessibleChild(ref);
           },
           ...this.props
-        );
+        });
       }
     });
     return children;


### PR DESCRIPTION
### Description of the Changes

Issue: props didn't pass correctly to the `cloneElement` function, `@babel/plugin-transform-spread` with loose mode make the spinner to not show up.
Solution: use `cloneElement` correctly and remove `@babel/plugin-transform-spread` which isn't needed anymore.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
