### PR TITLE
fix(FEC-11517): CVAA - dropdown lists for captions style don't open - regression

### DIFF
--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -126,7 +126,7 @@ class DropDown extends Component {
    */
   getActiveOption(): Object {
     const activeOption = this.props.options.find(option => option.active);
-    return activeOption ? activeOption : {label: 'Unlabled'};
+    return activeOption ? activeOption : this.props.options[0] || {label: 'Unlabled'};
   }
 
   /**

--- a/src/styles/_dropdown.scss
+++ b/src/styles/_dropdown.scss
@@ -12,6 +12,7 @@
 }
 
 .dropdown {
+  position: relative;
   font-size: 15px;
 
   .label-badge {


### PR DESCRIPTION
### Description of the Changes

restore the remove css properties in dropdown.scss and fallback label in dropdown.js

fix: FEC-11517

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
