### PR TITLE
fix(FEC-11260): if set abrEnabled=false, auto mode still remains enabled - HLS

### DIFF
--- a/src/components/settings/settings.js
+++ b/src/components/settings/settings.js
@@ -233,10 +233,10 @@ class Settings extends Component {
     const arrLength = qualities.length - 1;
     const previousTrack = qualities[arrLength];
     if (arrLength > -1 && currentTrack.label === previousTrack.label) {
-      currentTrack.active = currentTrack.active || previousTrack.active;
       if (currentTrack.bandwidth > previousTrack.bandwidth) {
         qualities[arrLength] = currentTrack;
       }
+      qualities[arrLength].active = currentTrack.active || previousTrack.active;
     } else {
       qualities.push(currentTrack);
     }


### PR DESCRIPTION
### Description of the Changes

Issue: UI doesn't reflect changes when two bitrates with the same height and the lowest selected.
Solution: always set the active flag if one of them is active to array after filter.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
