### PR TITLE
fix(FEC-10481): "advertisement" title displays during bumper, when using new Ad layout

### DIFF
--- a/docs/ui-components.md
+++ b/docs/ui-components.md
@@ -177,7 +177,7 @@ export class MyCustomPlugin extends KalturaPlayer.core.BasePlugin {
 }
 ```
 
-## Injecting and removing a UI component dynamically  
+## Injecting and removing a UI component dynamically
 
 The `UiManager` exposes an api `addComponent` to add a UI component dynamically.  
 This method returns a function for removing the injected component.

--- a/src/components/active-preset/active-preset.js
+++ b/src/components/active-preset/active-preset.js
@@ -16,6 +16,7 @@ const mapStateToProps = state => ({
     shell: state.shell,
     engine: {
       adBreak: state.engine.adBreak,
+      adIsBumper: state.engine.adIsBumper,
       isLive: state.engine.isLive,
       hasError: state.engine.hasError,
       isIdle: state.engine.isIdle,

--- a/src/components/engine-connector/engine-connector.js
+++ b/src/components/engine-connector/engine-connector.js
@@ -230,6 +230,7 @@ class EngineConnector extends Component {
     eventManager.listen(player, player.Event.AD_LOADED, e => {
       const ad = e.payload.ad;
       this.props.updateAdIsLinear(ad.linear);
+      this.props.updateAdIsBumper(ad.bumper);
       this.props.updateAdClickUrl(ad.clickThroughUrl);
       this.props.updateAdSkipTimeOffset(ad.skipOffset);
       this.props.updateAdSkippableState(ad.skippable);

--- a/src/reducers/engine.js
+++ b/src/reducers/engine.js
@@ -266,7 +266,7 @@ export default (state: Object = initialState, action: Object) => {
         adUrl: action.adUrl
       };
 
-      case types.UPDATE_AD_IS_BUMPER:
+    case types.UPDATE_AD_IS_BUMPER:
       return {
         ...state,
         adIsBumper: action.adIsBumper

--- a/src/reducers/engine.js
+++ b/src/reducers/engine.js
@@ -31,6 +31,7 @@ export const types = {
   UPDATE_AD_SKIPPABLE_STATE: `${component}/UPDATE_AD_SKIPPABLE_STATE`,
   UPDATE_AD_URL: `${component}/UPDATE_AD_URL`,
   UPDATE_AD_IS_LINEAR: `${component}/UPDATE_AD_IS_LINEAR`,
+  UPDATE_AD_IS_BUMPER: `${component}/UPDATE_AD_IS_BUMPER`,
   UPDATE_PLAYER_POSTER: `${component}/UPDATE_PLAYER_POSTER`,
   UPDATE_IS_LIVE: `${component}/UPDATE_IS_LIVE`,
   UPDATE_IS_DVR: `${component}/UPDATE_IS_DVR`,
@@ -78,6 +79,7 @@ export const initialState = {
   adIsPlaying: false,
   adSkipTimeOffset: 0,
   adSkippableState: false,
+  adIsBumper: false,
   isLive: false,
   isDvr: false,
   adProgress: {
@@ -264,6 +266,12 @@ export default (state: Object = initialState, action: Object) => {
         adUrl: action.adUrl
       };
 
+      case types.UPDATE_AD_IS_BUMPER:
+      return {
+        ...state,
+        adIsBumper: action.adIsBumper
+      };
+
     case types.UPDATE_PLAYER_POSTER:
       return {
         ...state,
@@ -395,6 +403,7 @@ export const actions = {
   updateAdSkippableState: (adSkippableState: boolean) => ({type: types.UPDATE_AD_SKIPPABLE_STATE, adSkippableState}),
   updateAdClickUrl: (adUrl: string) => ({type: types.UPDATE_AD_URL, adUrl}),
   updateAdIsLinear: (adIsLinear: boolean) => ({type: types.UPDATE_AD_IS_LINEAR, adIsLinear}),
+  updateAdIsBumper: (adIsBumper: boolean) => ({type: types.UPDATE_AD_IS_BUMPER, adIsBumper}),
   updatePlayerPoster: (poster: string) => ({type: types.UPDATE_PLAYER_POSTER, poster}),
   updateIsLive: (isLive: boolean) => ({type: types.UPDATE_IS_LIVE, isLive}),
   updateIsDvr: (isDvr: boolean) => ({type: types.UPDATE_IS_DVR, isDvr}),

--- a/src/ui-presets/ads.js
+++ b/src/ui-presets/ads.js
@@ -35,7 +35,7 @@ function AdsUI(props: any, context: any): ?React$Element<any> {
             <GuiArea>
               <Loading />
               <UnmuteIndication hasTopBar />
-              <TopBar disabled={true} leftControls={isBumper(props, context) ? undefined : <AdNotice />} />
+              <TopBar disabled={true} leftControls={isBumper(props) ? undefined : <AdNotice />} />
             </GuiArea>
           </div>
         </PlayerArea>
@@ -52,7 +52,7 @@ function AdsUI(props: any, context: any): ?React$Element<any> {
             <UnmuteIndication hasTopBar />
             <TopBar
               disabled={true}
-              leftControls={isBumper(props, context) ? undefined : <AdNotice />}
+              leftControls={isBumper(props) ? undefined : <AdNotice />}
               rightControls={adsUiCustomization.learnMoreButton ? <AdLearnMore /> : undefined}
             />
             {adsUiCustomization.skipButton ? <AdSkip /> : undefined}
@@ -123,12 +123,10 @@ function useDefaultAdsUi(props: any, context: any): boolean {
 /**
  * Whether the current ad is a bumper.
  * @param {any} props - component props
- * @param {any} context - component context
  * @returns {boolean} - Whether is bumper.
  */
-function isBumper(props: any, context: any): boolean {
-  const ad = context.player.ads.getAd();
-  return ad && ad.bumper;
+function isBumper(props: any): boolean {
+  return props.state.engine.adIsBumper;
 }
 
 /**


### PR DESCRIPTION
### Description of the Changes

Left controls are shown although the ad is of bumper type.
This caused since the TopBar component isn't rendered again after the ad started.
Adding new state and bind a prop to the ad preset that will trigger a re-rendering after it will update.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
