### PR TITLE
fix:(FEC-10962): The player's skin should not disappear after clicking on the control bar's buttons (even when the mouse wasn't moved for a few seconds)

### DIFF
--- a/src/components/bottom-bar/_bottom-bar.scss
+++ b/src/components/bottom-bar/_bottom-bar.scss
@@ -80,7 +80,7 @@
 }
 
 .player.casting,
-.player.metadata-loaded:hover,
+.player.metadata-loaded.hover,
 .player.state-paused,
 .player.state-idle,
 .player.ad-break,

--- a/src/components/bottom-bar/_bottom-bar.scss
+++ b/src/components/bottom-bar/_bottom-bar.scss
@@ -80,7 +80,7 @@
 }
 
 .player.casting,
-.player.metadata-loaded.hover,
+.player.metadata-loaded:hover,
 .player.state-paused,
 .player.state-idle,
 .player.ad-break,

--- a/src/components/shell/shell.js
+++ b/src/components/shell/shell.js
@@ -226,8 +226,7 @@ class Shell extends Component {
     eventManager.listen(this._playerResizeWatcher, FakeEvent.Type.RESIZE, debounce(this._onWindowResize, ON_PLAYER_RECT_CHANGE_DEBOUNCE_DELAY));
     eventManager.listen(player, player.Event.FIRST_PLAY, () => this._onWindowResize());
     this._onWindowResize();
-    eventManager.listen(player, FakeEvent.Type.USER_CLICKED_FORWARD, () => this._startHoverTimeout())
-    eventManager.listen(player, FakeEvent.Type.USER_CLICKED_REWIND, () => this._startHoverTimeout());
+    this._initRecountHoverStateOnUserInteraction();
   }
 
   /**
@@ -242,6 +241,21 @@ class Shell extends Component {
       this.props.updateDocumentWidth(document.body.clientWidth);
     }
   };
+
+  /**
+   * Listening to some common user actions and reset the hover state accordingly
+   * so that the controls-bar does not disappear while interacting.
+   *
+   * @returns {void}
+   * @memberof Shell
+   */
+  _initRecountHoverStateOnUserInteraction(): void {
+    const {player, eventManager} = this.props;
+    eventManager.listen(player, FakeEvent.Type.USER_CLICKED_FORWARD, () => this._startHoverTimeout());
+    eventManager.listen(player, FakeEvent.Type.USER_CLICKED_REWIND, () => this._startHoverTimeout());
+    eventManager.listen(player, FakeEvent.Type.USER_ENTERED_PICTURE_IN_PICTURE, () => this._startHoverTimeout());
+    eventManager.listen(player, FakeEvent.Type.USER_EXITED_PICTURE_IN_PICTURE, () => this._startHoverTimeout());
+  }
 
   /**
    * update the player rect

--- a/src/components/shell/shell.js
+++ b/src/components/shell/shell.js
@@ -226,6 +226,8 @@ class Shell extends Component {
     eventManager.listen(this._playerResizeWatcher, FakeEvent.Type.RESIZE, debounce(this._onWindowResize, ON_PLAYER_RECT_CHANGE_DEBOUNCE_DELAY));
     eventManager.listen(player, player.Event.FIRST_PLAY, () => this._onWindowResize());
     this._onWindowResize();
+    eventManager.listen(player, FakeEvent.Type.USER_CLICKED_FORWARD, () => this._startHoverTimeout())
+    eventManager.listen(player, FakeEvent.Type.USER_CLICKED_REWIND, () => this._startHoverTimeout());
   }
 
   /**

--- a/src/components/shell/shell.js
+++ b/src/components/shell/shell.js
@@ -226,7 +226,7 @@ class Shell extends Component {
     eventManager.listen(this._playerResizeWatcher, FakeEvent.Type.RESIZE, debounce(this._onWindowResize, ON_PLAYER_RECT_CHANGE_DEBOUNCE_DELAY));
     eventManager.listen(player, player.Event.FIRST_PLAY, () => this._onWindowResize());
     this._onWindowResize();
-    this._initRecountHoverStateOnUserInteraction();
+    eventManager.listen(player, FakeEvent.Type.UI_CLICKED, () => this._startHoverTimeout());
   }
 
   /**
@@ -241,21 +241,6 @@ class Shell extends Component {
       this.props.updateDocumentWidth(document.body.clientWidth);
     }
   };
-
-  /**
-   * Listening to some common user actions and reset the hover state accordingly
-   * so that the controls-bar does not disappear while interacting.
-   *
-   * @returns {void}
-   * @memberof Shell
-   */
-  _initRecountHoverStateOnUserInteraction(): void {
-    const {player, eventManager} = this.props;
-    eventManager.listen(player, FakeEvent.Type.USER_CLICKED_FORWARD, () => this._startHoverTimeout());
-    eventManager.listen(player, FakeEvent.Type.USER_CLICKED_REWIND, () => this._startHoverTimeout());
-    eventManager.listen(player, FakeEvent.Type.USER_ENTERED_PICTURE_IN_PICTURE, () => this._startHoverTimeout());
-    eventManager.listen(player, FakeEvent.Type.USER_EXITED_PICTURE_IN_PICTURE, () => this._startHoverTimeout());
-  }
 
   /**
    * update the player rect

--- a/src/components/shell/shell.js
+++ b/src/components/shell/shell.js
@@ -142,6 +142,7 @@ class Shell extends Component {
   onMouseUp = (): void => {
     this.unMuteFallback();
     this.props.notifyClick();
+    this._startHoverTimeout();
   };
 
   /**
@@ -226,7 +227,6 @@ class Shell extends Component {
     eventManager.listen(this._playerResizeWatcher, FakeEvent.Type.RESIZE, debounce(this._onWindowResize, ON_PLAYER_RECT_CHANGE_DEBOUNCE_DELAY));
     eventManager.listen(player, player.Event.FIRST_PLAY, () => this._onWindowResize());
     this._onWindowResize();
-    eventManager.listen(player, FakeEvent.Type.UI_CLICKED, () => this._startHoverTimeout());
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes
issue: hover state timer of 3 seconds restarting just on mouse-move event
fix: reset the timer on general ui-click event
solves: FEC-10962

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
