### PR TITLE
fix(FEC-12517): [web v7] volume bar arrow keys accessibility

### DIFF
--- a/src/components/volume/volume.js
+++ b/src/components/volume/volume.js
@@ -107,7 +107,21 @@ class Volume extends Component {
     });
     this.props.eventManager.listen(document, 'mouseup', this.onVolumeProgressBarMouseUp);
     this.props.eventManager.listen(document, 'mousemove', this.onVolumeProgressBarMouseMove);
+    this.props.eventManager.listen(document, 'click', e => this.handleClickOutside(e));
     this.props.registerKeyboardEvents(this._keyboardEventHandlers);
+  }
+
+  /**
+   * event listener for clicking outside handler.
+   *
+   * @param {*} e - click event
+   * @returns {void}
+   * @memberof Volume
+   */
+  handleClickOutside(e: any) {
+    if (!this.props.isMobile && !!this._volumeControlElement && !this._volumeControlElement.contains(e.target) && this.state.hover) {
+      this.setState({hover: false});
+    }
   }
 
   /**
@@ -247,6 +261,8 @@ class Volume extends Component {
       case KeyMap.DOWN:
       case KeyMap.ENTER:
       case KeyMap.SPACE:
+        event.preventDefault();
+        event.stopPropagation();
         this.handleKeydown(event, true);
         break;
       default:


### PR DESCRIPTION
**the issue:**
when navigating to volume component using the keyboard and pressing up/down arrows (to volume up/down), the entire page is scrolling.
another related issue that was observed- when the volume bar is open via a11y (using keyboard), then clicking anywhere is not closing the volume bar; it should be close in this case.

**root cause:**
we do not prevent from the keyboard event to bubble. when pressing up/down keyboard arrows, the native event scrolls the page.

### Description of the Changes

- preventing from keyboard event to bubble
- closing the volume bar once clicking outside the component

Solves FEC-12517

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
