### PR TITLE
fix(FEC-12236,FEC-FEC-12237): VPAID ads part of the AD is cut

### DIFF
--- a/src/components/loading/loading.js
+++ b/src/components/loading/loading.js
@@ -67,6 +67,10 @@ class Loading extends Component {
       this.props.updateLoadingSpinnerState(true);
     });
 
+    eventManager.listen(player, player.Event.AD_PROGRESS, () => {
+      this.props.updateLoadingSpinnerState(false);
+    });
+
     eventManager.listen(player, player.Event.AD_STARTED, () => {
       if (this.props.adIsLinear) {
         this.props.updateLoadingSpinnerState(false);

--- a/src/components/playback-controls/_playback-controls.scss
+++ b/src/components/playback-controls/_playback-controls.scss
@@ -8,6 +8,7 @@
   -webkit-transform: translate(-50%, -50%);
   -ms-transform: translate(-50%, -50%);
   white-space: nowrap;
+  z-index: 1;
 }
 
 .bottom-bar .playback-controls {


### PR DESCRIPTION
### Description of the Changes

center playback controls get z-index to let the user pause/play the player during the non-linear vpaid is displayed on small screen - see https://github.com/kaltura/playkit-js-ima/pull/229
also, turn the spinner off when there is no AD_STARTED event but AD_PROGRESS (non-linera vpaid)

Solves FEC-12236, FEC-12237

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
