### PR TITLE
fix(FEC-12155): RTL languages translation are not supported correctly on the resolution labels

### DIFF
--- a/src/components/settings/settings.js
+++ b/src/components/settings/settings.js
@@ -25,6 +25,7 @@ const HeightResolution = {
   UHD_4K: 2160,
   UHD_8K: 4320
 };
+const rtlLanguages = ['ae', 'ar', 'arc', 'bcc', 'bqi', 'ckb', 'dv', 'fa', 'glk', 'he', 'ku', 'mzn', 'nqo', 'pnb', 'ps', 'sd', 'ug', 'ur', 'yi'];
 
 /**
  * mapping state to props
@@ -319,7 +320,6 @@ class Settings extends Component {
     // Progressive playback doesn't support auto
     if (qualityOptions.length > 1 && player.streamType !== 'progressive') {
       const activeTrack: Object = qualityOptions.find(track => track.value.active === true).value;
-      var rtlLanguages = ['ae', 'ar', 'arc', 'bcc', 'bqi', 'ckb', 'dv', 'fa', 'glk', 'he', 'ku', 'mzn', 'nqo', 'pnb', 'ps', 'sd', 'ug', 'ur', 'yi'];
       var qualityLabel;
       if (rtlLanguages.includes(this.props.player._localPlayer._config.ui.locale)) {
         qualityLabel = activeTrack.label + ' - ' + this.props.qualityAutoLabelText;

--- a/src/components/settings/settings.js
+++ b/src/components/settings/settings.js
@@ -319,10 +319,16 @@ class Settings extends Component {
     // Progressive playback doesn't support auto
     if (qualityOptions.length > 1 && player.streamType !== 'progressive') {
       const activeTrack: Object = qualityOptions.find(track => track.value.active === true).value;
+      var qualityLabel;
+      if (this.props.player._localPlayer._config.ui.locale === 'ar' || this.props.player._localPlayer._config.ui.locale === 'he') {
+        qualityLabel = activeTrack.label + ' - ' + this.props.qualityAutoLabelText;
+      } else {
+        qualityLabel = this.props.qualityAutoLabelText + ' - ' + activeTrack.label;
+      }
       qualityOptions.unshift({
         label: this.props.qualityAutoLabelText,
         dropdownOptions: {
-          label: this.props.qualityAutoLabelText + ' - ' + activeTrack.label,
+          label: qualityLabel,
           badgeType: this.getLabelBadgeType(activeTrack.height)
         },
         active: player.isAdaptiveBitrateEnabled(),

--- a/src/components/settings/settings.js
+++ b/src/components/settings/settings.js
@@ -320,7 +320,7 @@ class Settings extends Component {
     // Progressive playback doesn't support auto
     if (qualityOptions.length > 1 && player.streamType !== 'progressive') {
       const activeTrack: Object = qualityOptions.find(track => track.value.active === true).value;
-      var qualityLabel;
+      let qualityLabel;
       if (rtlLanguages.includes(this.props.player._localPlayer._config.ui.locale)) {
         qualityLabel = activeTrack.label + ' - ' + this.props.qualityAutoLabelText;
       } else {

--- a/src/components/settings/settings.js
+++ b/src/components/settings/settings.js
@@ -319,8 +319,9 @@ class Settings extends Component {
     // Progressive playback doesn't support auto
     if (qualityOptions.length > 1 && player.streamType !== 'progressive') {
       const activeTrack: Object = qualityOptions.find(track => track.value.active === true).value;
+      var rtlLanguages = ['ae', 'ar', 'arc', 'bcc', 'bqi', 'ckb', 'dv', 'fa', 'glk', 'he', 'ku', 'mzn', 'nqo', 'pnb', 'ps', 'sd', 'ug', 'ur', 'yi'];
       var qualityLabel;
-      if (this.props.player._localPlayer._config.ui.locale === 'ar' || this.props.player._localPlayer._config.ui.locale === 'he') {
+      if (rtlLanguages.includes(this.props.player._localPlayer._config.ui.locale)) {
         qualityLabel = activeTrack.label + ' - ' + this.props.qualityAutoLabelText;
       } else {
         qualityLabel = this.props.qualityAutoLabelText + ' - ' + activeTrack.label;


### PR DESCRIPTION

### Description of the Changes

added support for RTL languages (Hebrew and Arabic), in the quality label the translate for "Auto" will be RTL.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
