### PR TITLE
fix(FEC-10526): iPad iOS11 - wrong full screen button state when PiP active

### DIFF
--- a/src/components/engine-connector/engine-connector.js
+++ b/src/components/engine-connector/engine-connector.js
@@ -278,7 +278,8 @@ class EngineConnector extends Component {
     });
 
     eventManager.listen(player, player.Event.PRESENTATION_MODE_CHANGED, () => {
-      player.isInPictureInPicture() ? this.props.updateIsInPictureInPicture(true) : this.props.updateIsInPictureInPicture(false);
+      this.props.updateIsInPictureInPicture(player.isInPictureInPicture());
+      this.props.updateFullscreen(player.isFullscreen());
     });
 
     eventManager.listen(player, player.Event.ENTER_FULLSCREEN, () => {


### PR DESCRIPTION
### Description of the Changes

Issue: iOS < 13 doesn't fire `EXIT_FULLSCREEN` when moving from native full screen (AV player) to PiP
Solution: Update the button state using `PRESENTATION_MODE_CHANGED` event

Solves FEC-10526

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
