### PR TITLE
fix(FEC-12235): accessibility: Not possible to change items for “Language“ and “Settings“ by space key

### DIFF
--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -99,6 +99,10 @@ class DropDown extends Component {
       case KeyMap.ENTER:
         this.onClick();
         break;
+      case KeyMap.SPACE:
+        e.preventDefault();
+        this.onClick();
+        break;
       case KeyMap.ESC:
         if (this.state.dropMenuActive) {
           this.onClose();


### PR DESCRIPTION
### Description of the Changes

Accessibility:
player allow open the internal dropdowns from “Language“ OR “Settings“ elements using space key (and not only from enter key).

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
