### PR TITLE
fix(FEC-12718): Player v7 | info v3.1.0-canary.7-c284265 | Accessibility | Space doesn't work for the X button inside info plugin.

### DIFF
--- a/src/components/overlay/overlay.js
+++ b/src/components/overlay/overlay.js
@@ -66,7 +66,7 @@ class Overlay extends Component {
    * @memberof Overlay
    */
   onCloseButtonKeyDown = (e: KeyboardEvent): void => {
-    if (e.keyCode === KeyMap.ENTER) {
+    if (e.keyCode === KeyMap.ENTER || e.keyCode === KeyMap.SPACE) {
       e.preventDefault();
       this.props.onClose();
     }


### PR DESCRIPTION
### Description of the Changes

add option to close the button also with the space key.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
