### PR TITLE
fix(FEC-11933): if seek with the mouse, the scrubber position doesn't match with the cursor

### DIFF
--- a/src/components/seekbar/seekbar.js
+++ b/src/components/seekbar/seekbar.js
@@ -423,7 +423,8 @@ class SeekBar extends Component {
     const xPosition = typeof e.clientX === 'number' ? e.clientX : e.changedTouches && e.changedTouches[0] && e.changedTouches[0].clientX;
     let time =
       this.props.duration *
-      ((xPosition - this._seekBarElement.offsetLeft - this.getOffset(this.props.playerElement).left) / this._seekBarElement.clientWidth);
+      ((xPosition - (this._seekBarElement.offsetParent?.offsetLeft || 0) - this.getOffset(this.props.playerElement).left) /
+        this._seekBarElement.clientWidth);
     time = parseFloat(time.toFixed(2));
     if (time < 0) {
       return 0;

--- a/src/components/seekbar/seekbar.js
+++ b/src/components/seekbar/seekbar.js
@@ -423,7 +423,9 @@ class SeekBar extends Component {
     const xPosition = typeof e.clientX === 'number' ? e.clientX : e.changedTouches && e.changedTouches[0] && e.changedTouches[0].clientX;
     let time =
       this.props.duration *
-      ((xPosition - (this._seekBarElement.offsetParent?.offsetLeft || 0) - this.getOffset(this.props.playerElement).left) /
+      ((xPosition -
+        (this._seekBarElement.offsetParent instanceof HTMLElement ? this._seekBarElement.offsetParent.offsetLeft : 0) -
+        this.getOffset(this.props.playerElement).left) /
         this._seekBarElement.clientWidth);
     time = parseFloat(time.toFixed(2));
     if (time < 0) {


### PR DESCRIPTION
### Description of the Changes

the seekbar moved (https://github.com/kaltura/playkit-js-ui/pull/653) into the bottom bar area so need to take the offset from its parent

Solves FEC-11933

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
