### PR TITLE
fix(FEC-11510): No default font size selected in cvaa

### DIFF
--- a/src/components/cvaa-overlay/custom-captions-window.js
+++ b/src/components/cvaa-overlay/custom-captions-window.js
@@ -61,10 +61,10 @@ class CustomCaptionsWindow extends Component {
     const edgeStyles = player.TextStyle.EdgeStyles;
     const standardColors = player.TextStyle.StandardColors;
 
-    const fontScaleOptions = player.TextStyle.FontSizes.map(scale => ({
-      value: scale.label,
-      label: scale.label,
-      active: props.customTextStyle.fontSize === scale.label
+    const fontSizeOptions = player.TextStyle.FontSizes.map(size => ({
+      value: size.label,
+      label: size.label,
+      active: props.customTextStyle.fontSize === size.label
     }));
 
     const fontColorOptions = Object.keys(standardColors).map(key => ({
@@ -97,7 +97,7 @@ class CustomCaptionsWindow extends Component {
           <DropDownCaptionsStyle
             addAccessibleChild={props.addAccessibleChild}
             labelId="cvaa.size_label"
-            options={fontScaleOptions}
+            options={fontSizeOptions}
             classNames={[style.formGroupRow, style.fontSize]}
             styleName="fontSize"
             changeCustomStyle={props.changeCustomStyle}

--- a/src/components/cvaa-overlay/custom-captions-window.js
+++ b/src/components/cvaa-overlay/custom-captions-window.js
@@ -62,9 +62,9 @@ class CustomCaptionsWindow extends Component {
     const standardColors = player.TextStyle.StandardColors;
 
     const fontScaleOptions = player.TextStyle.FontSizes.map(scale => ({
-      value: scale.value,
+      value: scale.label,
       label: scale.label,
-      active: props.customTextStyle.fontScale === scale.value
+      active: props.customTextStyle.fontSize === scale.label
     }));
 
     const fontColorOptions = Object.keys(standardColors).map(key => ({
@@ -99,7 +99,7 @@ class CustomCaptionsWindow extends Component {
             labelId="cvaa.size_label"
             options={fontScaleOptions}
             classNames={[style.formGroupRow, style.fontSize]}
-            styleName="fontScale"
+            styleName="fontSize"
             changeCustomStyle={props.changeCustomStyle}
           />
           <DropDownCaptionsStyle


### PR DESCRIPTION
### Description of the Changes

Use fontSize instead of fontScale.
Fixes FEC-11510.

Related PRs: 
https://github.com/kaltura/playkit-js/pull/603
https://github.com/kaltura/kaltura-player-js/pull/491

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
