### PR TITLE
fix(FEC-10782): spinner is shown while Imadai live ad

### DIFF
--- a/src/utils/with-animation.js
+++ b/src/utils/with-animation.js
@@ -30,6 +30,7 @@ export const withAnimation: Function = (cssClass: string) => (WrappedComponent: 
        * @memberof AnimationComponent
        */
       componentWillUnmount(): void {
+        if (!this.ref.current) return;
         this.ref.current.classList.remove(cssClass);
       }
 
@@ -39,6 +40,7 @@ export const withAnimation: Function = (cssClass: string) => (WrappedComponent: 
        * @memberof AnimationComponent
        */
       animate(): void {
+        if (!this.ref.current) return;
         this.ref.current.classList.add(cssClass);
       }
 


### PR DESCRIPTION
### Description of the Changes

In IMA DAI it is first changing to live preset and then to the ad preset causing the forward and backward button to unmount.
Due to changes in:
feat(FEC-10527): add RW/FF controls to live preset

These buttons in non dvr live return undefined in the render so we need to wrap withAnimation with relevant protection in all places. In the original ticket it was protected only in the didMount

Solves FEC-10782

### CheckLists

- [X] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [X] test are passing in local environment
- [X] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
