### PR TITLE
fix(FEC-11489): V3 - the bottom bar broken for next media in the playlist - regression bug

### DIFF
--- a/src/components/settings/settings.js
+++ b/src/components/settings/settings.js
@@ -250,10 +250,10 @@ class Settings extends Component {
   }
 
   /**
-   * Determines the badge icon type of the quality option based of the height resolution.
+   * Determines the badge icon type of the quality option based on the height of the resolution.
    *
-   * @param {number} videoTrackHeight - video track quality height.
-   * @returns {Component<Badge>} - the badge icon type.
+   * @param {number} videoTrackHeight - video track resolution height.
+   * @returns {string | null} - the badge icon type or null depends on the resolution height.
    * @memberof Settings
    */
   getLabelBadgeType(videoTrackHeight: number): string | null {
@@ -269,13 +269,13 @@ class Settings extends Component {
   }
 
   /**
-   * returns The badge icon type of the active quality option based of the height resolution
+   * returns The badge icon type of the active quality option based on the height of the resolution
    *
-   * @returns {string} - the badge icon type.
-   * @memberof DropDown
+   * @returns {string | null} - the badge icon type or null depends on the resolution height.
+   * @memberof Settings
    */
   getButtonBadgeType(): string | null {
-    const activeVideoTrackHeight: Object = this.props.player.getActiveTracks().video.height;
+    const activeVideoTrackHeight: Object = this.props.player.getActiveTracks()?.video?.height;
     return activeVideoTrackHeight ? this.getLabelBadgeType(activeVideoTrackHeight) : null;
   }
 


### PR DESCRIPTION


### Description of the Changes

The bottom bar broken for next media in the playlist  
The bottom bar broken, part of the icons don't exist and when click on other, nothing happens

bug: this.props.player.getActiveTracks().video is null when switching between playlist items in settings.js
fix: add check

solves: (FEC-11489)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
