### PR TITLE
fix(FEC-10784): No spinner between the preroll and the playback when disableMediaPreload is true

### DIFF
--- a/src/components/loading/loading.js
+++ b/src/components/loading/loading.js
@@ -40,7 +40,6 @@ class Loading extends Component {
    */
   constructor() {
     super();
-    this.setState({afterPlayingEvent: false});
   }
 
   /**
@@ -52,7 +51,6 @@ class Loading extends Component {
   componentDidMount() {
     const {player, eventManager} = this.props;
     eventManager.listen(player, player.Event.PLAYER_STATE_CHANGED, e => {
-      if (!this.state.afterPlayingEvent) return;
       const StateType = player.State;
       if (
         e.payload.newState.type === StateType.IDLE ||
@@ -84,12 +82,7 @@ class Loading extends Component {
     });
 
     eventManager.listen(player, player.Event.PLAYING, () => {
-      this.setState({afterPlayingEvent: true});
       this.props.updateLoadingSpinnerState(false);
-    });
-
-    eventManager.listen(player, player.Event.CHANGE_SOURCE_STARTED, () => {
-      this.setState({afterPlayingEvent: false});
     });
   }
 


### PR DESCRIPTION
### Description of the Changes

Issue: No spinner between the preroll and the playback when disableMediaPreload is true.
Solution: remove the afterPlayingEvent flag to show the spinner before playing the event as expected, no regression from https://kaltura.atlassian.net/browse/FEC-7368 ad_break_start shows the loading state and autoplay_failed remove the loading state.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
