### PR TITLE
fix(FEC-10055): tooltip default position prop should be of the wrapper control instead of the tooltip to enable overriding

### DIFF
--- a/src/components/share/share.js
+++ b/src/components/share/share.js
@@ -103,7 +103,7 @@ class Share extends Component {
       )
     ) : (
       <div className={style.controlButtonContainer}>
-        <Tooltip label={this.props.shareTxt} type={ToolTipType.BottomLeft}>
+        <Tooltip label={this.props.shareTxt} type={this.props.toolTipType ? this.props.toolTipType : ToolTipType.BottomLeft}>
           <Button aria-haspopup="true" className={style.controlButton} onClick={() => this.toggleOverlay()} aria-label={this.props.shareTxt}>
             <Icon type={IconType.Share} />
           </Button>

--- a/src/components/volume/volume.js
+++ b/src/components/volume/volume.js
@@ -373,7 +373,9 @@ class Volume extends Component {
         className={controlButtonClass.join(' ')}
         onMouseOver={() => this.onMouseOver()}
         onMouseOut={() => this.onMouseOut()}>
-        <Tooltip label={muted ? this.props.unmuteAriaLabel : this.props.muteAriaLabel} type={ToolTipType.Left}>
+        <Tooltip
+          label={muted ? this.props.unmuteAriaLabel : this.props.muteAriaLabel}
+          type={this.props.toolTipType ? this.props.toolTipType : ToolTipType.Left}>
           <Button
             tabIndex="0"
             aria-label={muted ? this.props.unmuteAriaLabel : this.props.muteAriaLabel}


### PR DESCRIPTION
### Description of the Changes

Exposed the default tooltip type in Volume and Share as props to be overridden.
solves FEC-10055

### CheckLists

- [X] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
