### PR TITLE
fix(FEC-11156): cast button appears for one player only when multiple players configured on the page and casting failed

### DIFF
--- a/flow-typed/modules/kaltura-player-js.js
+++ b/flow-typed/modules/kaltura-player-js.js
@@ -1,0 +1,3 @@
+declare module 'kaltura-player-js' {
+  declare module.exports: any;
+}

--- a/src/components/cast-on-tv/cast-before-play.js
+++ b/src/components/cast-on-tv/cast-before-play.js
@@ -9,6 +9,7 @@ import {Localizer, Text} from 'preact-i18n';
 import {withPlayer} from '../player';
 import {withLogger} from 'components/logger';
 import {Button} from 'components/button';
+import {cast} from 'kaltura-player-js';
 
 /**
  * mapping state to props
@@ -53,8 +54,7 @@ class CastBeforePlay extends Component {
    */
   onClick = (): void => {
     this.props.updateBackdropVisibility(true);
-    const castType = window.KalturaPlayer.cast.RemotePlayerType.CHROMECAST;
-    this.props.player.startCasting(castType).catch(() => this.props.updateBackdropVisibility(false));
+    this.props.player.startCasting(cast.RemotePlayerType.CHROMECAST).catch(() => this.props.updateBackdropVisibility(false));
   };
 
   /**

--- a/src/components/cast-on-tv/cast-before-play.js
+++ b/src/components/cast-on-tv/cast-before-play.js
@@ -52,7 +52,6 @@ class CastBeforePlay extends Component {
    * @memberof CastBeforePlay
    */
   onClick = (): void => {
-    this.props.player.setIsCastInitiator(true);
     this.props.updateBackdropVisibility(true);
     this.props.player.startCasting().catch(() => this.props.updateBackdropVisibility(false));
   };

--- a/src/components/cast-on-tv/cast-before-play.js
+++ b/src/components/cast-on-tv/cast-before-play.js
@@ -53,7 +53,8 @@ class CastBeforePlay extends Component {
    */
   onClick = (): void => {
     this.props.updateBackdropVisibility(true);
-    this.props.player.startCasting(this.props.player.RemotePlayerType.CHROMECAST).catch(() => this.props.updateBackdropVisibility(false));
+    const castType = window.KalturaPlayer.cast.RemotePlayerType.CHROMECAST;
+    this.props.player.startCasting(castType).catch(() => this.props.updateBackdropVisibility(false));
   };
 
   /**

--- a/src/components/cast-on-tv/cast-before-play.js
+++ b/src/components/cast-on-tv/cast-before-play.js
@@ -52,6 +52,7 @@ class CastBeforePlay extends Component {
    * @memberof CastBeforePlay
    */
   onClick = (): void => {
+    this.props.player.setIsCastInitiator(true);
     this.props.updateBackdropVisibility(true);
     this.props.player.startCasting().catch(() => this.props.updateBackdropVisibility(false));
   };

--- a/src/components/cast-on-tv/cast-before-play.js
+++ b/src/components/cast-on-tv/cast-before-play.js
@@ -53,7 +53,7 @@ class CastBeforePlay extends Component {
    */
   onClick = (): void => {
     this.props.updateBackdropVisibility(true);
-    this.props.player.startCasting().catch(() => this.props.updateBackdropVisibility(false));
+    this.props.player.startCasting(this.props.player.RemotePlayerType.CHROMECAST).catch(() => this.props.updateBackdropVisibility(false));
   };
 
   /**

--- a/src/components/cast/cast.js
+++ b/src/components/cast/cast.js
@@ -9,6 +9,7 @@ import {withEventManager} from 'event/with-event-manager';
 import {withLogger} from 'components/logger';
 import {Tooltip} from 'components/tooltip';
 import {withText} from 'preact-i18n';
+import {cast} from 'kaltura-player-js';
 
 /**
  * mapping state to props
@@ -42,8 +43,7 @@ class Cast extends Component {
    * @returns {void}
    */
   onClick = (): void => {
-    const castType = window.KalturaPlayer.cast.RemotePlayerType.CHROMECAST;
-    this.props.player.setIsCastInitiator(castType, true);
+    this.props.player.setIsCastInitiator(cast.RemotePlayerType.CHROMECAST, true);
     this.props.updateBackdropVisibility(true);
     this.props.eventManager.listenOnce(this.props.player, this.props.player.Event.Cast.CAST_SESSION_START_FAILED, () =>
       this.props.updateBackdropVisibility(false)
@@ -60,8 +60,7 @@ class Cast extends Component {
   onKeyDown = (e: KeyboardEvent): void => {
     if (e.keyCode === KeyMap.ENTER) {
       this.props.updateBackdropVisibility(true);
-      const castType = window.KalturaPlayer.cast.RemotePlayerType.CHROMECAST;
-      this.props.player.startCasting(castType).catch(() => this.props.updateBackdropVisibility(false));
+      this.props.player.startCasting(cast.RemotePlayerType.CHROMECAST).catch(() => this.props.updateBackdropVisibility(false));
     }
   };
 

--- a/src/components/cast/cast.js
+++ b/src/components/cast/cast.js
@@ -42,6 +42,7 @@ class Cast extends Component {
    * @returns {void}
    */
   onClick = (): void => {
+    this.props.player.setIsCastInitiator(true);
     this.props.updateBackdropVisibility(true);
     this.props.eventManager.listenOnce(this.props.player, this.props.player.Event.Cast.CAST_SESSION_START_FAILED, () =>
       this.props.updateBackdropVisibility(false)

--- a/src/components/cast/cast.js
+++ b/src/components/cast/cast.js
@@ -42,7 +42,7 @@ class Cast extends Component {
    * @returns {void}
    */
   onClick = (): void => {
-    this.props.player.setIsCastInitiator(true);
+    this.props.player.setIsCastInitiator(this.props.player.RemotePlayerType.CHROMECAST, true);
     this.props.updateBackdropVisibility(true);
     this.props.eventManager.listenOnce(this.props.player, this.props.player.Event.Cast.CAST_SESSION_START_FAILED, () =>
       this.props.updateBackdropVisibility(false)
@@ -59,7 +59,7 @@ class Cast extends Component {
   onKeyDown = (e: KeyboardEvent): void => {
     if (e.keyCode === KeyMap.ENTER) {
       this.props.updateBackdropVisibility(true);
-      this.props.player.startCasting().catch(() => this.props.updateBackdropVisibility(false));
+      this.props.player.startCasting(this.props.player.RemotePlayerType.CHROMECAST).catch(() => this.props.updateBackdropVisibility(false));
     }
   };
 

--- a/src/components/cast/cast.js
+++ b/src/components/cast/cast.js
@@ -42,7 +42,8 @@ class Cast extends Component {
    * @returns {void}
    */
   onClick = (): void => {
-    this.props.player.setIsCastInitiator(this.props.player.RemotePlayerType.CHROMECAST, true);
+    const castType = window.KalturaPlayer.cast.RemotePlayerType.CHROMECAST;
+    this.props.player.setIsCastInitiator(castType, true);
     this.props.updateBackdropVisibility(true);
     this.props.eventManager.listenOnce(this.props.player, this.props.player.Event.Cast.CAST_SESSION_START_FAILED, () =>
       this.props.updateBackdropVisibility(false)
@@ -59,7 +60,8 @@ class Cast extends Component {
   onKeyDown = (e: KeyboardEvent): void => {
     if (e.keyCode === KeyMap.ENTER) {
       this.props.updateBackdropVisibility(true);
-      this.props.player.startCasting(this.props.player.RemotePlayerType.CHROMECAST).catch(() => this.props.updateBackdropVisibility(false));
+      const castType = window.KalturaPlayer.cast.RemotePlayerType.CHROMECAST;
+      this.props.player.startCasting(castType).catch(() => this.props.updateBackdropVisibility(false));
     }
   };
 

--- a/src/components/seekbar/seekbar.js
+++ b/src/components/seekbar/seekbar.js
@@ -135,6 +135,7 @@ class SeekBar extends Component {
       return;
     }
     e.preventDefault(); // fixes firefox mouseup not firing after dragging the scrubber
+    e.stopPropagation(); // prevent other dragging effects
     this.props.updateSeekbarDraggingStatus(true);
     if (this.props.isDraggingActive) {
       let time = this.getTime(e);


### PR DESCRIPTION
### Description of the Changes

Add call for setIsCastInitiator to mark which in player the cast button was clicked
Fixes FEC-11156

Related PRs:
https://github.com/kaltura/kaltura-player-js/pull/495
https://github.com/kaltura/playkit-js-cast-sender/pull/70

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
