### PR TITLE
fix(FEC-11520): Multi dropdowns are openable in cvaa overlay

### DIFF
--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -51,6 +51,10 @@ class DropDown extends Component {
     }
   }
 
+  componentWillUnmount(): void {
+    console.error('');
+  }
+
   /**
    * is given option selected
    *
@@ -82,8 +86,8 @@ class DropDown extends Component {
    * @memberof DropDown
    */
   onClick = (e: Event): void => {
-    e.stopPropagation();
     this.toggleDropDown();
+    setTimeout(() => this.toggleDropDown(), 0);
   };
 
   /**


### PR DESCRIPTION
### Description of the Changes

issue: the stop propagation (on dropdown click event) prevent the close menus logic handler (which trigerd by docoment click listener) to be trigerd.

fix: remove the soop propagation and move the toggle dropdoen to be happen in the nextt event loop.

sovles: FEC-11520

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
