### PR TITLE
fix(FEC-10957): CastBeforePlay button is not aligned to the center

### DIFF
--- a/src/components/cast-on-tv/_cast-on-tv.scss
+++ b/src/components/cast-on-tv/_cast-on-tv.scss
@@ -20,9 +20,10 @@
 .player {
   .cast-on-tv-button-container {
     position: absolute;
+    top: 0;
+    left: 0;
     width: 100%;
-    text-align: center;
-    bottom: 20px;
+    height: 100%;
     opacity: 0;
 
     span {
@@ -41,6 +42,10 @@
     transition: max-width 200ms;
     padding: 0 16px;
     white-space: nowrap;
+    position: absolute;
+    bottom: 0;
+    transform: translate(-50%, -50%);
+    left: 50%;
 
     span {
       transform: translateX(0px);

--- a/src/components/cast-on-tv/cast-before-play.js
+++ b/src/components/cast-on-tv/cast-before-play.js
@@ -96,23 +96,21 @@ class CastBeforePlay extends Component {
         rootStyle.push(style.showCastOnTv);
       }
       return (
-        <div>
-          <div className={rootStyle.join(' ')}>
-            <Localizer>
-              <Button
-                tabIndex="0"
-                aria-label={<Text id={'cast.play_on_tv'} />}
-                onClick={() => this.onClick()}
-                className={[style.btn, style.btnDarkTransparent, style.castOnTvButton].join(' ')}>
-                <div className={style.castOnTvIconContainer}>
-                  <Icon type={props.icon} />
-                </div>
-                <span>
-                  <Text id="cast.play_on_tv" />
-                </span>
-              </Button>
-            </Localizer>
-          </div>
+        <div className={rootStyle.join(' ')}>
+          <Localizer>
+            <Button
+              tabIndex="0"
+              aria-label={<Text id={'cast.play_on_tv'} />}
+              onClick={() => this.onClick()}
+              className={[style.btn, style.btnDarkTransparent, style.castOnTvButton].join(' ')}>
+              <div className={style.castOnTvIconContainer}>
+                <Icon type={props.icon} />
+              </div>
+              <span>
+                <Text id="cast.play_on_tv" />
+              </span>
+            </Button>
+          </Localizer>
         </div>
       );
     }


### PR DESCRIPTION
### Description of the Changes

When page defines margin:auto for divs, cast before play button is not aligned to the center.
css fixes:
1. Remve redundant div.
2. Container div should cover player.
3. Child div should center the button correctly.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
