### PR TITLE
fix(FEC-11100): bumper advertisement text appears for second when bumper starts

### DIFF
--- a/src/components/engine-connector/engine-connector.js
+++ b/src/components/engine-connector/engine-connector.js
@@ -232,6 +232,7 @@ class EngineConnector extends Component {
     eventManager.listen(player, player.Event.AD_LOADED, e => {
       const ad = e.payload.ad;
       this.props.updateAdIsLinear(ad.linear);
+      this.props.updateAdIsBumper(ad.bumper);
       this.props.updateAdClickUrl(ad.clickThroughUrl);
       this.props.updateAdSkipTimeOffset(ad.skipOffset);
       this.props.updateAdSkippableState(ad.skippable);


### PR DESCRIPTION
### Description of the Changes

Issue: 
1. UI bumper change status on ad_started which could be too late and show the text "advertisement" for a second. 
2. ad_started used because bumper dispatch ad_loaded once before pre-roll for pre-roll and post-roll so with IMA mid-roll it'll keep the advertisement text.

Solution: 
1. add ad_loaded handler to avoid this use case that the status change is too late, ad_loaded will change the status.
2. ad_started shouldn't change the status only on case 2 mentioned above.


### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
