### PR TITLE
fix(FEC-10577): the player bars displayed when overlay is open

### DIFF
--- a/src/components/bottom-bar/_bottom-bar.scss
+++ b/src/components/bottom-bar/_bottom-bar.scss
@@ -74,7 +74,7 @@
   visibility: visible;
 }
 
-.player.overlay-active .bottom-bar {
+.player.overlay-active .gui-area .bottom-bar {
   opacity: 0;
   visibility: hidden;
 }

--- a/src/components/top-bar/_top-bar.scss
+++ b/src/components/top-bar/_top-bar.scss
@@ -47,7 +47,7 @@
   visibility: visible;
 }
 
-.player.overlay-active .top-bar {
+.player.overlay-active .gui-area .top-bar {
   opacity: 0;
   visibility: hidden;
 }


### PR DESCRIPTION
### Description of the Changes

The bars should be hidden when the overlay is open (to prevent hover toggling)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
