### PR TITLE
fix(FEC-10702): Make sure all timers are cleaned on component unmount

### DIFF
--- a/src/components/cast-on-tv/cast-after-play.js
+++ b/src/components/cast-on-tv/cast-after-play.js
@@ -71,7 +71,7 @@ class CastAfterPlay extends Component {
    * @memberof CastAfterPlay
    */
   componentWillUnmount(): void {
-    if (this._timeoutId !== null) {
+    if (this._timeoutId) {
       clearTimeout(this._timeoutId);
       this._timeoutId = null;
     }

--- a/src/components/cast-on-tv/cast-after-play.js
+++ b/src/components/cast-on-tv/cast-after-play.js
@@ -39,6 +39,7 @@ class CastAfterPlay extends Component {
     icon: IconType.CastBrand
   };
 
+  _timeoutId: ?TimeoutID = null;
   /**
    * on click call the stop casting API.
    *
@@ -58,9 +59,22 @@ class CastAfterPlay extends Component {
    * @memberof CastAfterPlay
    */
   componentDidMount(): void {
-    setTimeout(() => {
+    this._timeoutId = setTimeout(() => {
       this.setState({show: true});
     }, 700);
+  }
+
+  /**
+   * after component unmount, clear timeouts
+   *
+   * @returns {void}
+   * @memberof CastAfterPlay
+   */
+  componentWillUnmount(): void {
+    if (this._timeoutId !== null) {
+      clearTimeout(this._timeoutId);
+      this._timeoutId = null;
+    }
   }
 
   /**

--- a/src/components/cast-on-tv/cast-before-play.js
+++ b/src/components/cast-on-tv/cast-before-play.js
@@ -35,6 +35,8 @@ const COMPONENT_NAME = 'CastBeforePlay';
 @withPlayer
 @withLogger(COMPONENT_NAME)
 class CastBeforePlay extends Component {
+  _timeoutId: ?TimeoutID = null;
+
   /**
    * @static
    * @type {Object} - Component default props
@@ -61,9 +63,22 @@ class CastBeforePlay extends Component {
    * @memberof CastBeforePlay
    */
   componentDidMount(): void {
-    setTimeout(() => {
+    this._timeoutId = setTimeout(() => {
       this.setState({show: true});
     }, 700);
+  }
+
+  /**
+   * after component unmount, clear timeouts
+   *
+   * @returns {void}
+   * @memberof CastBeforePlay
+   */
+  componentWillUnmount(): void {
+    if (this._timeoutId !== null) {
+      clearTimeout(this._timeoutId);
+      this._timeoutId = null;
+    }
   }
 
   /**

--- a/src/components/cast-on-tv/cast-before-play.js
+++ b/src/components/cast-on-tv/cast-before-play.js
@@ -75,7 +75,7 @@ class CastBeforePlay extends Component {
    * @memberof CastBeforePlay
    */
   componentWillUnmount(): void {
-    if (this._timeoutId !== null) {
+    if (this._timeoutId) {
       clearTimeout(this._timeoutId);
       this._timeoutId = null;
     }

--- a/src/components/copy-button/copy-button.js
+++ b/src/components/copy-button/copy-button.js
@@ -49,7 +49,7 @@ class CopyButton extends Component {
    * @memberof CopyButton
    */
   componentWillUnmount(): void {
-    if (this._timeoutId !== null) {
+    if (this._timeoutId) {
       clearTimeout(this._timeoutId);
       this._timeoutId = null;
     }

--- a/src/components/copy-button/copy-button.js
+++ b/src/components/copy-button/copy-button.js
@@ -23,6 +23,7 @@ const COMPONENT_NAME = 'CopyButton';
  * @extends {Component}
  */
 class CopyButton extends Component {
+  _timeoutId: ?TimeoutID = null;
   /**
    * @static
    * @type {Object} - Component default props
@@ -42,6 +43,19 @@ class CopyButton extends Component {
   }
 
   /**
+   * after component unmount, clear timeouts
+   *
+   * @returns {void}
+   * @memberof CopyButton
+   */
+  componentWillUnmount(): void {
+    if (this._timeoutId !== null) {
+      clearTimeout(this._timeoutId);
+      this._timeoutId = null;
+    }
+  }
+
+  /**
    * copy and update the state
    * @returns {void}
    */
@@ -49,7 +63,7 @@ class CopyButton extends Component {
     try {
       this.props.copy();
       this.setState({copySuccess: true});
-      setTimeout(() => {
+      this._timeoutId = setTimeout(() => {
         this.setState({copySuccess: false});
       }, TIMEOUT);
     } catch (e) {

--- a/src/components/overlay-action/overlay-action.js
+++ b/src/components/overlay-action/overlay-action.js
@@ -76,6 +76,17 @@ class OverlayAction extends Component {
   _clickTimeout: ?TimeoutID = null;
 
   /**
+   * after component unmount, clear timeouts
+   *
+   * @returns {void}
+   * @memberof OverlayAction
+   */
+  componentWillUnmount(): void {
+    this.cancelClickTimeout();
+    this.cancelIconTimeout();
+  }
+
+  /**
    * toggle play pause and set animation to icon change
    *
    * @returns {void}
@@ -217,6 +228,19 @@ class OverlayAction extends Component {
   }
 
   /**
+   * cancel the clickTimeout
+   *
+   * @returns {void}
+   * @memberof OverlayAction
+   */
+  cancelIconTimeout(): void {
+    if (this._iconTimeout) {
+      clearTimeout(this._iconTimeout);
+      this._iconTimeout = null;
+    }
+  }
+
+  /**
    * should component update handler
    *
    * @returns {boolean} - always update component
@@ -250,8 +274,7 @@ class OverlayAction extends Component {
       });
     };
     if (this._iconTimeout !== null) {
-      clearTimeout(this._iconTimeout);
-      this._iconTimeout = null;
+      this.cancelIconTimeout();
       this.setState({animation: false}, () => {
         this.forceUpdate();
         showIcon();

--- a/src/components/overlay/overlay.js
+++ b/src/components/overlay/overlay.js
@@ -23,6 +23,7 @@ const COMPONENT_NAME = 'Overlay';
  */
 @connect(null, bindActions(actions))
 class Overlay extends Component {
+  _timeoutId: ?TimeoutID = null;
   /**
    * componentWillMount
    *
@@ -30,7 +31,7 @@ class Overlay extends Component {
    * @memberof Overlay
    */
   componentDidMount(): void {
-    this.timeoutId = setTimeout(() => this.props.addPlayerClass(style.overlayActive), 0);
+    this._timeoutId = setTimeout(() => this.props.addPlayerClass(style.overlayActive), 0);
   }
 
   /**
@@ -40,8 +41,10 @@ class Overlay extends Component {
    * @memberof Overlay
    */
   componentWillUnmount(): void {
-    clearTimeout(this.timeoutId);
-    this.timeoutId = null;
+    if (this._timeoutId) {
+      clearTimeout(this._timeoutId);
+      this._timeoutId = null;
+    }
     this.props.removePlayerClass(style.overlayActive);
   }
 

--- a/src/components/overlay/overlay.js
+++ b/src/components/overlay/overlay.js
@@ -30,7 +30,7 @@ class Overlay extends Component {
    * @memberof Overlay
    */
   componentDidMount(): void {
-    setTimeout(() => this.props.addPlayerClass(style.overlayActive));
+    this.timeoutId = setTimeout(() => this.props.addPlayerClass(style.overlayActive), 0);
   }
 
   /**
@@ -40,6 +40,8 @@ class Overlay extends Component {
    * @memberof Overlay
    */
   componentWillUnmount(): void {
+    clearTimeout(this.timeoutId);
+    this.timeoutId = null;
     this.props.removePlayerClass(style.overlayActive);
   }
 

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -39,7 +39,7 @@ const ToolTipType = {
 @connect(mapStateToProps)
 class Tooltip extends Component {
   state: Object;
-  _hoverTimeout: ?TimeoutID;
+  _hoverTimeout: ?TimeoutID = null;
   textElement: HTMLSpanElement;
   lastAlternativeTypeIndex: number = -1;
 
@@ -54,15 +54,25 @@ class Tooltip extends Component {
   };
 
   /**
+   * clear hover timeout
+   *
+   * @returns {void}
+   * @memberof Tooltip
+   */
+  _clearHoverTimeout(): void {
+    if (this._hoverTimeout) {
+      clearTimeout(this._hoverTimeout);
+      this._hoverTimeout = null;
+    }
+  }
+
+  /**
    * on mouse over handler.
    * @memberof Tooltip
    * @returns {void}
    */
   onMouseOver(): void {
-    if (this._hoverTimeout) {
-      clearTimeout(this._hoverTimeout);
-      this._hoverTimeout = null;
-    }
+    this._clearHoverTimeout();
     this._hoverTimeout = setTimeout(() => {
       this.setState({showTooltip: true});
     }, TOOLTIP_SHOW_TIMEOUT);
@@ -75,8 +85,7 @@ class Tooltip extends Component {
    */
   onMouseLeave(): void {
     this.setState({showTooltip: false});
-    clearTimeout(this._hoverTimeout);
-    this._hoverTimeout = null;
+    this._clearHoverTimeout();
   }
 
   /**
@@ -144,6 +153,16 @@ class Tooltip extends Component {
         }
       }
     }
+  }
+
+  /**
+   * after component unmount, clear timeouts
+   *
+   * @returns {void}
+   * @memberof Tooltip
+   */
+  componentWillUnmount(): void {
+    this._clearHoverTimeout();
   }
 
   /**

--- a/src/components/unmute-indication/unmute-indication.js
+++ b/src/components/unmute-indication/unmute-indication.js
@@ -39,6 +39,7 @@ const COMPONENT_NAME = 'UnmuteIndication';
 @withEventManager
 @withLogger(COMPONENT_NAME)
 class UnmuteIndication extends Component {
+  _iconTimeout: ?TimeoutID = null;
   /**
    * after component updated, check the fallbackToMutedAutoPlay prop for updating the state of the component
    *
@@ -55,13 +56,26 @@ class UnmuteIndication extends Component {
   }
 
   /**
+   * after component unmount, clear timeouts
+   *
+   * @returns {void}
+   * @memberof UnmuteIndication
+   */
+  componentWillUnmount(): void {
+    if (this._iconTimeout) {
+      clearTimeout(this._iconTimeout);
+      this._iconTimeout = null;
+    }
+  }
+
+  /**
    * The icon only timeout handler
    * @private
    * @memberof UnmuteIndication
    * @returns {void}
    */
   _iconOnlyTimeout(): void {
-    setTimeout(() => {
+    this._iconTimeout = setTimeout(() => {
       this.setState({iconOnly: true});
     }, MUTED_AUTOPLAY_ICON_ONLY_DEFAULT_TIMEOUT);
   }

--- a/src/components/watermark/watermark.js
+++ b/src/components/watermark/watermark.js
@@ -34,6 +34,7 @@ const COMPONENT_NAME = 'Watermark';
 @withEventManager
 @withLogger(COMPONENT_NAME)
 class Watermark extends Component {
+  _timeoutId: ?TimeoutID = null;
   /**
    * Creates an instance of Watermark.
    * @memberof Watermark
@@ -56,7 +57,7 @@ class Watermark extends Component {
      */
     const onPlaying = () => {
       if (this.props.config.timeout > 0) {
-        setTimeout(() => this.setState({show: false}), this.props.config.timeout);
+        this._timeoutId = setTimeout(() => this.setState({show: false}), this.props.config.timeout);
       }
     };
 
@@ -66,6 +67,19 @@ class Watermark extends Component {
       this.setState({show: true});
       this.props.eventManager.listenOnce(player, player.Event.PLAYING, onPlaying);
     });
+  }
+
+  /**
+   * componentWillUnmount
+   *
+   * @returns {void}
+   * @memberof Watermark
+   */
+  componentWillUnmount(): void {
+    if (this._timeoutId) {
+      clearTimeout(this._timeoutId);
+      this._timeoutId = null;
+    }
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

Issue: overlay mounts and unmount immediately then overlayActive class exists.
Solution: clear the timer on unmount to make sure it won't add an overlayActive class after unmount and clear timeout on unmount for all.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
