### PR TITLE
feat: allow side panel and player area on the idle preset

### DIFF
--- a/src/ui-presets/idle.js
+++ b/src/ui-presets/idle.js
@@ -1,8 +1,8 @@
 //@flow
-import {h} from 'preact';
+import {Component, h} from 'preact';
 import style from '../styles/style.scss';
 import {Loading} from '../components/loading';
-import {PlayerArea} from 'components/player-area';
+import {PlayerArea, withPlayerPreset} from '../components/player-area';
 import {GuiArea} from 'components/gui-area';
 
 const PRESET_NAME = 'Idle';
@@ -12,16 +12,28 @@ const PRESET_NAME = 'Idle';
  *
  * @returns {React$Element} player ui tree
  */
-export function IdleUI(): React$Element<any> {
-  return (
-    <div className={style.playbackGuiWrapper}>
-      <PlayerArea name={'PresetArea'}>
-        <GuiArea>
-          <Loading />
-        </GuiArea>
-      </PlayerArea>
-    </div>
-  );
+@withPlayerPreset({
+  allowSidePanels: true,
+  allowPlayerArea: true
+})
+class IdleUI extends Component {
+  /**
+   * render component
+   *
+   * @returns {React$Element} - component element
+   * @memberof IdleUI
+   */
+  render() {
+    return (
+      <div className={style.playbackGuiWrapper}>
+        <PlayerArea name={'PresetArea'}>
+          <GuiArea>
+            <Loading />
+          </GuiArea>
+        </PlayerArea>
+      </div>
+    );
+  }
 }
 
 IdleUI.displayName = PRESET_NAME;


### PR DESCRIPTION
### Description of the Changes

make side panels persistent between medias

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
