### PR TITLE
fix(FEC-10281): chromecast does not work after playing it once and trying it on another video

### DIFF
--- a/src/components/engine-connector/engine-connector.js
+++ b/src/components/engine-connector/engine-connector.js
@@ -41,6 +41,7 @@ class EngineConnector extends Component {
     });
 
     eventManager.listen(player, player.Event.SOURCE_SELECTED, () => {
+      this.props.updateIsCastAvailable(player.isCastAvailable());
       this.props.updateIsVr(player.isVr());
       this.props.updateIsInPictureInPicture(player.isInPictureInPicture());
       if (player.config.playback.autoplay) {


### PR DESCRIPTION
### Description of the Changes

Check for cast availability from previous sessions when source is selected.

Solves FEC-10281
Related to https://github.com/kaltura/playkit-js-cast-sender/pull/51

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
