### PR TITLE
fix(FEC-10289): controls disappear using keyboard

### DIFF
--- a/src/components/keyboard/keyboard.js
+++ b/src/components/keyboard/keyboard.js
@@ -114,7 +114,7 @@ class Keyboard extends Component {
         this.props.player.play();
         this.props.updateOverlayActionIcon(IconType.Play);
       }
-      this.toggleHoverState();
+      this.props.updatePlayerHoverState(true);
       return {preventDefault: true, payload: true};
     },
     [KeyMap.UP]: (): KeyboardEventResult => {
@@ -157,7 +157,7 @@ class Keyboard extends Component {
         this.props.logger.debug('Exit Picture In Picture');
         this.props.player.exitPictureInPicture();
       }
-      this.toggleHoverState();
+      this.props.updatePlayerHoverState(true);
       return {preventDefault: true, payload: true};
     },
     [KeyMap.ESC]: (): KeyboardEventResult => {
@@ -176,7 +176,7 @@ class Keyboard extends Component {
         this.props.logger.debug(`Seek. ${from} => ${to}`);
         this.props.player.currentTime = to;
         this.props.updateOverlayActionIcon(IconType.Rewind);
-        this.toggleHoverState();
+        this.props.updatePlayerHoverState(true);
         return {preventDefault: true, payload: {from: from, to: to}};
       }
       return {preventDefault: true, payload: null};
@@ -189,7 +189,7 @@ class Keyboard extends Component {
         this.props.logger.debug(`Seek. ${from} => ${to}`);
         this.props.player.currentTime = newTime > this.props.player.duration ? this.props.player.duration : newTime;
         this.props.updateOverlayActionIcon(IconType.Forward);
-        this.toggleHoverState();
+        this.props.updatePlayerHoverState(true);
         return {preventDefault: true, payload: {from: from, to: to}};
       }
       return {preventDefault: true, payload: null};
@@ -201,7 +201,7 @@ class Keyboard extends Component {
         this.props.logger.debug(`Seek. ${from} => ${to}`);
         this.props.player.currentTime = to;
         this.props.updateOverlayActionIcon(IconType.StartOver);
-        this.toggleHoverState();
+        this.props.updatePlayerHoverState(true);
         return {preventDefault: true, payload: {from: from, to: to}};
       }
       return {preventDefault: true, payload: null};
@@ -213,7 +213,7 @@ class Keyboard extends Component {
         this.props.logger.debug(`Seek. ${from} => ${to}`);
         this.props.player.currentTime = to;
         this.props.updateOverlayActionIcon(IconType.SeekEnd);
-        this.toggleHoverState();
+        this.props.updatePlayerHoverState(true);
         return {preventDefault: true, payload: {from: from, to: to}};
       }
       return {preventDefault: true, payload: null};
@@ -285,25 +285,6 @@ class Keyboard extends Component {
       return {preventDefault: true, payload: null};
     }
   };
-
-  /**
-   * toggles the shell hover state
-   *
-   * @returns {void}
-   * @memberof Keyboard
-   */
-  toggleHoverState(): void {
-    if (this._hoverTimeout !== null) {
-      clearTimeout(this._hoverTimeout);
-      this._hoverTimeout = null;
-    }
-    this.props.updatePlayerHoverState(true);
-    this.props.notifyHoverChange({hover: true});
-    this._hoverTimeout = setTimeout(() => {
-      this.props.updatePlayerHoverState(false);
-      this.props.notifyHoverChange({hover: false});
-    }, CONTROL_BAR_HOVER_DEFAULT_TIMEOUT);
-  }
 }
 
 export {Keyboard};

--- a/src/components/keyboard/keyboard.js
+++ b/src/components/keyboard/keyboard.js
@@ -6,7 +6,6 @@ import {actions as overlayIconActions} from '../../reducers/overlay-action';
 import {bindActions} from '../../utils/bind-actions';
 import {KeyMap, getKeyName} from '../../utils/key-map';
 import {IconType} from '../icon';
-import {CONTROL_BAR_HOVER_DEFAULT_TIMEOUT} from '../shell/shell';
 import {isPlayingAdOrPlayback} from '../../reducers/getters';
 import {withPlayer} from '../player';
 import {withEventDispatcher} from 'components/event-dispatcher';

--- a/src/components/overlay-action/overlay-action.js
+++ b/src/components/overlay-action/overlay-action.js
@@ -90,7 +90,6 @@ class OverlayAction extends Component {
       this.props.updateOverlayActionIcon(IconType.Play);
     }
     this.props.updatePlayerHoverState(true);
-    this.props.notifyHoverChange({hover: true});
     this.props.notifyClick({
       type: 'PlayPause'
     });

--- a/src/components/picture-in-picture/picture-in-picture.js
+++ b/src/components/picture-in-picture/picture-in-picture.js
@@ -12,6 +12,8 @@ import {withKeyboardEvent} from 'components/keyboard';
 import {withEventDispatcher} from 'components/event-dispatcher';
 import {Tooltip} from 'components/tooltip';
 import {Button} from 'components/button';
+import {bindActions} from 'utils/bind-actions';
+import {actions as shellActions} from 'reducers/shell';
 
 /**
  * mapping state to props
@@ -32,7 +34,7 @@ const COMPONENT_NAME = 'PictureInPicture';
  * @class PictureInPicture
  * @extends {Component}
  */
-@connect(mapStateToProps)
+@connect(mapStateToProps, bindActions(shellActions))
 @withPlayer
 @withKeyboardEvent(COMPONENT_NAME)
 @withLogger(COMPONENT_NAME)
@@ -49,6 +51,7 @@ class PictureInPicture extends Component {
       },
       action: () => {
         this.togglePip();
+        this.props.updatePlayerHoverState(true);
       }
     }
   ];

--- a/src/components/play-pause/play-pause.js
+++ b/src/components/play-pause/play-pause.js
@@ -15,6 +15,7 @@ import {actions as settingActions} from 'reducers/settings';
 import {actions as overlayIconActions} from 'reducers/overlay-action';
 import {Tooltip} from 'components/tooltip';
 import {Button} from 'components/button';
+import {actions as shellActions} from 'reducers/shell';
 
 /**
  * mapping state to props
@@ -37,7 +38,7 @@ const COMPONENT_NAME = 'PlayPause';
  * @example <PlayPause />
  * @extends {Component}
  */
-@connect(mapStateToProps, bindActions({...settingActions, ...overlayIconActions}))
+@connect(mapStateToProps, bindActions({...shellActions, ...settingActions, ...overlayIconActions}))
 @withPlayer
 @withKeyboardEvent(COMPONENT_NAME)
 @withLogger(COMPONENT_NAME)
@@ -56,6 +57,7 @@ class PlayPause extends Component {
       action: () => {
         this.props.isPlayingAdOrPlayback ? this.props.updateOverlayActionIcon(IconType.Pause) : this.props.updateOverlayActionIcon(IconType.Play);
         this.togglePlayPause();
+        this.props.updatePlayerHoverState(true);
       }
     }
   ];

--- a/src/components/seekbar/seekbar.js
+++ b/src/components/seekbar/seekbar.js
@@ -5,7 +5,7 @@ import {toHHMMSS} from '../../utils/time-format';
 import {KeyMap} from '../../utils/key-map';
 import {connect} from 'react-redux';
 import {bindActions} from '../../utils/bind-actions';
-import {actions} from '../../reducers/shell';
+import {actions as shellActions} from '../../reducers/shell';
 import {bindMethod} from '../../utils/bind-method';
 import {withPlayer} from '../player';
 import {withKeyboardEvent} from 'components/keyboard';
@@ -38,7 +38,7 @@ const KEYBOARD_DEFAULT_SEEK_JUMP: number = 5;
  * @class SeekBar
  * @extends {Component}
  */
-@connect(mapStateToProps, bindActions({...actions, ...overlayIconActions}))
+@connect(mapStateToProps, bindActions({...shellActions, ...overlayIconActions}))
 @withPlayer
 @withKeyboardEvent(COMPONENT_NAME)
 @withText({sliderAriaLabel: 'controls.seekBarSlider'})
@@ -258,6 +258,7 @@ class SeekBar extends Component {
       });
     };
     let newTime;
+    this.props.updatePlayerHoverState(true);
     switch (event.keyCode) {
       case KeyMap.LEFT:
         if (!isAccessibility) {

--- a/src/components/shell/shell.js
+++ b/src/components/shell/shell.js
@@ -366,6 +366,10 @@ class Shell extends Component {
       (!this.props.adBreak && prevProps.adBreak) ||
       (this.props.adBreak && !prevProps.adBreak)
     ) {
+      // hover updated from different component should notify this change.
+      if (this.state.hover !== this.props.playerHover) {
+        this.props.notifyHoverChange({hover: this.props.playerHover});
+      }
       this._updatePlayerHoverState();
     }
   }

--- a/src/components/shell/shell.js
+++ b/src/components/shell/shell.js
@@ -121,9 +121,7 @@ class Shell extends Component {
       return;
     }
     if (this.state.hover) {
-      this.setState({hover: false});
-      this.props.updatePlayerHoverState(false);
-      this.props.notifyHoverChange({hover: false});
+      this._updatePlayerHover(false);
     }
   }
 
@@ -284,11 +282,15 @@ class Shell extends Component {
       return;
     }
     if (!this.state.hover) {
-      this.props.updatePlayerHoverState(true);
-      this.props.notifyHoverChange({hover: true});
-      this.setState({hover: true});
+      this._updatePlayerHover(true);
     }
     this._startHoverTimeout();
+  }
+
+  _updatePlayerHover(hover: boolean): void {
+    this.props.updatePlayerHoverState(hover);
+    this.props.notifyHoverChange({hover});
+    this.setState({hover});
   }
 
   /**
@@ -317,9 +319,7 @@ class Shell extends Component {
     this._clearHoverTimeout();
     this.hoverTimeout = setTimeout(() => {
       if (this._canEndHoverState()) {
-        this.props.updatePlayerHoverState(false);
-        this.props.notifyHoverChange({hover: false});
-        this.setState({hover: false});
+        this._updatePlayerHover(false);
       }
     }, this.props.hoverTimeout || CONTROL_BAR_HOVER_DEFAULT_TIMEOUT);
   }
@@ -347,10 +347,12 @@ class Shell extends Component {
    */
   componentDidUpdate(prevProps: Object): void {
     // Update the hover state if the transition was from pre playback screen
+    // or hover state changed from different component - should be handled in shell
     // or from paused to playing
     // or after an ad break
     // or in ad break
     if (
+      this.state.hover !== this.props.playerHover ||
       (this.props.currentState === 'playing' && prevProps.currentState === 'paused') ||
       (!this.props.prePlayback && prevProps.prePlayback) ||
       (!this.props.adBreak && prevProps.adBreak) ||

--- a/src/components/shell/shell.js
+++ b/src/components/shell/shell.js
@@ -287,6 +287,14 @@ class Shell extends Component {
     this._startHoverTimeout();
   }
 
+  /**
+   * update hover as atomic change - all props for hover change at one place
+   * to be able to know to handle outside changes for player hover
+   * @returns {void} - if hover state can be ended
+   * @param {boolean} hover - is needed to update to hover or not
+   * @private
+   * @memberof Shell
+   */
   _updatePlayerHover(hover: boolean): void {
     this.props.updatePlayerHoverState(hover);
     this.props.notifyHoverChange({hover});


### PR DESCRIPTION
### Description of the Changes

Issue: there are multiple timeouts that could be with different timing to handle the disappearing of UI, so there are cases that it makes the wrong behavior.
The new keyboard handler doesn't change the hover state.
Solution: handle UI disappearing in shell only
Change the hover state on new keyboard handler as it was on the previous one.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
