### PR TITLE
fix(FEC-10844): advanced caption settings custom caption is always marked even when choose sample

### DIFF
--- a/src/components/cvaa-overlay/main-captions_window.js
+++ b/src/components/cvaa-overlay/main-captions_window.js
@@ -28,16 +28,16 @@ class MainCaptionsWindow extends Component {
   componentWillMount() {
     const {player} = this.props;
 
-    this.captionsStyleDefault = Object.assign(new player.TextStyle(), {
+    this.captionsStyleDefault = player.TextStyle.fromJson({
       backgroundOpacity: player.TextStyle.StandardOpacities.TRANSPARENT
     });
 
-    this.captionsStyleYellow = Object.assign(new player.TextStyle(), {
+    this.captionsStyleYellow = player.TextStyle.fromJson({
       backgroundOpacity: player.TextStyle.StandardOpacities.TRANSPARENT,
       fontColor: player.TextStyle.StandardColors.YELLOW
     });
 
-    this.captionsStyleBlackBG = Object.assign(new player.TextStyle(), {
+    this.captionsStyleBlackBG = player.TextStyle.fromJson({
       backgroundColor: player.TextStyle.StandardColors.BLACK,
       fontColor: player.TextStyle.StandardColors.WHITE
     });

--- a/src/components/cvaa-overlay/main-captions_window.js
+++ b/src/components/cvaa-overlay/main-captions_window.js
@@ -7,7 +7,6 @@ import {default as Icon, IconType} from '../icon';
 import {SampleCaptionsStyleButton} from './sample-captions-style-button';
 import {h} from 'preact';
 import {withPlayer} from '../player';
-import isEqual from '../../utils/is-equal';
 
 /**
  * MainWindow component
@@ -135,9 +134,9 @@ class MainCaptionsWindow extends Component {
   isAdvancedStyleApplied(): boolean {
     const {player} = this.props;
     return (
-      !isEqual(player.textStyle, this.captionsStyleDefault) &&
-      !isEqual(player.textStyle, this.captionsStyleBlackBG) &&
-      !isEqual(player.textStyle, this.captionsStyleYellow)
+      !player.textStyle.isEqual(this.captionsStyleDefault) &&
+      !player.textStyle.isEqual(this.captionsStyleBlackBG) &&
+      !player.textStyle.isEqual(this.captionsStyleYellow)
     );
   }
 }

--- a/src/components/cvaa-overlay/sample-captions-style-button.js
+++ b/src/components/cvaa-overlay/sample-captions-style-button.js
@@ -1,7 +1,6 @@
 //@flow
 import {KeyMap} from '../../utils/key-map';
 import {Text} from 'preact-i18n';
-import isEqual from '../../utils/is-equal';
 import style from '../../styles/style.scss';
 import {default as Icon, IconType} from '../icon';
 import {h} from 'preact';
@@ -27,7 +26,7 @@ const SampleCaptionsStyleButton = (props: any): React$Element<any> => {
         }
       }}>
       <Text id={'cvaa.sample_caption_tag'} />
-      {isEqual(props.player.textStyle, props.captionsStyle) ? (
+      {props.player.textStyle.isEqual(props.captionsStyle) ? (
         <div className={style.activeTick}>
           <Icon type={IconType.Check} />
         </div>


### PR DESCRIPTION
### Description of the Changes

Issue: we use isEqual method which makes a class property check.
Solution: use the textStyle isEqual API instead.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
