### PR TITLE
fix(FEC-10481): "advertisement" title displays during bumper, when using new ad layout 

### DIFF
--- a/src/components/active-preset/active-preset.js
+++ b/src/components/active-preset/active-preset.js
@@ -16,7 +16,6 @@ const mapStateToProps = state => ({
     shell: state.shell,
     engine: {
       adBreak: state.engine.adBreak,
-      adIsBumper: state.engine.adIsBumper,
       isLive: state.engine.isLive,
       hasError: state.engine.hasError,
       isIdle: state.engine.isIdle,

--- a/src/components/ad-notice/ad-notice.js
+++ b/src/components/ad-notice/ad-notice.js
@@ -2,7 +2,7 @@
 import style from '../../styles/style.scss';
 import {h, Component} from 'preact';
 import {Text} from 'preact-i18n';
-import {connect} from "react-redux";
+import {connect} from 'react-redux';
 
 const COMPONENT_NAME = 'AdNotice';
 
@@ -31,7 +31,7 @@ class AdNotice extends Component {
     }
     return (
       <span className={style.adNotice}>
-        <Text id={'ads.ad_notice'}/>
+        <Text id={'ads.ad_notice'} />
       </span>
     );
   }

--- a/src/components/ad-notice/ad-notice.js
+++ b/src/components/ad-notice/ad-notice.js
@@ -2,8 +2,13 @@
 import style from '../../styles/style.scss';
 import {h, Component} from 'preact';
 import {Text} from 'preact-i18n';
+import {connect} from "react-redux";
 
 const COMPONENT_NAME = 'AdNotice';
+
+const mapStateToProps = state => ({
+  adIsBumper: state.engine.adIsBumper
+});
 
 /**
  * AdNotice component
@@ -12,6 +17,7 @@ const COMPONENT_NAME = 'AdNotice';
  * @example <AdNotice />
  * @extends {Component}
  */
+@connect(mapStateToProps)
 class AdNotice extends Component {
   /**
    * render component
@@ -20,9 +26,12 @@ class AdNotice extends Component {
    * @memberof AdNotice
    */
   render(): React$Element<any> {
+    if (this.props.adIsBumper) {
+      return undefined;
+    }
     return (
       <span className={style.adNotice}>
-        <Text id={'ads.ad_notice'} />
+        <Text id={'ads.ad_notice'}/>
       </span>
     );
   }

--- a/src/ui-presets/ads.js
+++ b/src/ui-presets/ads.js
@@ -33,9 +33,9 @@ function AdsUI(props: any, context: any): ?React$Element<any> {
         <PlayerArea name={'PresetArea'}>
           <div className={style.playerGui} id="player-gui">
             <GuiArea>
-              <Loading />
-              <UnmuteIndication hasTopBar />
-              <TopBar disabled={true} leftControls={isBumper(props) ? undefined : <AdNotice />} />
+              <Loading/>
+              <UnmuteIndication hasTopBar/>
+              <TopBar disabled={true} leftControls={<AdNotice/>}/>
             </GuiArea>
           </div>
         </PlayerArea>
@@ -48,26 +48,26 @@ function AdsUI(props: any, context: any): ?React$Element<any> {
       <PlayerArea name={'PresetArea'}>
         <div className={style.playerGui} id="player-gui">
           <GuiArea>
-            <Loading />
-            <UnmuteIndication hasTopBar />
+            <Loading/>
+            <UnmuteIndication hasTopBar/>
             <TopBar
               disabled={true}
-              leftControls={isBumper(props) ? undefined : <AdNotice />}
-              rightControls={adsUiCustomization.learnMoreButton ? <AdLearnMore /> : undefined}
+              leftControls={<AdNotice/>}
+              rightControls={adsUiCustomization.learnMoreButton ? <AdLearnMore/> : undefined}
             />
-            {adsUiCustomization.skipButton ? <AdSkip /> : undefined}
-            <PlaybackControls className={style.centerPlaybackControls} />
+            {adsUiCustomization.skipButton ? <AdSkip/> : undefined}
+            <PlaybackControls className={style.centerPlaybackControls}/>
             <BottomBar
               leftControls={
                 <Fragment>
-                  <PlaybackControls />
-                  <TimeDisplayAdsContainer />
+                  <PlaybackControls/>
+                  <TimeDisplayAdsContainer/>
                 </Fragment>
               }
               rightControls={
                 <Fragment>
-                  <Volume />
-                  <Fullscreen />
+                  <Volume/>
+                  <Fullscreen/>
                 </Fragment>
               }
             />
@@ -80,6 +80,7 @@ function AdsUI(props: any, context: any): ?React$Element<any> {
 
 const AdsUIComponent = withKeyboardEvent(PRESET_NAME)(AdsUI);
 AdsUIComponent.displayName = PRESET_NAME;
+
 /**
  * Ads ui interface
  *
@@ -118,15 +119,6 @@ function useDefaultAdsUi(props: any, context: any): boolean {
     // Do nothing
   }
   return isMobileUI || useStyledLinearAds;
-}
-
-/**
- * Whether the current ad is a bumper.
- * @param {any} props - component props
- * @returns {boolean} - Whether is bumper.
- */
-function isBumper(props: any): boolean {
-  return props.state.engine.adIsBumper;
 }
 
 /**

--- a/src/ui-presets/ads.js
+++ b/src/ui-presets/ads.js
@@ -33,9 +33,9 @@ function AdsUI(props: any, context: any): ?React$Element<any> {
         <PlayerArea name={'PresetArea'}>
           <div className={style.playerGui} id="player-gui">
             <GuiArea>
-              <Loading/>
-              <UnmuteIndication hasTopBar/>
-              <TopBar disabled={true} leftControls={<AdNotice/>}/>
+              <Loading />
+              <UnmuteIndication hasTopBar />
+              <TopBar disabled={true} leftControls={<AdNotice />} />
             </GuiArea>
           </div>
         </PlayerArea>
@@ -48,26 +48,22 @@ function AdsUI(props: any, context: any): ?React$Element<any> {
       <PlayerArea name={'PresetArea'}>
         <div className={style.playerGui} id="player-gui">
           <GuiArea>
-            <Loading/>
-            <UnmuteIndication hasTopBar/>
-            <TopBar
-              disabled={true}
-              leftControls={<AdNotice/>}
-              rightControls={adsUiCustomization.learnMoreButton ? <AdLearnMore/> : undefined}
-            />
-            {adsUiCustomization.skipButton ? <AdSkip/> : undefined}
-            <PlaybackControls className={style.centerPlaybackControls}/>
+            <Loading />
+            <UnmuteIndication hasTopBar />
+            <TopBar disabled={true} leftControls={<AdNotice />} rightControls={adsUiCustomization.learnMoreButton ? <AdLearnMore /> : undefined} />
+            {adsUiCustomization.skipButton ? <AdSkip /> : undefined}
+            <PlaybackControls className={style.centerPlaybackControls} />
             <BottomBar
               leftControls={
                 <Fragment>
-                  <PlaybackControls/>
-                  <TimeDisplayAdsContainer/>
+                  <PlaybackControls />
+                  <TimeDisplayAdsContainer />
                 </Fragment>
               }
               rightControls={
                 <Fragment>
-                  <Volume/>
-                  <Fullscreen/>
+                  <Volume />
+                  <Fullscreen />
                 </Fragment>
               }
             />


### PR DESCRIPTION
### Description of the Changes

`TopBar` component isn't re-rendered when its `leftControls` prop change to `undefined`.
Solution: Manage the `AdNotice` component inside the component itself by binding the `adIsBumper` state to it.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
