### PR TITLE
fix(FEC-11922): Live indicator on progress bar skips back and forward

### DIFF
--- a/src/components/engine-connector/engine-connector.js
+++ b/src/components/engine-connector/engine-connector.js
@@ -38,6 +38,7 @@ class EngineConnector extends Component {
       this.props.updateCurrentTime(0);
       this.props.updateIsIdle(true);
       this.props.updateIsPlaybackStarted(false);
+      this.props.updateDataLoadingStatus(false);
     });
 
     eventManager.listen(player, player.Event.SOURCE_SELECTED, () => {
@@ -88,6 +89,7 @@ class EngineConnector extends Component {
     eventManager.listen(player, player.Event.LOADED_DATA, () => {
       this.props.updateDuration(player.isLive() ? player.liveDuration : player.duration);
       this.props.updatePictureInPictureSupport(player.isPictureInPictureSupported());
+      this.props.updateDataLoadingStatus(true);
     });
 
     eventManager.listen(player, player.Event.LOADED_METADATA, () => {

--- a/src/components/seekbar-live-playback-container/seekbar-live-playback-container.js
+++ b/src/components/seekbar-live-playback-container/seekbar-live-playback-container.js
@@ -84,7 +84,7 @@ class SeekBarLivePlaybackContainer extends Component {
    * @memberof SeekBarLivePlaybackContainer
    */
   render(props: any) {
-    if (!props.isDvr || !props.dataLoaded) {
+    if (!props.isDvr) {
       return undefined;
     }
     return (
@@ -112,6 +112,7 @@ class SeekBarLivePlaybackContainer extends Component {
         isMobile={this.props.isMobile}
         notifyChange={payload => this.props.notifyChange(payload)}
         forceFullProgress={this.props.player.isOnLiveEdge()}
+        dataLoaded={this.props.dataLoaded}
       />
     );
   }

--- a/src/components/seekbar-live-playback-container/seekbar-live-playback-container.js
+++ b/src/components/seekbar-live-playback-container/seekbar-live-playback-container.js
@@ -20,7 +20,8 @@ const mapStateToProps = state => ({
   isDraggingActive: state.seekbar.draggingActive,
   isMobile: state.shell.isMobile,
   poster: state.engine.poster,
-  isDvr: state.engine.isDvr
+  isDvr: state.engine.isDvr,
+  dataLoaded: state.engine.dataLoaded
 });
 
 const COMPONENT_NAME = 'SeekBarLivePlaybackContainer';
@@ -54,14 +55,6 @@ class SeekBarLivePlaybackContainer extends Component {
     });
     eventManager.listen(player, player.Event.LOADED_DATA, () => {
       updateCurrentTime(Math.max(player.normalizedCurrentTime, 0));
-      this.setState({
-        show: true
-      });
-    });
-    eventManager.listen(player, player.Event.RESET, () => {
-      this.setState({
-        show: false
-      });
     });
   }
 
@@ -91,7 +84,7 @@ class SeekBarLivePlaybackContainer extends Component {
    * @memberof SeekBarLivePlaybackContainer
    */
   render(props: any) {
-    if (!props.isDvr || !this.state.show) {
+    if (!props.isDvr || !props.dataLoaded) {
       return undefined;
     }
     return (

--- a/src/components/seekbar-playback-container/seekbar-playback-container.js
+++ b/src/components/seekbar-playback-container/seekbar-playback-container.js
@@ -20,7 +20,8 @@ const mapStateToProps = state => ({
   duration: state.engine.duration,
   isDraggingActive: state.seekbar.draggingActive,
   isMobile: state.shell.isMobile,
-  poster: state.engine.poster
+  poster: state.engine.poster,
+  dataLoaded: state.engine.dataLoaded
 });
 
 const COMPONENT_NAME = 'SeekBarPlaybackContainer';
@@ -78,6 +79,7 @@ class SeekBarPlaybackContainer extends Component {
         isDraggingActive={this.props.isDraggingActive}
         isMobile={this.props.isMobile}
         notifyChange={payload => this.props.notifyChange(payload)}
+        dataLoaded={this.props.dataLoaded}
       />
     );
   }

--- a/src/components/seekbar/seekbar.js
+++ b/src/components/seekbar/seekbar.js
@@ -423,7 +423,8 @@ class SeekBar extends Component {
     const xPosition = typeof e.clientX === 'number' ? e.clientX : e.changedTouches && e.changedTouches[0] && e.changedTouches[0].clientX;
     let time =
       this.props.duration *
-      ((xPosition - this._seekBarElement.offsetLeft - this.getOffset(this.props.playerElement).left) / this._seekBarElement.clientWidth);
+      ((xPosition - (this._seekBarElement.offsetParent?.offsetLeft || 0) - this.getOffset(this.props.playerElement).left) /
+        this._seekBarElement.clientWidth);
     time = parseFloat(time.toFixed(2));
     if (time < 0) {
       return 0;

--- a/src/components/seekbar/seekbar.js
+++ b/src/components/seekbar/seekbar.js
@@ -423,7 +423,9 @@ class SeekBar extends Component {
     const xPosition = typeof e.clientX === 'number' ? e.clientX : e.changedTouches && e.changedTouches[0] && e.changedTouches[0].clientX;
     let time =
       this.props.duration *
-      ((xPosition - (this._seekBarElement.offsetParent?.offsetLeft || 0) - this.getOffset(this.props.playerElement).left) /
+      ((xPosition -
+        (this._seekBarElement.offsetParent instanceof HTMLElement ? this._seekBarElement.offsetParent.offsetLeft : 0) -
+        this.getOffset(this.props.playerElement).left) /
         this._seekBarElement.clientWidth);
     time = parseFloat(time.toFixed(2));
     if (time < 0) {

--- a/src/components/seekbar/seekbar.js
+++ b/src/components/seekbar/seekbar.js
@@ -583,9 +583,11 @@ class SeekBar extends Component {
             {this.renderFramePreview()}
             {this.renderTimeBubble()}
             <div className={style.buffered} style={{width: bufferedWidth}} />
-            <div className={style.progress} style={{width: progressWidth}}>
-              {props.adBreak ? undefined : <a className={style.scrubber} />}
-            </div>
+            {props.dataLoaded ? (
+              <div className={style.progress} style={{width: progressWidth}}>
+                {props.adBreak ? undefined : <a className={style.scrubber} />}
+              </div>
+            ) : undefined}
             <div className={style.virtualProgress} style={{width: virtualProgressWidth}}>
               <div className={style.virtualProgressIndicator} />
             </div>

--- a/src/reducers/engine.js
+++ b/src/reducers/engine.js
@@ -20,6 +20,7 @@ export const types = {
   UPDATE_VOLUME: `${component}/UPDATE_VOLUME`,
   UPDATE_MUTED: `${component}/UPDATE_MUTED`,
   UPDATE_METADATA_LOADING_STATUS: `${component}/UPDATE_METADATA_LOADING_STATUS`,
+  UPDATE_DATA_LOADING_STATUS: `${component}/UPDATE_DATA_LOADING_STATUS`,
   UPDATE_AUDIO_TRACKS: `${component}/UPDATE_AUDIO_TRACKS`,
   UPDATE_VIDEO_TRACKS: `${component}/UPDATE_VIDEO_TRACKS`,
   UPDATE_TEXT_TRACKS: `${component}/UPDATE_TEXT_TRACKS`,
@@ -61,6 +62,7 @@ export const initialState = {
   isChangingSource: false,
   prePlayback: true,
   metadataLoaded: false,
+  dataLoaded: false,
   playerState: {
     previousState: '',
     currentState: ''
@@ -197,6 +199,12 @@ export default (state: Object = initialState, action: Object) => {
       return {
         ...state,
         metadataLoaded: action.metadataLoaded
+      };
+
+    case types.UPDATE_DATA_LOADING_STATUS:
+      return {
+        ...state,
+        dataLoaded: action.dataLoaded
       };
 
     case types.UPDATE_AUDIO_TRACKS:
@@ -396,6 +404,10 @@ export const actions = {
   updateMetadataLoadingStatus: (metadataLoaded: boolean) => ({
     type: types.UPDATE_METADATA_LOADING_STATUS,
     metadataLoaded
+  }),
+  updateDataLoadingStatus: (dataLoaded: boolean) => ({
+    type: types.UPDATE_DATA_LOADING_STATUS,
+    dataLoaded
   }),
   updateAudioTracks: (tracks: Array<any>) => ({type: types.UPDATE_AUDIO_TRACKS, tracks}),
   updateVideoTracks: (tracks: Array<any>) => ({type: types.UPDATE_VIDEO_TRACKS, tracks}),


### PR DESCRIPTION
### Description of the Changes

hide the progress bar until LOADED_DATA event fired
use `normalizedCurrentTime` and `normalizedDuration` api's

Solves FEC-11922

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
