### PR TITLE
fix(FEC-10660): loading spinner is not showing

### DIFF
--- a/src/components/loading/loading.js
+++ b/src/components/loading/loading.js
@@ -110,7 +110,7 @@ class Loading extends Component {
             {Array(8)
               .fill(0)
               .map((val, i) => (
-                <span key={i} />
+                <span key={i + 1} />
               ))}
           </div>
         </div>

--- a/src/components/loading/loading.js
+++ b/src/components/loading/loading.js
@@ -107,9 +107,11 @@ class Loading extends Component {
       <div className={[style.loadingBackdrop, style.show].join(' ')}>
         <div className={style.spinnerContainer}>
           <div className={style.spinner}>
-            {[...Array(8)].map(i => (
-              <span key={i} />
-            ))}
+            {Array(8)
+              .fill(0)
+              .map((val, i) => (
+                <span key={i} />
+              ))}
           </div>
         </div>
       </div>


### PR DESCRIPTION
### Description of the Changes

Due to adding "loose": true in "@babel/plugin-transform-spread"
https://github.com/kaltura/playkit-js-ui/blob/master/.babelrc#L31

...Array(8) returns an empty array as it doesn't allow empty spaces in the array

### CheckLists

- [X] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
