### PR TITLE
feat(FEC-10798): support ima-dai ad breaks cue points

### DIFF
--- a/src/components/player-area/styles-store-adapter.js
+++ b/src/components/player-area/styles-store-adapter.js
@@ -55,16 +55,16 @@ class StylesStoreAdapter extends Component {
   shouldComponentUpdate(nextProps: Object): boolean {
     const {sidePanelsModes, sidePanelsSizes, allowSidePanels, playerClientRect} = this.props;
     const {
-      sidePanelsModes: prevSidePanelsModes,
-      sidePanelsSizes: prevSidePanelsSizes,
-      allowSidePanels: prevAllowSidePanels,
-      playerClientRect: prevPlayerClientRect
+      sidePanelsModes: nextSidePanelsModes,
+      sidePanelsSizes: nextSidePanelsSizes,
+      allowSidePanels: nextAllowSidePanels,
+      playerClientRect: nextPlayerClientRect
     } = nextProps;
     return !(
-      sidePanelsModes === prevSidePanelsModes &&
-      sidePanelsSizes === prevSidePanelsSizes &&
-      allowSidePanels === prevAllowSidePanels &&
-      playerClientRect === prevPlayerClientRect
+      sidePanelsModes === nextSidePanelsModes &&
+      sidePanelsSizes === nextSidePanelsSizes &&
+      allowSidePanels === nextAllowSidePanels &&
+      playerClientRect === nextPlayerClientRect
     );
   }
 

--- a/src/components/seekbar/seekbar.js
+++ b/src/components/seekbar/seekbar.js
@@ -110,6 +110,8 @@ class SeekBar extends Component {
    */
   componentDidMount(): void {
     const {player, eventManager} = this.props;
+    const clientRect = this._seekBarElement.getBoundingClientRect();
+    this.props.updateSeekbarClientRect(clientRect);
     eventManager.listen(player, FakeEvent.Type.GUI_RESIZE, () => {
       this.setState({resizing: true});
       setTimeout(() => {


### PR DESCRIPTION
### Description of the Changes

Issue: The Seekbar mounted after `GUI_RESIZE` already triggered (in imadai event sequence) so the Seekbar dimensions is wrong (0)
Solution: Update the Seekbar dimensions on mounting 

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
