### PR TITLE
fix(FEC-10745): Chromecast - DVR seekbar displayed for Live ,despite DVR mode isn't supported by Cast SDK

### DIFF
--- a/src/components/seekbar-live-playback-container/seekbar-live-playback-container.js
+++ b/src/components/seekbar-live-playback-container/seekbar-live-playback-container.js
@@ -21,7 +21,8 @@ const mapStateToProps = state => ({
   isDraggingActive: state.seekbar.draggingActive,
   isMobile: state.shell.isMobile,
   poster: state.engine.poster,
-  isDvr: state.engine.isDvr
+  isDvr: state.engine.isDvr,
+  isCasting: state.engine.isCasting
 });
 
 const COMPONENT_NAME = 'SeekBarLivePlaybackContainer';
@@ -71,7 +72,7 @@ class SeekBarLivePlaybackContainer extends Component {
    * @memberof SeekBarLivePlaybackContainer
    */
   render(props: any) {
-    if (!props.isDvr) {
+    if (!props.isDvr || props.isCasting) {
       return undefined;
     }
     return (


### PR DESCRIPTION
### Description of the Changes

Hide the progress bar for live DVR stream on chromecast.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
