### PR TITLE
fix(FEC-12154): Playlist - Active Prev and Next buttons have no tooltip when player width <= 480px

### DIFF
--- a/src/components/playback-controls/_playback-controls.scss
+++ b/src/components/playback-controls/_playback-controls.scss
@@ -43,10 +43,6 @@
             width: 64px;
             height: 64px;
           }
-
-          .poster-preview {
-            opacity: 0;
-          }
         }
       }
     }

--- a/src/components/playback-controls/playback-controls.js
+++ b/src/components/playback-controls/playback-controls.js
@@ -70,9 +70,9 @@ class PlaybackControls extends Component {
         <PlayerArea name={name} shouldUpdate={shouldUpdate}>
           {props.playlist ? (
             <Fragment>
-              <PlaylistButton type="prev" />
+              <PlaylistButton type="prev" showPreview={props.showPreview} />
               <PlayPause />
-              <PlaylistButton type="next" />
+              <PlaylistButton type="next" showPreview={props.showPreview} />
             </Fragment>
           ) : (
             <PlayPause />

--- a/src/components/playlist-button/playlist-button.js
+++ b/src/components/playlist-button/playlist-button.js
@@ -44,7 +44,7 @@ class PlaylistButton extends Component {
    */
   render(props: any): React$Element<any> | void {
     const item = props.playlist[props.type];
-    return <PrevNext type={props.type} item={item} onClick={this.onClick.bind(this)} />;
+    return <PrevNext type={props.type} item={item} onClick={this.onClick.bind(this)} showPreview={props.showPreview} />;
   }
 }
 

--- a/src/components/playlist-button/prev-next.js
+++ b/src/components/playlist-button/prev-next.js
@@ -34,7 +34,7 @@ class PrevNext extends Component {
 
     return (
       <div className={[style.controlButtonContainer, style.controlPlaylistButton].join(' ')}>
-        {previewImage || previewText ? (
+        {props.showPreview && (previewImage || previewText) ? (
           <Fragment>
             <div className={style.posterPreview}>
               <div className={style.posterPreviewText}>

--- a/src/ui-presets/ads.js
+++ b/src/ui-presets/ads.js
@@ -52,7 +52,7 @@ function AdsUI(props: any, context: any): ?React$Element<any> {
     <BottomBar
       leftControls={
         <Fragment>
-          <PlaybackControls name={'BottomBarPlaybackControls'} />
+          <PlaybackControls name={'BottomBarPlaybackControls'} showPreview={true} />
           <TimeDisplayAdsContainer />
         </Fragment>
       }

--- a/src/ui-presets/live.js
+++ b/src/ui-presets/live.js
@@ -83,7 +83,7 @@ class LiveUI extends Component {
                   <BottomBar
                     leftControls={
                       <Fragment>
-                        <PlaybackControls name={'BottomBarPlaybackControls'} />
+                        <PlaybackControls name={'BottomBarPlaybackControls'} showPreview={true} />
                         <Rewind step={10} />
                         <Forward step={10} />
                         <LiveTag />

--- a/src/ui-presets/playback.js
+++ b/src/ui-presets/playback.js
@@ -89,7 +89,7 @@ class PlaybackUI extends Component {
                   <BottomBar
                     leftControls={
                       <Fragment>
-                        <PlaybackControls name={'BottomBarPlaybackControls'} />
+                        <PlaybackControls name={'BottomBarPlaybackControls'} showPreview={true} />
                         <Rewind step={10} />
                         <Forward step={10} />
                         <TimeDisplayPlaybackContainer format="current / total" />


### PR DESCRIPTION
### Description of the Changes

Always show tooltip on overlay playback controls instead of showing preview

Resolves FEC-12154

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
