### PR TITLE
fix(FEC-10535): activePreset log doesn't show, getLogger called before logger initialised

### DIFF
--- a/src/components/active-preset/active-preset.js
+++ b/src/components/active-preset/active-preset.js
@@ -27,7 +27,6 @@ const mapStateToProps = state => ({
   config: state.config
 });
 
-const logger = getLogger('ActivePreset');
 const COMPONENT_NAME = 'ActivePreset';
 
 /**
@@ -39,6 +38,16 @@ const COMPONENT_NAME = 'ActivePreset';
 @withEventDispatcher(COMPONENT_NAME)
 @connect(mapStateToProps, bindActions(actions))
 class ActivePreset extends Component {
+  static logger: any;
+
+  /**
+   * Creates an instance of ActivePreset.
+   * @memberof ActivePreset
+   */
+  constructor() {
+    super();
+    ActivePreset.logger = getLogger('ActivePreset');
+  }
   /**
    * get the single matched UI to render based on the UIs and it's conditions
    *
@@ -79,7 +88,7 @@ class ActivePreset extends Component {
         props.notifyChange({from: activePresetName, to: presetName});
         props.updateActivePresetName(presetName);
         props.updatePresetSettings(null);
-        logger.debug(`update active preset to '${activePresetName}' and reset preset settings`);
+        ActivePreset.logger.debug(`update active preset to '${activePresetName}' and reset preset settings`);
       }
       return uiComponent;
     } else {

--- a/src/middlewares/logger.js
+++ b/src/middlewares/logger.js
@@ -2,8 +2,7 @@
 /* eslint-disable no-unused-vars */
 import getLogger from '../utils/logger';
 
-const logger = getLogger('UILoggerMiddleware');
-
+let logger;
 /**
  * The logger middleware.
  * Prints action logs in case of received debug=true from the UI config.
@@ -11,6 +10,9 @@ const logger = getLogger('UILoggerMiddleware');
  * @returns {void}
  */
 const loggerMiddleware = (config: UIOptionsObject) => (store: Object) => (next: Function) => (action: Object) => {
+  if (!logger) {
+    logger = getLogger('UILoggerMiddleware');
+  }
   if (config.debugActions) {
     logger.debug('Action fired', action);
   }


### PR DESCRIPTION
### Description of the Changes

Issue: logs don't show up.
Solution: create the logger when an instance created.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
