### PR TITLE
fix(FEC-12372): [WEB][UI] - [O2CZ] Autoplay_WEB - After seeking to the end of the program, the next program will not start playing automatically

### DIFF
--- a/src/components/overlay-action/overlay-action.js
+++ b/src/components/overlay-action/overlay-action.js
@@ -23,7 +23,8 @@ const mapStateToProps = state => ({
   isMobile: state.shell.isMobile,
   guiStyles: state.shell.layoutStyles.gui,
   isSmartContainerOpen: state.shell.smartContainerOpen,
-  fullscreenConfig: state.config.components.fullscreen
+  fullscreenConfig: state.config.components.fullscreen,
+  seekbarDraggingActive: state.seekbar.draggingActive
 });
 
 /**
@@ -176,7 +177,9 @@ class OverlayAction extends Component {
       clientY: event.clientY || (event.changedTouches && event.changedTouches[0] && event.changedTouches[0].clientY)
     };
     return (
-      Math.abs(points.clientX - this._pointerDownPosX) > DRAGGING_THRESHOLD || Math.abs(points.clientY - this._pointerDownPosY) > DRAGGING_THRESHOLD
+      this.props.seekbarDraggingActive ||
+      Math.abs(points.clientX - this._pointerDownPosX) > DRAGGING_THRESHOLD ||
+      Math.abs(points.clientY - this._pointerDownPosY) > DRAGGING_THRESHOLD
     );
   }
 


### PR DESCRIPTION
### Description of the Changes

When a user performs a mousedown on the seekbar, and a mouseup on the overlay, and no mousedown event has been fired on the overlay earlier, overlay-action does not detect a drag. This causes the mousedown to toggle the player's play/pause.
The solution was to update the drag detection in isDragging by adding the seekbar drag state.

Resolves FEC-12372

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
