### PR TITLE
fix(FEC-10949): spinner looks stuck in autoplay "inview"

### DIFF
--- a/src/components/engine-connector/engine-connector.js
+++ b/src/components/engine-connector/engine-connector.js
@@ -8,6 +8,7 @@ import {actions as shellActions} from '../../reducers/shell';
 import {withPlayer} from '../player';
 import {withEventManager} from 'event/with-event-manager';
 import {withLogger} from 'components/logger';
+import {AutoPlayType} from '@playkit-js/playkit-js';
 
 const COMPONENT_NAME = 'EngineConnector';
 
@@ -32,7 +33,7 @@ class EngineConnector extends Component {
   componentDidMount() {
     const {player, eventManager} = this.props;
     const TrackType = player.Track;
-    this.props.updatePrePlayback(!player.config.playback.autoplay);
+    this.props.updatePrePlayback(player.config.playback.autoplay !== AutoPlayType.TRUE);
 
     eventManager.listen(player, player.Event.PLAYER_RESET, () => {
       this.props.updateCurrentTime(0);
@@ -43,7 +44,7 @@ class EngineConnector extends Component {
     eventManager.listen(player, player.Event.SOURCE_SELECTED, () => {
       this.props.updateIsVr(player.isVr());
       this.props.updateIsInPictureInPicture(player.isInPictureInPicture());
-      if (player.config.playback.autoplay) {
+      if (player.config.playback.autoplay === AutoPlayType.TRUE) {
         this.props.updateLoadingSpinnerState(true);
       } else {
         this.props.updateLoadingSpinnerState(false);
@@ -51,7 +52,7 @@ class EngineConnector extends Component {
     });
 
     eventManager.listen(player, player.Event.CHANGE_SOURCE_STARTED, () => {
-      this.props.updatePrePlayback(!player.config.playback.autoplay && !this.props.engine.isPlaybackStarted);
+      this.props.updatePrePlayback(player.config.playback.autoplay !== AutoPlayType.TRUE && !this.props.engine.isPlaybackStarted);
       this.props.updateIsChangingSource(true);
       this.props.updateFallbackToMutedAutoPlay(false);
       this.props.updateAdBreak(false);


### PR DESCRIPTION
### Description of the Changes

Because threshold can be defined 100% and player can scroll slowly.
We need to handle autoplay inview like manual playback

Solves FEC-10949

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
