### PR TITLE
fix(FEC-12719): [WEB][UI]- Player v7 | playlist v3.0.1-canary.1-51e0b54 | Accessibility | After entry reaches the end, when tab navigate to the square next video in the middle of the player (autoContinue: false) "Space" doesn't work.

### DIFF
--- a/src/components/playlist-next-screen/playlist-next-screen.js
+++ b/src/components/playlist-next-screen/playlist-next-screen.js
@@ -78,7 +78,8 @@ class PlaylistNextScreen extends Component {
    * @memberof PlaylistNextScreen
    */
   onKeyDown = (e: KeyboardEvent): void => {
-    if (e.keyCode === KeyMap.ENTER) {
+    if (e.keyCode === KeyMap.ENTER || e.keyCode === KeyMap.SPACE) {
+      e.preventDefault();
       this.onPosterClick();
     }
   };


### PR DESCRIPTION
### Description of the Changes
add the ability to move the next video by space key.

solves FEC-12719

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
