### PR TITLE
fix(FEC-10445): voice over unable to play media

### DIFF
--- a/src/components/shell/shell.js
+++ b/src/components/shell/shell.js
@@ -426,6 +426,7 @@ class Shell extends Component {
     return (
       <div
         tabIndex="0"
+        aria-label="video player"
         className={playerClasses}
         onTouchEnd={e => this.onTouchEnd(e)}
         onMouseUp={() => this.onMouseUp()}

--- a/src/components/shell/shell.js
+++ b/src/components/shell/shell.js
@@ -426,7 +426,7 @@ class Shell extends Component {
     return (
       <div
         tabIndex="0"
-        aria-label="video player"
+        aria-label="Video Player"
         className={playerClasses}
         onTouchEnd={e => this.onTouchEnd(e)}
         onMouseUp={() => this.onMouseUp()}


### PR DESCRIPTION
### Description of the Changes

Because the playkit shell has tabIndex and is focusable but doesn't have roles / aria tags then the screen reader is trying to guess the content upon its children.
Before the change it used to say the "Unable to play media" (not sure actually why)
I added aria label "Video Player" and now the screen reader says - "Video Player Group"

Solves FEC-10445

### CheckLists

- [X] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
