### PR TITLE
fix(FEC-12335): Side Panel Item gets refreshed in every 'change media' 

### DIFF
--- a/src/components/engine-connector/engine-connector.js
+++ b/src/components/engine-connector/engine-connector.js
@@ -36,7 +36,7 @@ class EngineConnector extends Component {
 
     eventManager.listen(player, player.Event.PLAYER_RESET, () => {
       this.props.updateCurrentTime(0);
-      this.props.updateIsIdle(true);
+      // this.props.updateIsIdle(true);
       this.props.updateIsPlaybackStarted(false);
       this.props.updateDataLoadingStatus(false);
     });

--- a/src/components/engine-connector/engine-connector.js
+++ b/src/components/engine-connector/engine-connector.js
@@ -34,11 +34,9 @@ class EngineConnector extends Component {
     const TrackType = player.Track;
     this.props.updatePrePlayback(!player.config.playback.autoplay);
 
-    eventManager.listen(player, player.Event.PLAYER_RESET, event => {
+    eventManager.listen(player, player.Event.PLAYER_RESET, () => {
       this.props.updateCurrentTime(0);
-      if (!event.payload.isChangeMedia) {
-        this.props.updateIsIdle(true);
-      }
+      this.props.updateIsIdle(true);
       this.props.updateIsPlaybackStarted(false);
       this.props.updateDataLoadingStatus(false);
     });

--- a/src/components/engine-connector/engine-connector.js
+++ b/src/components/engine-connector/engine-connector.js
@@ -34,9 +34,11 @@ class EngineConnector extends Component {
     const TrackType = player.Track;
     this.props.updatePrePlayback(!player.config.playback.autoplay);
 
-    eventManager.listen(player, player.Event.PLAYER_RESET, () => {
+    eventManager.listen(player, player.Event.PLAYER_RESET, event => {
       this.props.updateCurrentTime(0);
-      this.props.updateIsIdle(true);
+      if (!event.payload.isChangeMedia) {
+        this.props.updateIsIdle(true);
+      }
       this.props.updateIsPlaybackStarted(false);
       this.props.updateDataLoadingStatus(false);
     });

--- a/src/components/engine-connector/engine-connector.js
+++ b/src/components/engine-connector/engine-connector.js
@@ -34,9 +34,11 @@ class EngineConnector extends Component {
     const TrackType = player.Track;
     this.props.updatePrePlayback(!player.config.playback.autoplay);
 
-    eventManager.listen(player, player.Event.PLAYER_RESET, () => {
+    eventManager.listen(player, player.Event.PLAYER_RESET, event => {
       this.props.updateCurrentTime(0);
-      // this.props.updateIsIdle(true);
+      if (!event.payload.isChangeMedia) {
+        this.props.updateIsIdle(true);
+      }
       this.props.updateIsPlaybackStarted(false);
       this.props.updateDataLoadingStatus(false);
     });


### PR DESCRIPTION
### Description of the Changes
issue: the engine connector is listening to PLAYER.RESET event (which is called on change media)
and switch from 'playback' preset to 'idle' preset which is a totally different UI
fix: cancel the switch and remains on the active preset on change media
(i think the 'idle' preset is intended only for player start up)

solves: [FEC-12335](https://kaltura.atlassian.net/browse/FEC-12335)

related prs:
https://github.com/kaltura/kaltura-player-js/pull/562
https://github.com/kaltura/playkit-js/pull/659

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
