### PR TITLE
fix(FEC-10675): V3 - Replay button displayed for half of seconds after the media finished when loopback enabled

### DIFF
--- a/src/components/pre-playback-play-overlay/pre-playback-play-overlay.js
+++ b/src/components/pre-playback-play-overlay/pre-playback-play-overlay.js
@@ -63,7 +63,8 @@ class PrePlaybackPlayOverlay extends Component {
    * @memberof PrePlaybackPlayOverlay
    */
   render(props: any): React$Element<any> | void {
-    if ((!props.prePlayback && (!props.isPlaybackEnded || (props.playlist && props.playlist.next))) || props.loading) {
+    const isStartOver = props.isPlaybackEnded && !props.player.config.playback.loop && !(props.playlist && props.playlist.next);
+    if (!(props.prePlayback || isStartOver) || props.loading) {
       return undefined;
     }
     const labelText = props.isPlaybackEnded ? props.startOverText : props.playText;


### PR DESCRIPTION
### Description of the Changes

Issue: Replay button displayed for half of the second, before the playback started again.
Solution: don't show replay button on the end when loop is enabled, same for the playlist.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
