### PR TITLE
fix(FEC-10481): "advertisement" title displays during bumper, when using new ad layout

### DIFF
--- a/src/components/active-preset/active-preset.js
+++ b/src/components/active-preset/active-preset.js
@@ -16,7 +16,6 @@ const mapStateToProps = state => ({
     shell: state.shell,
     engine: {
       adBreak: state.engine.adBreak,
-      adIsBumper: state.engine.adIsBumper,
       isLive: state.engine.isLive,
       hasError: state.engine.hasError,
       isIdle: state.engine.isIdle,

--- a/src/components/ad-left-controls/ad-left-controls.js
+++ b/src/components/ad-left-controls/ad-left-controls.js
@@ -1,0 +1,39 @@
+//@flow
+import {h, Component} from 'preact';
+import {connect} from 'react-redux';
+import {AdNotice} from 'components/ad-notice/ad-notice';
+
+const COMPONENT_NAME = 'AdLeftControls';
+
+/**
+ * mapping state to props
+ * @param {*} state - redux store state
+ * @returns {Object} - mapped state to this component
+ */
+const mapStateToProps = state => ({
+  isBumper: state.engine.adIsBumper
+});
+
+/**
+ * AdLeftControls component
+ *
+ * @class AdNotice
+ * @example <AdLeftControls />
+ * @extends {Component}
+ */
+@connect(mapStateToProps)
+class AdLeftControls extends Component {
+  /**
+   * render component
+   *
+   * @returns {?React$Element} - component element
+   * @memberof AdLeftControls
+   */
+  render(): ?React$Element<any> {
+    return this.props.isBumper ? null : <AdNotice />;
+  }
+}
+
+AdLeftControls.displayName = COMPONENT_NAME;
+
+export {AdLeftControls};

--- a/src/components/ad-left-controls/index.js
+++ b/src/components/ad-left-controls/index.js
@@ -1,0 +1,1 @@
+export {AdLeftControls} from './ad-left-controls';

--- a/src/ui-presets/ads.js
+++ b/src/ui-presets/ads.js
@@ -10,11 +10,11 @@ import {AdLearnMore} from '../components/ad-learn-more';
 import {TopBar} from '../components/top-bar';
 import {BottomBar} from '../components/bottom-bar';
 import {UnmuteIndication} from '../components/unmute-indication';
-import {AdNotice} from '../components/ad-notice/ad-notice';
 import {PlaybackControls} from '../components/playback-controls';
 import {withKeyboardEvent} from 'components/keyboard';
 import {PlayerArea} from 'components/player-area';
 import {GuiArea} from 'components/gui-area';
+import {AdLeftControls} from 'components/ad-left-controls';
 
 const PRESET_NAME = 'Ads';
 
@@ -38,7 +38,7 @@ function AdsUI(props: any, context: any): ?React$Element<any> {
                 <UnmuteIndication hasTopBar />
               </Fragment>
               <Fragment>
-                <TopBar disabled={true} leftControls={isBumper(props) ? undefined : <AdNotice />} />
+                <TopBar disabled={true} leftControls={<AdLeftControls />} />
               </Fragment>
             </GuiArea>
           </div>
@@ -61,7 +61,7 @@ function AdsUI(props: any, context: any): ?React$Element<any> {
             <Fragment>
               <TopBar
                 disabled={true}
-                leftControls={isBumper(props) ? undefined : <AdNotice />}
+                leftControls={<AdLeftControls />}
                 rightControls={adsUiCustomization.learnMoreButton ? <AdLearnMore /> : undefined}
               />
               <BottomBar
@@ -126,15 +126,6 @@ function useDefaultAdsUi(props: any, context: any): boolean {
     // Do nothing
   }
   return isMobileUI || useStyledLinearAds;
-}
-
-/**
- * Whether the current ad is a bumper.
- * @param {any} props - component props
- * @returns {boolean} - Whether is bumper.
- */
-function isBumper(props: any): boolean {
-  return props.state.engine.adIsBumper;
 }
 
 /**


### PR DESCRIPTION
### Description of the Changes

Create a wrapper component for the ad left controls and move the logic to there.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
