### PR TITLE
fix(FEC-10980): Video tracks selection miss active flag

### DIFF
--- a/src/components/settings/settings.js
+++ b/src/components/settings/settings.js
@@ -233,10 +233,10 @@ class Settings extends Component {
     const arrLength = qualities.length - 1;
     const previousTrack = qualities[arrLength];
     if (arrLength > -1 && currentTrack.label === previousTrack.label) {
+      currentTrack.active = previousTrack.active || currentTrack.active;
       if (currentTrack.bandwidth > previousTrack.bandwidth) {
         qualities[arrLength] = currentTrack;
       }
-      qualities[arrLength].active = previousTrack.active || currentTrack.active;
     } else {
       qualities.push(currentTrack);
     }

--- a/src/components/settings/settings.js
+++ b/src/components/settings/settings.js
@@ -233,7 +233,7 @@ class Settings extends Component {
     const arrLength = qualities.length - 1;
     const previousTrack = qualities[arrLength];
     if (arrLength > -1 && currentTrack.label === previousTrack.label) {
-      currentTrack.active = previousTrack.active || currentTrack.active;
+      currentTrack.active = currentTrack.active || previousTrack.active;
       if (currentTrack.bandwidth > previousTrack.bandwidth) {
         qualities[arrLength] = currentTrack;
       }

--- a/src/components/settings/settings.js
+++ b/src/components/settings/settings.js
@@ -236,6 +236,7 @@ class Settings extends Component {
       if (currentTrack.bandwidth > previousTrack.bandwidth) {
         qualities[arrLength] = currentTrack;
       }
+      qualities[arrLength].active = previousTrack.active || currentTrack.active;
     } else {
       qualities.push(currentTrack);
     }


### PR DESCRIPTION
### Description of the Changes

Issue: doesn't keep the active flag after changing filtering unique values.
Solution: keep the active flag for the same quality.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
