### PR TITLE
fix(FEC-11733): Hide mouse cursor when it's idle in fullscreen

### DIFF
--- a/src/styles/_shell.scss
+++ b/src/styles/_shell.scss
@@ -11,6 +11,7 @@
   -ms-user-select: none;
   user-select: none;
   -webkit-tap-highlight-color: transparent;
+  cursor: none;
 
   .playback-gui-wrapper,
   .ad-gui-wrapper {
@@ -89,4 +90,14 @@
     -webkit-transform: translateY(-$default-hovering-offset);
     -ms-transform: translateY(-$default-hovering-offset);
   }
+}
+
+.player.casting,
+.player.metadata-loaded.hover,
+.player.state-paused,
+.player.state-idle,
+.player.ad-break,
+.player.menu-active,
+.player.overlay-active {
+    cursor: auto;
 }


### PR DESCRIPTION
### Description of the Changes

use the same technique like we use to hide the bottom bar and use the css classes representing the player state to toggle the cursor (hide and show it along with the bottom bar)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
