### PR TITLE
feat(FEC-10667): control-bar auto-hide timeout configuration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,7 +16,7 @@ var uiManager = new playkit.ui.UIManager(player, config);
   targetId: string,
   debugActions?: boolean, // optional
   forceTouchUI?: boolean, // optional
-  controlBarHoverTimeout?: number, // optional
+  hoverTimeout?: number, // optional
   logger?: loggerType, // optional
   components?: Object, // optional
   uiComponents: Array<Object>, //optional
@@ -61,7 +61,7 @@ var uiManager = new playkit.ui.UIManager(player, config);
 
 ##
 
-> ### config.controlBarHoverTimeout
+> ### config.hoverTimeout
 >
 > ##### Type: `number`
 >

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,6 +16,7 @@ var uiManager = new playkit.ui.UIManager(player, config);
   targetId: string,
   debugActions?: boolean, // optional
   forceTouchUI?: boolean, // optional
+  controlBarHoverTimeout?: number, // optional
   logger?: loggerType, // optional
   components?: Object, // optional
   uiComponents: Array<Object>, //optional
@@ -57,6 +58,18 @@ var uiManager = new playkit.ui.UIManager(player, config);
 > ##### Description: Defines the view type of the UI (mobile or desktop).
 >
 > Useful for applications that wants to force mobile view of player UI.
+
+##
+
+> ### config.controlBarHoverTimeout
+>
+> ##### Type: `number`
+>
+> ##### Default: `3000`
+>
+> ##### Description: Defines the timeout for control bar hover, 0 - don't hide.
+>
+> Useful for applications that wants to set different value for bar hover display.
 
 ##
 

--- a/flow-typed/types/ui-options.js
+++ b/flow-typed/types/ui-options.js
@@ -5,6 +5,7 @@ declare type UIOptionsObject = {
   targetId: string,
   debugActions?: boolean,
   forceTouchUI?: boolean,
+  controlBarHoverTimeout?: number,
   logger?: loggerType,
   components?: ComponentsConfig,
   uiComponents?: Array<KPUIComponent>,

--- a/flow-typed/types/ui-options.js
+++ b/flow-typed/types/ui-options.js
@@ -5,7 +5,7 @@ declare type UIOptionsObject = {
   targetId: string,
   debugActions?: boolean,
   forceTouchUI?: boolean,
-  controlBarHoverTimeout?: number,
+  hoverTimeout?: number,
   logger?: loggerType,
   components?: ComponentsConfig,
   uiComponents?: Array<KPUIComponent>,

--- a/src/components/shell/shell.js
+++ b/src/components/shell/shell.js
@@ -22,7 +22,7 @@ import {FakeEvent} from 'event/fake-event';
 const mapStateToProps = state => ({
   targetId: state.config.targetId,
   forceTouchUI: state.config.forceTouchUI,
-  controlBarHoverTimeout: state.config.controlBarHoverTimeout,
+  hoverTimeout: state.config.hoverTimeout,
   metadataLoaded: state.engine.metadataLoaded,
   currentState: state.engine.playerState.currentState,
   playerClasses: state.shell.playerClasses,
@@ -326,12 +326,12 @@ class Shell extends Component {
    */
   _startHoverTimeout(): void {
     this._clearHoverTimeout();
-    if (this.props.controlBarHoverTimeout) {
+    if (this.props.hoverTimeout) {
       this.hoverTimeout = setTimeout(() => {
         if (this._canEndHoverState()) {
           this._updatePlayerHover(false);
         }
-      }, this.props.controlBarHoverTimeout);
+      }, this.props.hoverTimeout);
     }
   }
 

--- a/src/components/shell/shell.js
+++ b/src/components/shell/shell.js
@@ -22,6 +22,7 @@ import {FakeEvent} from 'event/fake-event';
 const mapStateToProps = state => ({
   targetId: state.config.targetId,
   forceTouchUI: state.config.forceTouchUI,
+  controlBarHoverTimeout: state.config.controlBarHoverTimeout,
   metadataLoaded: state.engine.metadataLoaded,
   currentState: state.engine.playerState.currentState,
   playerClasses: state.shell.playerClasses,
@@ -325,11 +326,13 @@ class Shell extends Component {
    */
   _startHoverTimeout(): void {
     this._clearHoverTimeout();
-    this.hoverTimeout = setTimeout(() => {
-      if (this._canEndHoverState()) {
-        this._updatePlayerHover(false);
-      }
-    }, this.props.hoverTimeout || CONTROL_BAR_HOVER_DEFAULT_TIMEOUT);
+    if (this.props.controlBarHoverTimeout) {
+      this.hoverTimeout = setTimeout(() => {
+        if (this._canEndHoverState()) {
+          this._updatePlayerHover(false);
+        }
+      }, this.props.controlBarHoverTimeout);
+    }
   }
 
   /**

--- a/src/components/shell/shell.js
+++ b/src/components/shell/shell.js
@@ -43,12 +43,6 @@ const mapStateToProps = state => ({
   playlist: state.engine.playlist
 });
 
-/**
- * The default control bar hover time rendering timeout value
- * @type {number}
- * @const
- */
-const CONTROL_BAR_HOVER_DEFAULT_TIMEOUT: number = 3000;
 const ON_WINDOW_RESIZE_DEBOUNCE_DELAY: number = 100;
 
 const PLAYER_SIZE: {[size: string]: string} = {
@@ -443,4 +437,4 @@ class Shell extends Component {
   }
 }
 
-export {Shell, CONTROL_BAR_HOVER_DEFAULT_TIMEOUT, PLAYER_SIZE};
+export {Shell, PLAYER_SIZE};

--- a/src/reducers/config.js
+++ b/src/reducers/config.js
@@ -1,6 +1,5 @@
 //@flow
 import {mergeDeep} from '../utils/merge-deep';
-import {CONTROL_BAR_HOVER_DEFAULT_TIMEOUT} from 'components/shell/shell';
 
 export const types = {
   UPDATE: 'config/UPDATE',
@@ -10,7 +9,7 @@ export const types = {
 
 export const initialState = {
   forceTouchUI: false,
-  hoverTimeout: CONTROL_BAR_HOVER_DEFAULT_TIMEOUT,
+  hoverTimeout: 3000,
   components: {
     watermark: {},
     seekbar: {},

--- a/src/reducers/config.js
+++ b/src/reducers/config.js
@@ -1,5 +1,6 @@
 //@flow
 import {mergeDeep} from '../utils/merge-deep';
+import {CONTROL_BAR_HOVER_DEFAULT_TIMEOUT} from 'components/shell/shell';
 
 export const types = {
   UPDATE: 'config/UPDATE',
@@ -9,6 +10,7 @@ export const types = {
 
 export const initialState = {
   forceTouchUI: false,
+  controlBarHoverTimeout: CONTROL_BAR_HOVER_DEFAULT_TIMEOUT,
   components: {
     watermark: {},
     seekbar: {},

--- a/src/reducers/config.js
+++ b/src/reducers/config.js
@@ -10,7 +10,7 @@ export const types = {
 
 export const initialState = {
   forceTouchUI: false,
-  controlBarHoverTimeout: CONTROL_BAR_HOVER_DEFAULT_TIMEOUT,
+  hoverTimeout: CONTROL_BAR_HOVER_DEFAULT_TIMEOUT,
   components: {
     watermark: {},
     seekbar: {},


### PR DESCRIPTION
### Description of the Changes

Issue: unable to change our default for hiding the control bar.
Solution: add a new config called controlBarHoverTimeout which will pass the duration of timeout the user wants for this action.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
