### PR TITLE
fix(FEC-12596): Related plugin doesn't load because of an exception

### DIFF
--- a/src/event/fake-event-target.js
+++ b/src/event/fake-event-target.js
@@ -15,7 +15,7 @@ import getLogger from '../utils/logger';
 class FakeEventTarget {
   _listeners: MultiMap<(event: FakeEvent) => boolean | void>;
   dispatchTarget: FakeEventTarget;
-  logger: any;
+  __logger: any;
 
   /**
    * @constructor
@@ -31,7 +31,7 @@ class FakeEventTarget {
      * @type {FakeEventTarget}
      */
     this.dispatchTarget = this;
-    this.logger = getLogger(`UI FakeEventTarget`);
+    this.__logger = getLogger(`UI FakeEventTarget`);
   }
 
   /**
@@ -101,7 +101,7 @@ class FakeEventTarget {
         // Exceptions during event handlers should not affect the caller,
         // but should appear on the console as uncaught, according to MDN:
         // http://goo.gl/N6Ff27
-        this.logger.error(`Error occurred when handling event: ${event.type}.`, exception);
+        this.__logger.error(`Error occurred when handling event: ${event.type}.`, exception);
       }
 
       if (event.stopped) {


### PR DESCRIPTION
### Description of the Changes

Rename fake-event-target logger to not conflict with children.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
