### PR TITLE
fix(FEC-11392): document.querySelector breaks

### DIFF
--- a/src/components/language/language.js
+++ b/src/components/language/language.js
@@ -212,7 +212,8 @@ class Language extends Component {
    * @memberof Language
    */
   renderAll(audioOptions: Array<Object>, textOptions: Array<Object>): React$Element<any> {
-    const portalSelector = `#${this.props.player.config.targetId} .overlay-portal`;
+    const targetId = document.getElementById(this.props.player.config.targetId);
+    const portalSelector = `.overlay-portal`;
     return (
       <ButtonControl name={COMPONENT_NAME} ref={c => (c ? (this._controlLanguageElement = c) : undefined)}>
         <Tooltip label={this.props.buttonLabel}>
@@ -252,7 +253,7 @@ class Language extends Component {
             )}
           </SmartContainer>
         )}
-        {this.state.cvaaOverlay ? createPortal(<CVAAOverlay onClose={this.onCVAAOverlayClose} />, document.querySelector(portalSelector)) : <div />}
+        {this.state.cvaaOverlay ? createPortal(<CVAAOverlay onClose={this.onCVAAOverlayClose} />, targetId.querySelector(portalSelector)) : <div />}
       </ButtonControl>
     );
   }

--- a/src/components/language/language.js
+++ b/src/components/language/language.js
@@ -212,7 +212,7 @@ class Language extends Component {
    * @memberof Language
    */
   renderAll(audioOptions: Array<Object>, textOptions: Array<Object>): React$Element<any> {
-    const targetId = document.getElementById(this.props.player.config.targetId);
+    const targetId = document.getElementById(this.props.player.config.targetId) || document;
     const portalSelector = `.overlay-portal`;
     return (
       <ButtonControl name={COMPONENT_NAME} ref={c => (c ? (this._controlLanguageElement = c) : undefined)}>

--- a/src/components/smart-container/smart-container.js
+++ b/src/components/smart-container/smart-container.js
@@ -89,7 +89,7 @@ class SmartContainer extends Component {
    * @memberof SmartContainer
    */
   render(props: any): React$Element<any> {
-    const targetId = document.getElementById(this.props.targetId);
+    const targetId = document.getElementById(this.props.targetId) || document;
     const portalSelector = `.overlay-portal`;
     props.clearAccessibleChildren();
     return this.isPortal ? (

--- a/src/components/smart-container/smart-container.js
+++ b/src/components/smart-container/smart-container.js
@@ -89,7 +89,8 @@ class SmartContainer extends Component {
    * @memberof SmartContainer
    */
   render(props: any): React$Element<any> {
-    const portalSelector = `#${this.props.targetId} .overlay-portal`;
+    const targetId = document.getElementById(this.props.targetId);
+    const portalSelector = `.overlay-portal`;
     props.clearAccessibleChildren();
     return this.isPortal ? (
       createPortal(
@@ -97,7 +98,7 @@ class SmartContainer extends Component {
           <div className={style.title}>{props.title}</div>
           {this.renderChildren(props)}
         </Overlay>,
-        document.querySelector(portalSelector)
+        targetId.querySelector(portalSelector)
       )
     ) : (
       <div onKeyDown={props.handleKeyDown} tabIndex="-1" className={[style.smartContainer, style.top, style.left].join(' ')}>


### PR DESCRIPTION
### Description of the Changes

Issue: document.querySelector doesn't work correctly when element id contains query chars.
Solution: get element by id and make the query.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
