### PR TITLE
fix:(FEC-11358): Floating player - basic playback - Float window moves while seeking

### DIFF
--- a/src/components/seekbar/seekbar.js
+++ b/src/components/seekbar/seekbar.js
@@ -135,6 +135,7 @@ class SeekBar extends Component {
       return;
     }
     e.preventDefault(); // fixes firefox mouseup not firing after dragging the scrubber
+    e.stopPropagation(); // prevent dragging while visibility plugin registered and configured to floating
     this.props.updateSeekbarDraggingStatus(true);
     if (this.props.isDraggingActive) {
       let time = this.getTime(e);

--- a/src/components/seekbar/seekbar.js
+++ b/src/components/seekbar/seekbar.js
@@ -135,7 +135,7 @@ class SeekBar extends Component {
       return;
     }
     e.preventDefault(); // fixes firefox mouseup not firing after dragging the scrubber
-    e.stopPropagation(); // prevent dragging while visibility plugin registered and configured to floating
+    e.stopPropagation(); // prevent other dragging effects
     this.props.updateSeekbarDraggingStatus(true);
     if (this.props.isDraggingActive) {
       let time = this.getTime(e);


### PR DESCRIPTION
### Description of the Changes

issue : the visibility plugin and seekbar component both listening to mousedown event, while visibility plugin 
            which configured by default with draggable true, drag the player element.
fix: stop the mousedown event propagation as long as is fired from seekbar area

solves: FEC-11358

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
