### PR TITLE
fix(FEC-10275): bumper incorrectly recognized as ad

### DIFF
--- a/src/components/engine-connector/engine-connector.js
+++ b/src/components/engine-connector/engine-connector.js
@@ -203,10 +203,11 @@ class EngineConnector extends Component {
       this.props.updateAdBreakCompleted();
     });
 
-    eventManager.listen(player, player.Event.AD_STARTED, () => {
+    eventManager.listen(player, player.Event.AD_STARTED, e => {
       this.props.updateLoadingSpinnerState(false);
       this.props.updateAdIsPlaying(true);
       this.props.updatePrePlayback(false);
+      this.props.updateAdIsBumper(e.payload.ad.bumper);
     });
 
     eventManager.listen(player, player.Event.AD_RESUMED, () => {
@@ -230,7 +231,6 @@ class EngineConnector extends Component {
     eventManager.listen(player, player.Event.AD_LOADED, e => {
       const ad = e.payload.ad;
       this.props.updateAdIsLinear(ad.linear);
-      this.props.updateAdIsBumper(ad.bumper);
       this.props.updateAdClickUrl(ad.clickThroughUrl);
       this.props.updateAdSkipTimeOffset(ad.skipOffset);
       this.props.updateAdSkippableState(ad.skippable);


### PR DESCRIPTION
### Description of the Changes

Issue: ima post-roll changes `adIsBumper` state to `false` once the pre-roll is loading while the bumper is playing
Solution: Update `adIsBumper` on `AD_STARTED` instead of `AD_LOADED`

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
