### PR TITLE
fix(FEC-11151): quality dropdown is cropped when user clicks on ‘Quality’ settings on the player after scrolling down

### DIFF
--- a/src/components/shell/shell.js
+++ b/src/components/shell/shell.js
@@ -219,8 +219,8 @@ class Shell extends Component {
    */
   componentDidMount() {
     const {player, eventManager} = this.props;
-    eventManager.listen(document, 'scroll', debounce(this._onDocumentScroll, ON_PLAYER_RECT_CHANGE_DEBOUNCE_DELAY));
     eventManager.listen(window, 'resize', debounce(this._onWindowResize, ON_PLAYER_RECT_CHANGE_DEBOUNCE_DELAY));
+    eventManager.listen(document, 'scroll', debounce(this._updatePlayerClientRect, ON_PLAYER_RECT_CHANGE_DEBOUNCE_DELAY));
     this._playerResizeWatcher = new ResizeWatcher();
     this._playerResizeWatcher.init(document.getElementById(this.props.targetId));
     eventManager.listen(this._playerResizeWatcher, FakeEvent.Type.RESIZE, debounce(this._onWindowResize, ON_PLAYER_RECT_CHANGE_DEBOUNCE_DELAY));
@@ -242,27 +242,17 @@ class Shell extends Component {
   };
 
   /**
-   * document scroll handler
-   *
-   * @returns {void}
-   * @memberof Shell
-   */
-  _onDocumentScroll = () => {
-    this._updatePlayerClientRect();
-  };
-
-  /**
    * update the player rect
    *
    * @returns {void}
    * @memberof Shell
    */
-  _updatePlayerClientRect(): void {
+  _updatePlayerClientRect = () => {
     const playerContainer = document.getElementById(this.props.targetId);
     if (playerContainer) {
       this.props.updatePlayerClientRect(playerContainer.getBoundingClientRect());
     }
-  }
+  };
 
   /**
    * before component mounted, remove event listeners

--- a/src/components/shell/shell.js
+++ b/src/components/shell/shell.js
@@ -219,29 +219,11 @@ class Shell extends Component {
    */
   componentDidMount() {
     const {player, eventManager} = this.props;
-    eventManager.listen(
-      document,
-      'scroll',
-      debounce(() => {
-        this._onDocumentScroll();
-      }, ON_PLAYER_RECT_CHANGE_DEBOUNCE_DELAY)
-    );
-    eventManager.listen(
-      window,
-      'resize',
-      debounce(() => {
-        this._onWindowResize();
-      }, ON_PLAYER_RECT_CHANGE_DEBOUNCE_DELAY)
-    );
+    eventManager.listen(document, 'scroll', debounce(this._onDocumentScroll, ON_PLAYER_RECT_CHANGE_DEBOUNCE_DELAY));
+    eventManager.listen(window, 'resize', debounce(this._onWindowResize, ON_PLAYER_RECT_CHANGE_DEBOUNCE_DELAY));
     this._playerResizeWatcher = new ResizeWatcher();
     this._playerResizeWatcher.init(document.getElementById(this.props.targetId));
-    eventManager.listen(
-      this._playerResizeWatcher,
-      FakeEvent.Type.RESIZE,
-      debounce(() => {
-        this._onWindowResize();
-      }, ON_PLAYER_RECT_CHANGE_DEBOUNCE_DELAY)
-    );
+    eventManager.listen(this._playerResizeWatcher, FakeEvent.Type.RESIZE, debounce(this._onWindowResize, ON_PLAYER_RECT_CHANGE_DEBOUNCE_DELAY));
     eventManager.listen(player, player.Event.FIRST_PLAY, () => this._onWindowResize());
     this._onWindowResize();
   }
@@ -252,12 +234,12 @@ class Shell extends Component {
    * @returns {void}
    * @memberof Shell
    */
-  _onWindowResize(): void {
+  _onWindowResize = () => {
     this._updatePlayerClientRect();
     if (document.body) {
       this.props.updateDocumentWidth(document.body.clientWidth);
     }
-  }
+  };
 
   /**
    * document scroll handler
@@ -265,9 +247,9 @@ class Shell extends Component {
    * @returns {void}
    * @memberof Shell
    */
-  _onDocumentScroll(): void {
+  _onDocumentScroll = () => {
     this._updatePlayerClientRect();
-  }
+  };
 
   /**
    * update the player rect


### PR DESCRIPTION
### Description of the Changes

update the player client rect on document.scroll event

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
