### PR TITLE
fix - remove max-width from dropdown style

### DIFF
--- a/src/components/smart-container/_smart-container.scss
+++ b/src/components/smart-container/_smart-container.scss
@@ -81,7 +81,6 @@
       }
       .dropdown {
         span:not(.badge-icon) {
-          max-width: 100px;
           overflow: hidden;
           text-overflow: ellipsis;
           vertical-align: middle;


### PR DESCRIPTION
### Description of the Changes

**the issue:**
after change the player font to Lato, in quality dropdown is created 3 dotes when translate for Hebrew.

**the solution:** 
remove the max-width from the dropdown style. 

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
