### PR TITLE
feat(FEC-10768): add thumbsHeight to SeekbarConfig

### DIFF
--- a/flow-typed/types/seekbar-config.js
+++ b/flow-typed/types/seekbar-config.js
@@ -2,5 +2,6 @@
 declare type SeekbarConfig = {
   thumbsSprite: string,
   thumbsWidth: number,
-  thumbsSlices: number
+  thumbsSlices: number,
+  thumbsHeight: number
 };


### PR DESCRIPTION
### Description of the Changes

Add `thumbsHeight` definition to seekbar config type.
Note this whole config will be removed after the UI will start to work with new thumbnail API.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
