### PR TITLE
feat(FEC-12700): Make the player colors configurable from studio

### DIFF
--- a/docs/colors-override.md
+++ b/docs/colors-override.md
@@ -1,5 +1,5 @@
 
-#Customize the player colors
+# Customize the player colors
 
 in order to override the player default colors you can pass your own color (in HEX color format!) in the `ui` section in player config
 

--- a/docs/colors-override.md
+++ b/docs/colors-override.md
@@ -1,0 +1,31 @@
+
+#Customize the player colors
+
+in order to override the player default colors you can pass your own color (in HEX color format!) in the `ui` section in player config
+
+> This guide assumes you are using the [Kaltura Player]
+
+[kaltura player]: https://github.com/kaltura/kaltura-player-js/
+
+### Example
+```js
+const config = {
+  targetId: 'player-placeholder',
+  provider: {
+    partnerId: 1234567,
+  },
+  ui: {
+    userTheme: {
+      colors: {
+        primary: '#da3633',
+        secondary: '#c4da33'
+      }
+    }
+  }
+}
+
+const player = KalturaPlayer.setup(config);
+```
+> Note: only HEX color format is excepted
+
+[See here for full configuration options](https://github.com/kaltura/playkit-js-ui/tree/master/flow-typed/types/user-theme.js)

--- a/docs/ui-customization.md
+++ b/docs/ui-customization.md
@@ -28,3 +28,7 @@ More information on how to build UI components and injecting them to UI see:
 The captions customizing level can be modified by removing settings from the captions setting menu.
 
 More information on removing settings from the menu can be found [here](cvaa-override.md).
+
+## Override Player Theme (Main colors)
+
+Some style (currently - mainly the player primary colors) can be configured

--- a/flow-typed/types/ui-options.js
+++ b/flow-typed/types/ui-options.js
@@ -11,5 +11,6 @@ declare type UIOptionsObject = {
   components?: ComponentsConfig,
   uiComponents?: Array<KPUIComponent>,
   translations?: {[langKey: string]: Object},
-  locale?: string
+  locale?: string;
+  userTheme?: UserTheme
 };

--- a/flow-typed/types/user-theme.js
+++ b/flow-typed/types/user-theme.js
@@ -1,0 +1,15 @@
+// @flow
+declare type ColorType = {
+  primary: string,
+  secondary: string,
+  success: string,
+  danger: string,
+  warning: string,
+  live: string,
+  playerBackground: string
+};
+
+
+declare type UserTheme = {
+  colors: ColorType
+};

--- a/src/components/ad-learn-more/_ad-learn-more.scss
+++ b/src/components/ad-learn-more/_ad-learn-more.scss
@@ -1,6 +1,3 @@
-@import '~styles/variables';
-@import '~styles/buttons';
-
 .player {
   .learn-more {
     font-weight: lighter;

--- a/src/components/bottom-bar/_bottom-bar.scss
+++ b/src/components/bottom-bar/_bottom-bar.scss
@@ -1,5 +1,3 @@
-@import '~styles/variables';
-
 .player .bottom-bar {
   background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.6) 100%);
   color: #fff;

--- a/src/components/cast/_cast.scss
+++ b/src/components/cast/_cast.scss
@@ -6,8 +6,8 @@
     background-color: rgba(255, 255, 255, 0);
     border: none;
     cursor: pointer;
-    --connected-color: var(--playkti-tone-2-color);
-    --disconnected-color:  var(--playkit-tone-2-color);
+    --connected-color: $tone-2-color;
+    --disconnected-color: $tone-2-color;
 
     &:hover {
       --connected-color: #FFFFFFFF;
@@ -18,7 +18,7 @@
       --connected-color: rgba(1, 172, 205, 0.8);
 
       &:hover {
-        --connected-color: var(--playkit-primary-color);
+        --connected-color: $primary-color;
       }
     }
   }

--- a/src/components/cast/_cast.scss
+++ b/src/components/cast/_cast.scss
@@ -1,5 +1,3 @@
-@import '~styles/variables';
-
 .player {
   .cast-button {
     display: block;
@@ -8,19 +6,19 @@
     background-color: rgba(255, 255, 255, 0);
     border: none;
     cursor: pointer;
-    --connected-color: #{$grayscale4};
-    --disconnected-color: #{$grayscale4};
+    --connected-color: var(--playkti-tone-2-color);
+    --disconnected-color:  var(--playkit-tone-2-color);
 
     &:hover {
-      --connected-color: #{$white};
-      --disconnected-color: #{$white};
+      --connected-color: #FFFFFFFF;
+      --disconnected-color: #FFFFFFFF;
     }
 
     &.cast-button-active {
       --connected-color: rgba(1, 172, 205, 0.8);
-  
+
       &:hover {
-        --connected-color: #{$brand-color};  
+        --connected-color: var(--playkit-primary-color);
       }
     }
   }

--- a/src/components/cvaa-overlay/_cvaa-overlay.scss
+++ b/src/components/cvaa-overlay/_cvaa-overlay.scss
@@ -25,7 +25,7 @@
       height: 16px;
       width: 16px;
       border-radius: 8px;
-      background-color: var(--playkit-primary-color);
+      background-color: $primary-color;
       position: absolute;
       top: -5px;
       right: -5px;
@@ -59,7 +59,7 @@
   .custom-captions-applied {
     margin-top: 50px;
     a {
-      color: var(--playkit-primary-brighter-color);
+      color: $primary-brighter-color;
     }
   }
 

--- a/src/components/cvaa-overlay/_cvaa-overlay.scss
+++ b/src/components/cvaa-overlay/_cvaa-overlay.scss
@@ -1,5 +1,3 @@
-@import '~styles/variables';
-
 .overlay.cvaa-overlay {
   .sample {
     border: 2px solid rgba(255, 255, 255, 0.2);

--- a/src/components/cvaa-overlay/_cvaa-overlay.scss
+++ b/src/components/cvaa-overlay/_cvaa-overlay.scss
@@ -27,7 +27,7 @@
       height: 16px;
       width: 16px;
       border-radius: 8px;
-      background-color: $brand-color;
+      background-color: var(--playkit-primary-color);
       position: absolute;
       top: -5px;
       right: -5px;
@@ -61,7 +61,7 @@
   .custom-captions-applied {
     margin-top: 50px;
     a {
-      color: $brand-color-light;
+      color: var(--playkit-primary-brighter-color);
     }
   }
 

--- a/src/components/error-overlay/_error-overlay.scss
+++ b/src/components/error-overlay/_error-overlay.scss
@@ -1,7 +1,7 @@
 @import '~styles/variables';
 
 .overlay.error-overlay {
-  background-color: $grayscale1;
+  background-color: var(--playkit-tone-7-color);
   font-size: 0em;
 }
 
@@ -30,7 +30,7 @@
   }
 
   .headline {
-    color: $white;
+    color: var(--playkit-tone-1-color);
     font-size: $headline-font-size;
     margin: 10px 0 14px 0;
     flex: 1;
@@ -38,7 +38,7 @@
 
   .error-session {
     font-size: $subheadline-font-size;
-    color: $grayscale4;
+    color: var(--playkit-tone-2-color);
     margin: auto;
     user-select: text;
     -webkit-user-select: text;
@@ -60,10 +60,10 @@
     width: auto;
     min-width: 120px;
     padding: 0 8px;
-    border: 2px solid $grayscale1;
+    border: 2px solid var(--playkit-tone-7-color);
     border-radius: 18px;
     background-color: black;
-    color: $white;
+    color: var(--playkit-tone-1-color);
     font-size: 15px;
     font-weight: bold;
     line-height: 32px;

--- a/src/components/error-overlay/_error-overlay.scss
+++ b/src/components/error-overlay/_error-overlay.scss
@@ -1,5 +1,3 @@
-@import '~styles/variables';
-
 .overlay.error-overlay {
   background-color: var(--playkit-tone-7-color);
   font-size: 0em;

--- a/src/components/error-overlay/_error-overlay.scss
+++ b/src/components/error-overlay/_error-overlay.scss
@@ -1,5 +1,5 @@
 .overlay.error-overlay {
-  background-color: var(--playkit-tone-7-color);
+  background-color: $tone-7-color;
   font-size: 0em;
 }
 
@@ -28,7 +28,7 @@
   }
 
   .headline {
-    color: var(--playkit-tone-1-color);
+    color: $tone-1-color;
     font-size: $headline-font-size;
     margin: 10px 0 14px 0;
     flex: 1;
@@ -36,7 +36,7 @@
 
   .error-session {
     font-size: $subheadline-font-size;
-    color: var(--playkit-tone-2-color);
+    color: $tone-2-color;
     margin: auto;
     user-select: text;
     -webkit-user-select: text;
@@ -58,10 +58,10 @@
     width: auto;
     min-width: 120px;
     padding: 0 8px;
-    border: 2px solid var(--playkit-tone-7-color);
+    border: 2px solid $tone-7-color;
     border-radius: 18px;
     background-color: black;
-    color: var(--playkit-tone-1-color);
+    color: $tone-1-color;
     font-size: 15px;
     font-weight: bold;
     line-height: 32px;

--- a/src/components/icon/icon.js
+++ b/src/components/icon/icon.js
@@ -15,6 +15,7 @@ const IconType = {
   Close: 'close',
   Settings: 'settings',
   Check: 'check',
+  CheckActive: 'check-active',
   Language: 'language',
   Quality: 'quality',
   Captions: 'captions',
@@ -41,15 +42,13 @@ const IconType = {
   ClosedCaptionsOff: 'closed-captions-off'
 };
 
-const dynamicIconClass = 'playkit-dynamic-icon';
-
 const BadgeType = {
   qualityHd: `${style.badgeIcon} ${style.iconQualityHd}`,
-  qualityHdActive: `${style.badgeIcon} ${style.iconQualityHdActive} ${dynamicIconClass}`,
+  qualityHdActive: `${style.badgeIcon} ${style.iconQualityHdActive}`,
   quality4k: `${style.badgeIcon} ${style.iconQuality4K}`,
-  quality4kActive: `${style.badgeIcon} ${style.iconQuality4KActive} ${dynamicIconClass}`,
+  quality4kActive: `${style.badgeIcon} ${style.iconQuality4KActive}`,
   quality8k: `${style.badgeIcon} ${style.iconQuality8K}`,
-  quality8kActive: `${style.badgeIcon} ${style.iconQuality8KActive} ${dynamicIconClass}`
+  quality8kActive: `${style.badgeIcon} ${style.iconQuality8KActive}`
 };
 
 const IconState: {[state: string]: number} = {
@@ -233,7 +232,10 @@ class Icon extends Component {
           return <i className={[style.icon, style.iconSettings].join(' ')} />;
 
         case IconType.Check:
-          return <i className={[style.icon, style.iconCheck, dynamicIconClass].join(' ')} />;
+          return <i className={[style.icon, style.iconCheck].join(' ')} />;
+
+        case IconType.CheckActive:
+          return <i className={[style.icon, style.iconCheckActive].join(' ')} />;
 
         case IconType.Language:
           return <i className={[style.icon, style.iconLanguage].join(' ')} />;
@@ -281,13 +283,13 @@ class Icon extends Component {
           return <i className={[style.icon, style.iconVrStereo].join(' ')} />;
 
         case IconType.vrStereoFull:
-          return <i className={[style.icon, style.iconVrStereoFull, dynamicIconClass].join(' ')} />;
+          return <i className={[style.icon, style.iconVrStereoFull].join(' ')} />;
 
         case IconType.Cast:
           return <i className={[style.icon, style.iconChromecast].join(' ')} />;
 
         case IconType.CastBrand:
-          return <i className={[style.icon, style.iconChromecastBrand, dynamicIconClass].join(' ')} />;
+          return <i className={[style.icon, style.iconChromecastBrand].join(' ')} />;
 
         case IconType.Next:
           return <i className={[style.icon, style.iconNext].join(' ')} />;

--- a/src/components/icon/icon.js
+++ b/src/components/icon/icon.js
@@ -41,13 +41,15 @@ const IconType = {
   ClosedCaptionsOff: 'closed-captions-off'
 };
 
+const dynamicIconClass = 'playkit-dynamic-icon';
+
 const BadgeType = {
   qualityHd: `${style.badgeIcon} ${style.iconQualityHd}`,
-  qualityHdActive: `${style.badgeIcon} ${style.iconQualityHdActive}`,
+  qualityHdActive: `${style.badgeIcon} ${style.iconQualityHdActive} ${dynamicIconClass}`,
   quality4k: `${style.badgeIcon} ${style.iconQuality4K}`,
-  quality4kActive: `${style.badgeIcon} ${style.iconQuality4KActive}`,
+  quality4kActive: `${style.badgeIcon} ${style.iconQuality4KActive} ${dynamicIconClass}`,
   quality8k: `${style.badgeIcon} ${style.iconQuality8K}`,
-  quality8kActive: `${style.badgeIcon} ${style.iconQuality8KActive}`
+  quality8kActive: `${style.badgeIcon} ${style.iconQuality8KActive} ${dynamicIconClass}`
 };
 
 const IconState: {[state: string]: number} = {
@@ -231,7 +233,7 @@ class Icon extends Component {
           return <i className={[style.icon, style.iconSettings].join(' ')} />;
 
         case IconType.Check:
-          return <i className={[style.icon, style.iconCheck].join(' ')} />;
+          return <i className={[style.icon, style.iconCheck, dynamicIconClass].join(' ')} />;
 
         case IconType.Language:
           return <i className={[style.icon, style.iconLanguage].join(' ')} />;
@@ -279,13 +281,13 @@ class Icon extends Component {
           return <i className={[style.icon, style.iconVrStereo].join(' ')} />;
 
         case IconType.vrStereoFull:
-          return <i className={[style.icon, style.iconVrStereoFull].join(' ')} />;
+          return <i className={[style.icon, style.iconVrStereoFull, dynamicIconClass].join(' ')} />;
 
         case IconType.Cast:
           return <i className={[style.icon, style.iconChromecast].join(' ')} />;
 
         case IconType.CastBrand:
-          return <i className={[style.icon, style.iconChromecastBrand].join(' ')} />;
+          return <i className={[style.icon, style.iconChromecastBrand, dynamicIconClass].join(' ')} />;
 
         case IconType.Next:
           return <i className={[style.icon, style.iconNext].join(' ')} />;

--- a/src/components/icon/icon.scss
+++ b/src/components/icon/icon.scss
@@ -249,7 +249,8 @@
 }
 
 .icon-vr-stereo-full {
-  background-image: icon(vrStereoFull, $brand-color);
+  --playkit-icon-data-url: #{icon(vrStereoFull, $brand-color)};
+  background-image: var(--playkit-icon-data-url);
 }
 
 .icon-chromecast {
@@ -257,7 +258,8 @@
 }
 
 .icon-chromecast-brand {
-  background-image: icon(chromecast, $brand-color);
+  --playkit-icon-data-url: #{icon(chromecast, $brand-color)};
+  background-image: var(--playkit-icon-data-url);
 }
 
 .icon-next {
@@ -283,8 +285,9 @@
 }
 
 .icon-quality-hd-active {
+  --playkit-icon-data-url: #{icon(qualityHdActive, $brand-color, '16', '0 0 16 16')};
   &:after {
-    background-image: icon(qualityHdActive, $brand-color, '16', '0 0 16 16');
+    background-image: var(--playkit-icon-data-url);
   }
 }
 
@@ -295,8 +298,9 @@
 }
 
 .icon-quality-4k-active {
+  --playkit-icon-data-url: #{icon(quality4kActive, $brand-color, '16', '0 0 16 16')};
   &:after {
-    background-image: icon(quality4kActive, $brand-color, '16', '0 0 16 16');
+    background-image: var(--playkit-icon-data-url);
   }
 }
 
@@ -307,8 +311,9 @@
 }
 
 .icon-quality-8k-active {
+  --playkit-icon-data-url: #{icon(quality8kActive, $brand-color, '16', '0 0 16 16')};
   &:after {
-    background-image: icon(quality8kActive, $brand-color, '16', '0 0 16 16');
+    background-image: var(--playkit-icon-data-url);
   }
 }
 

--- a/src/components/icon/icon.scss
+++ b/src/components/icon/icon.scss
@@ -1,5 +1,3 @@
-@import '~styles/variables';
-
 @function svg-url($svg, $size, $viewBox) {
   $svg: '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="#{$viewBox}" width="#{$size}" height="#{$size}">#{$svg}</svg>';
 
@@ -144,6 +142,16 @@
   background-position: 50% 50%;
 }
 
+// Dynamic Colored Icons
+.player {
+  --playkit-icon-check-active-url: #{icon(check, $brand-color)};
+  --playkit-icon-vr-stereo-full-url: #{icon(vrStereoFull, $brand-color)};
+  --playkit-icon-chromecast-url: #{icon(chromecast, $brand-color)};
+  --playkit-icon-quality-HD-active-url: #{icon(qualityHdActive, $brand-color, '16', '0 0 16 16')};
+  --playkit-icon-quality-4K-active-url: #{icon(quality4kActive, $brand-color, '16', '0 0 16 16')};
+  --playkit-icon-quality-8K-active-url: #{icon(quality8kActive, $brand-color, '16', '0 0 16 16')};
+}
+
 .icon-maximize {
   background-image: icon(maximize, '#fff');
 }
@@ -186,6 +194,10 @@
 
 .icon-check {
   background-image: icon(check, '#fff');
+}
+
+.icon-check-active {
+  background-image: var(--playkit-icon-check-active-url);
 }
 
 .icon-language {
@@ -249,8 +261,7 @@
 }
 
 .icon-vr-stereo-full {
-  --playkit-icon-data-url: #{icon(vrStereoFull, $brand-color)};
-  background-image: var(--playkit-icon-data-url);
+  background-image: var(--playkit-icon-vr-stereo-full-url);
 }
 
 .icon-chromecast {
@@ -258,8 +269,7 @@
 }
 
 .icon-chromecast-brand {
-  --playkit-icon-data-url: #{icon(chromecast, $brand-color)};
-  background-image: var(--playkit-icon-data-url);
+  background-image: var(--playkit-icon-chromecast-url);
 }
 
 .icon-next {
@@ -285,9 +295,8 @@
 }
 
 .icon-quality-hd-active {
-  --playkit-icon-data-url: #{icon(qualityHdActive, $brand-color, '16', '0 0 16 16')};
   &:after {
-    background-image: var(--playkit-icon-data-url);
+    background-image: var(--playkit-icon-quality-HD-active-url);
   }
 }
 
@@ -298,9 +307,8 @@
 }
 
 .icon-quality-4k-active {
-  --playkit-icon-data-url: #{icon(quality4kActive, $brand-color, '16', '0 0 16 16')};
   &:after {
-    background-image: var(--playkit-icon-data-url);
+    background-image: var(--playkit-icon-quality-4K-active-url);
   }
 }
 
@@ -311,9 +319,8 @@
 }
 
 .icon-quality-8k-active {
-  --playkit-icon-data-url: #{icon(quality8kActive, $brand-color, '16', '0 0 16 16')};
   &:after {
-    background-image: var(--playkit-icon-data-url);
+    background-image: var(--playkit-icon-quality-8K-active-url);
   }
 }
 

--- a/src/components/interactive-area/_interactive-area.scss
+++ b/src/components/interactive-area/_interactive-area.scss
@@ -1,4 +1,3 @@
-@import '~styles/variables';
 .player.overlay-active .interactive-area {
   filter: blur($blur);
 }

--- a/src/components/language/_language.scss
+++ b/src/components/language/_language.scss
@@ -1,7 +1,7 @@
 .player {
   a:not([href]) {
     &.advanced-captions-menu-link {
-      color: var(--playkit-primary-brighter-color);
+      color: $primary-brighter-color;
       text-decoration: underline;
     }
   }

--- a/src/components/language/_language.scss
+++ b/src/components/language/_language.scss
@@ -1,7 +1,7 @@
 .player {
   a:not([href]) {
     &.advanced-captions-menu-link {
-      color: $brand-color-light;
+      color: var(--playkit-primary-brighter-color);
       text-decoration: underline;
     }
   }

--- a/src/components/live-tag/_live-tag.scss
+++ b/src/components/live-tag/_live-tag.scss
@@ -1,5 +1,3 @@
-@import '~styles/variables';
-
 .live-tag {
   display: inline-block;
   background-color: var(--playkit-live-color);

--- a/src/components/live-tag/_live-tag.scss
+++ b/src/components/live-tag/_live-tag.scss
@@ -2,7 +2,7 @@
 
 .live-tag {
   display: inline-block;
-  background-color: $new-live-color;
+  background-color: var(--playkit-live-color);
   color: #FFFFFF;
   border-radius: 4px;
   padding: 3px 4px;

--- a/src/components/live-tag/_live-tag.scss
+++ b/src/components/live-tag/_live-tag.scss
@@ -1,6 +1,6 @@
 .live-tag {
   display: inline-block;
-  background-color: var(--playkit-live-color);
+  background-color: $live-color;
   color: #FFFFFF;
   border-radius: 4px;
   padding: 3px 4px;

--- a/src/components/loading/_loading.scss
+++ b/src/components/loading/_loading.scss
@@ -1,5 +1,3 @@
-@import '~styles/variables';
-
 @keyframes kaltura-spinner {
   0% {
     transform: rotate(0deg) scale(0.7);

--- a/src/components/menu/menu.js
+++ b/src/components/menu/menu.js
@@ -267,7 +267,7 @@ class MenuItem extends Component {
         onKeyDown={this.onKeyDown}>
         <span className={badgeType ? [style.labelBadge, badgeType].join(' ') : ''}>{props.data.label}</span>
         <span className={[style.menuIconContainer, style.active].join(' ')}>
-          <Icon type={IconType.Check} />
+          <Icon type={IconType.CheckActive} />
         </span>
       </div>
     );

--- a/src/components/picture-in-picture-overlay/_picture-in-picture-overlay.scss
+++ b/src/components/picture-in-picture-overlay/_picture-in-picture-overlay.scss
@@ -46,7 +46,7 @@
   }
 
   .picture-in-picture-text {
-    color: $white;
+    color: var(--playkit-tone-1-color);
     font-size: $headline-font-size;
     white-space: nowrap;
     overflow: hidden;
@@ -55,10 +55,10 @@
   .picture-in-picture-button {
     height: 36px;
     width: 120px;
-    border: 2px solid $grayscale2;
+    border: 2px solid var(--playkit-tone-6-color);
     border-radius: 18px;
-    background-color: $grayscale1;
-    color: $white;
+    background-color: var(--playkit-tone-7-color);
+    color: var(--playkit-tone-1-color);
     font-size: 15px;
     font-weight: bold;
     line-height: 30px;
@@ -66,7 +66,7 @@
     margin-top: 20px;
     align-self: center;
     &:hover {
-      background-color: $grayscale2;
+      background-color: var(--playkit-tone-6-color);
     }
   }
 }

--- a/src/components/picture-in-picture-overlay/_picture-in-picture-overlay.scss
+++ b/src/components/picture-in-picture-overlay/_picture-in-picture-overlay.scss
@@ -44,7 +44,7 @@
   }
 
   .picture-in-picture-text {
-    color: var(--playkit-tone-1-color);
+    color: $tone-1-color;
     font-size: $headline-font-size;
     white-space: nowrap;
     overflow: hidden;
@@ -53,10 +53,10 @@
   .picture-in-picture-button {
     height: 36px;
     width: 120px;
-    border: 2px solid var(--playkit-tone-6-color);
+    border: 2px solid $tone-6-color;
     border-radius: 18px;
-    background-color: var(--playkit-tone-7-color);
-    color: var(--playkit-tone-1-color);
+    background-color: $tone-7-color;
+    color: $tone-1-color;
     font-size: 15px;
     font-weight: bold;
     line-height: 30px;
@@ -64,7 +64,7 @@
     margin-top: 20px;
     align-self: center;
     &:hover {
-      background-color: var(--playkit-tone-6-color);
+      background-color: $tone-6-color;
     }
   }
 }

--- a/src/components/picture-in-picture-overlay/_picture-in-picture-overlay.scss
+++ b/src/components/picture-in-picture-overlay/_picture-in-picture-overlay.scss
@@ -1,5 +1,3 @@
-@import '~styles/variables';
-
 .picture-in-picture-overlay {
   position: absolute;
   top: 0;

--- a/src/components/seekbar/_seekbar.scss
+++ b/src/components/seekbar/_seekbar.scss
@@ -1,5 +1,3 @@
-@import '~styles/variables';
-
 .player .seek-bar {
   padding: 12px 0 12px 0;
   cursor: pointer;

--- a/src/components/seekbar/_seekbar.scss
+++ b/src/components/seekbar/_seekbar.scss
@@ -23,13 +23,13 @@
     cursor: initial;
 
     .progress-bar .progress {
-      background-color: var(--playkit-ads-color);
+      background-color: $ads-color;
     }
   }
 
   &.live {
     .progress-bar .progress {
-      background-color: var(--playkit-live-color);
+      background-color: $live-color;
     }
   }
 
@@ -47,7 +47,7 @@
       left: 0;
       height: 100%;
       border-radius: inherit;
-      background-color: var(--playkit-primary-color);
+      background-color: $primary-color;
     }
     .virtual-progress {
       display: none;
@@ -68,7 +68,7 @@
     .virtual-progress-indicator {
       width: 1px;
       height: 100%;
-      background-color: var(--playkit-tone-1-color);
+      background-color: $tone-1-color;
       float: right;
     }
 
@@ -81,7 +81,7 @@
       border-radius: 8px;
       height: 16px;
       width: 16px;
-      background-color: var(--playkit-tone-1-color);
+      background-color: $tone-1-color;
       box-shadow: 0 0 31px 0 rgba(0, 0, 0, 0.3);
       transform: scale(0);
       transition: 100ms transform;

--- a/src/components/seekbar/_seekbar.scss
+++ b/src/components/seekbar/_seekbar.scss
@@ -25,13 +25,13 @@
     cursor: initial;
 
     .progress-bar .progress {
-      background-color: $ads-color;
+      background-color: var(--playkit-ads-color);
     }
   }
 
   &.live {
     .progress-bar .progress {
-      background-color: $new-live-color;
+      background-color: var(--playkit-live-color);
     }
   }
 
@@ -49,7 +49,7 @@
       left: 0;
       height: 100%;
       border-radius: inherit;
-      background-color: $brand-color;
+      background-color: var(--playkit-primary-color);
     }
     .virtual-progress {
       display: none;
@@ -70,7 +70,7 @@
     .virtual-progress-indicator {
       width: 1px;
       height: 100%;
-      background-color: $white;
+      background-color: var(--playkit-tone-1-color);
       float: right;
     }
 
@@ -83,7 +83,7 @@
       border-radius: 8px;
       height: 16px;
       width: 16px;
-      background-color: $white;
+      background-color: var(--playkit-tone-1-color);
       box-shadow: 0 0 31px 0 rgba(0, 0, 0, 0.3);
       transform: scale(0);
       transition: 100ms transform;

--- a/src/components/slider/_slider.scss
+++ b/src/components/slider/_slider.scss
@@ -4,7 +4,7 @@
   background-color: rgba(255, 255, 255, 0.2);
 
   .progress {
-    background-color: var(--playkit-primary-color);
+    background-color: $primary-color;
     height: 8px;
     border-radius: 4px;
     position: relative;

--- a/src/components/slider/_slider.scss
+++ b/src/components/slider/_slider.scss
@@ -1,12 +1,10 @@
-@import '~styles/variables';
-
 .slider {
   height: 8px;
   border-radius: 4px;
   background-color: rgba(255, 255, 255, 0.2);
 
   .progress {
-    background-color: $brand-color;
+    background-color: var(--playkit-primary-color);
     height: 8px;
     border-radius: 4px;
     position: relative;

--- a/src/components/tooltip/_tooltip.scss
+++ b/src/components/tooltip/_tooltip.scss
@@ -11,8 +11,8 @@
   width: 100%;
   .tooltip-label {
     visibility: hidden;
-    background-color: $tooltip-bg-color;
-    color: $tooltip-color;
+    background-color: var(--playkit-tooltip-background-color);
+    color: var(--playkit-tooltip-color);
     text-align: center;
     padding: 4px 6px;
     border-radius: 4px;
@@ -31,7 +31,7 @@
       border-width: 5px;
       border-style: solid;
       border-radius: 3px;
-      color: $tooltip-bg-color;
+      color: var(--playkit-tooltip-background-color);
       z-index: -1;
     }
     &.tooltip-top {

--- a/src/components/tooltip/_tooltip.scss
+++ b/src/components/tooltip/_tooltip.scss
@@ -11,8 +11,8 @@
   width: 100%;
   .tooltip-label {
     visibility: hidden;
-    background-color: var(--playkit-tooltip-background-color);
-    color: var(--playkit-tooltip-color);
+    background-color: $tooltip-background-color;
+    color: $tooltip-color;
     text-align: center;
     padding: 4px 6px;
     border-radius: 4px;
@@ -31,7 +31,7 @@
       border-width: 5px;
       border-style: solid;
       border-radius: 3px;
-      color: var(--playkit-tooltip-background-color);
+      color: $tooltip-background-color;
       z-index: -1;
     }
     &.tooltip-top {

--- a/src/components/top-bar/_top-bar.scss
+++ b/src/components/top-bar/_top-bar.scss
@@ -1,5 +1,3 @@
-@import '~styles/variables';
-
 .player .top-bar {
   background: linear-gradient(0deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.6) 100%);
   color: #fff;

--- a/src/components/video-player/_video-player.scss
+++ b/src/components/video-player/_video-player.scss
@@ -1,5 +1,3 @@
-@import '~styles/variables';
-
 .video-player {
   position: absolute;
   top: 0;

--- a/src/components/video-player/_video-player.scss
+++ b/src/components/video-player/_video-player.scss
@@ -6,7 +6,7 @@
   left: 0;
   width: 100%;
   height: 100%;
-  background: black;
+  background: var(--playkit-player-background-color);
   transition: all #{$default-transition-time}ms;
   transition-property: left, right, bottom, top, width, height;
   .overlay-active & {

--- a/src/components/video-player/_video-player.scss
+++ b/src/components/video-player/_video-player.scss
@@ -4,7 +4,7 @@
   left: 0;
   width: 100%;
   height: 100%;
-  background: var(--playkit-player-background-color);
+  background: $player-background-color;
   transition: all #{$default-transition-time}ms;
   transition-property: left, right, bottom, top, width, height;
   .overlay-active & {

--- a/src/components/volume/_volume.scss
+++ b/src/components/volume/_volume.scss
@@ -1,5 +1,3 @@
-@import '~styles/variables';
-
 .control-button-container {
   &.control-volume,
   &.volume-control {

--- a/src/components/volume/_volume.scss
+++ b/src/components/volume/_volume.scss
@@ -95,7 +95,7 @@
     left: 0;
     width: 100%;
     border-radius: 0 0 2px 2px;
-    background-color: $brand-color;
+    background-color: var(--playkit-primary-color);
   }
 }
 

--- a/src/components/volume/_volume.scss
+++ b/src/components/volume/_volume.scss
@@ -93,7 +93,7 @@
     left: 0;
     width: 100%;
     border-radius: 0 0 2px 2px;
-    background-color: var(--playkit-primary-color);
+    background-color: $primary-color;
   }
 }
 

--- a/src/styles/_buttons.scss
+++ b/src/styles/_buttons.scss
@@ -25,7 +25,7 @@
   }
 
   &.btn-branded {
-    background-color: var(--playkit-primary-color);
+    background-color: $primary-color;
 
     &:hover {
       color: #fff;
@@ -84,11 +84,11 @@
   }
 
   label {
-    color: var(--playkit-tone-1-color);
+    color: $tone-1-color;
   }
 
   &:hover {
-    background-color: var(--playkit-tone-4-color);
+    background-color: $tone-4-color;
   }
 }
 

--- a/src/styles/_buttons.scss
+++ b/src/styles/_buttons.scss
@@ -25,7 +25,7 @@
   }
 
   &.btn-branded {
-    background-color: $brand-color;
+    background-color: var(--playkit-primary-color);
 
     &:hover {
       color: #fff;
@@ -84,11 +84,11 @@
   }
 
   label {
-    color: $color-tone1;
+    color: var(--playkit-tone-1-color);
   }
 
   &:hover {
-    background-color: $color-tone4;
+    background-color: var(--playkit-tone-4-color);
   }
 }
 

--- a/src/styles/_dropdown.scss
+++ b/src/styles/_dropdown.scss
@@ -109,18 +109,13 @@
     }
 
     &.active {
-      color: $brand-color;
-
-      .icon-check {
-        --playkit-icon-data-url: #{icon(check, $brand-color)};
-        background-image: var(--playkit-icon-data-url);
-      }
+      color: var(--playkit-primary-color);
 
       .menu-icon-container {
         opacity: 1;
       }
     }
-    .icon-check {
+    .icon-check-active {
       display: inline-block;
       margin-left: 16px;
       vertical-align: middle;

--- a/src/styles/_dropdown.scss
+++ b/src/styles/_dropdown.scss
@@ -109,7 +109,7 @@
     }
 
     &.active {
-      color: var(--playkit-primary-color);
+      color: $primary-color;
 
       .menu-icon-container {
         opacity: 1;

--- a/src/styles/_dropdown.scss
+++ b/src/styles/_dropdown.scss
@@ -112,7 +112,8 @@
       color: $brand-color;
 
       .icon-check {
-        background-image: icon(check, $brand-color);
+        --playkit-icon-data-url: #{icon(check, $brand-color)};
+        background-image: var(--playkit-icon-data-url);
       }
 
       .menu-icon-container {

--- a/src/styles/_inputs.scss
+++ b/src/styles/_inputs.scss
@@ -5,7 +5,7 @@
     max-width: 100%;
 
     &.has-error .form-control {
-      border-color: var(--playkit-danger-color);
+      border-color: $danger-color;
 
       &:focus {
         border-color: #fff;
@@ -48,14 +48,14 @@
     &:focus {
       background-color: #fff;
       border-color: #fff;
-      color: var(--playkit-tone-7-color);
+      color: $tone-7-color;
 
       &::-webkit-input-placeholder {
-        color: var(--playkit-tone-2-color);
+        color: $tone-2-color;
       }
 
       + .icon {
-        fill: var(--playkit-tone-3-color);
+        fill: $tone-3-color;
       }
     }
   }

--- a/src/styles/_inputs.scss
+++ b/src/styles/_inputs.scss
@@ -5,7 +5,7 @@
     max-width: 100%;
 
     &.has-error .form-control {
-      border-color: $danger-color;
+      border-color: var(--playkit-danger-color);
 
       &:focus {
         border-color: #fff;
@@ -48,14 +48,14 @@
     &:focus {
       background-color: #fff;
       border-color: #fff;
-      color: $grayscale1;
+      color: var(--playkit-tone-7-color);
 
       &::-webkit-input-placeholder {
-        color: $grayscale4;
+        color: var(--playkit-tone-2-color);
       }
 
       + .icon {
-        fill: $grayscale3;
+        fill: var(--playkit-tone-3-color);
       }
     }
   }

--- a/src/styles/_links.scss
+++ b/src/styles/_links.scss
@@ -2,9 +2,10 @@
   font-size: 15px;
   line-height: 18px;
   cursor: pointer;
+  --primary-hover-color: hsl(var(--playkit-primary-hsl-hue) var(--playkit-hsl-saturation) calc(var(--playkit-hsl-lightness) - 10%));
 
   &:hover {
-    color: darken($brand-color, 10%);
+    color: var(--primary-hover-color);
   }
   &:active {
     opacity: 0.7;

--- a/src/styles/_plugin-button.scss
+++ b/src/styles/_plugin-button.scss
@@ -4,7 +4,7 @@
   border-radius: 4px;
   padding: 2px;
   cursor: pointer;
-  color: $tone-1;
+  color: var(--playkit-tone-1-color);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -14,12 +14,12 @@
   margin: 0 4px;
 
   &:hover {
-    background-color: $tone-4;
+    background-color: var(--playkit-tone-4-color);
     opacity: 1;
   }
 
   &:focus {
-    background-color: $tone-6;
+    background-color: var(--playkit-tone-6-color);
     opacity: 1;
   }
 

--- a/src/styles/_plugin-button.scss
+++ b/src/styles/_plugin-button.scss
@@ -4,7 +4,7 @@
   border-radius: 4px;
   padding: 2px;
   cursor: pointer;
-  color: var(--playkit-tone-1-color);
+  color: $tone-1-color;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -14,12 +14,12 @@
   margin: 0 4px;
 
   &:hover {
-    background-color: var(--playkit-tone-4-color);
+    background-color: $tone-4-color;
     opacity: 1;
   }
 
   &:focus {
-    background-color: var(--playkit-tone-6-color);
+    background-color: $tone-6-color;
     opacity: 1;
   }
 

--- a/src/styles/_shell.scss
+++ b/src/styles/_shell.scss
@@ -70,7 +70,7 @@
 .player.nav {
   * {
     &:focus {
-      outline: 1px solid var(--playkit-tab-focus-color) !important;
+      outline: 1px solid $tab-focus-color !important;
     }
   }
 }

--- a/src/styles/_shell.scss
+++ b/src/styles/_shell.scss
@@ -70,7 +70,7 @@
 .player.nav {
   * {
     &:focus {
-      outline: 1px solid $tab-focus-color !important;
+      outline: 1px solid var(--playkit-tab-focus-color) !important;
     }
   }
 }

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -1,10 +1,3 @@
-@import 'exported';
-
-// Static (Compile time) Variables
-$brand-color: #006bff;      // - refs in code and related-plugin
-$white: #ffffff;            // - refs in code and related-plugin
-//$live-color: #da1f26;     - deprecated - related-plugin ref
-
 $headline-font-size: 18px;
 $subheadline-font-size: 14px;
 $tooltip-margin: calc(100% + 10px);
@@ -28,70 +21,52 @@ $bottom-bar-bottom-gutter: 4;
 $gui-gutter: 16;
 $gui-small-gutter: 8;
 $blur: 16px;
-
-// Dynamic (Runtime) Variables
-.player {
-  // HSL args
-  --playkit-primary-hsl-hue: #{hue($brand-color)};
-  //--playkit-primary-hsl-hue: 215deg;
-  --playkit-secondary-hsl-hue: 40deg;
-  --playkit-success-hsl-hue: 136deg;
-  --playkit-danger-hsl-hue: 355deg;
-  --playkit-warning-hsl-hue: 21deg;
-
-  --playkit-hsl-saturation: 100%;
-  --playkit-hsl-lightness: 50%;
-
-  // Accent Colors
-  --playkit-primary-color: hsl(var(--playkit-primary-hsl-hue) var(--playkit-hsl-saturation) var(--playkit-hsl-lightness));
-  --playkit-primary-darker-color: hsl(var(--playkit-primary-hsl-hue) var(--playkit-hsl-saturation) calc(var(--playkit-hsl-lightness) - 15%));
-  --playkit-primary-brighter-color: hsl(var(--playkit-primary-hsl-hue) var(--playkit-hsl-saturation) calc(var(--playkit-hsl-lightness) + 15%));
-  --playkit-primary-text-contrast-color: #ffffff;
-
-  --playkit-secondary-color: hsl(var(--playkit-secondary-hsl-hue) var(--playkit-hsl-saturation) var(--playkit-hsl-lightness));
-  --playkit-secondary-darker-color: hsl(var(--playkit-secondary-hsl-hue) var(--playkit-hsl-saturation) calc(var(--playkit-hsl-lightness) - 15%));
-  --playkit-secondary-brighter-color: hsl(var(--playkit-secondary-hsl-hue) var(--playkit-hsl-saturation) calc(var(--playkit-hsl-lightness) + 15%));
-  --playkit-secondary-text-contrast-color: #ffffff;
-
-  // Acknowledgement Colors
-  --playkit-success-color: hsl(var(--playkit-success-hsl-hue) var(--playkit-hsl-saturation) var(--playkit-hsl-lightness));
-  --playkit-success-darker-color: hsl(var(--playkit-success-hsl-hue) var(--playkit-hsl-saturation) calc(var(--playkit-hsl-lightness) - 15%));
-  --playkit-success-brighter-color: hsl(var(--playkit-success-hsl-hue) var(--playkit-hsl-saturation) calc(var(--playkit-hsl-lightness) + 15%));
-  --playkit-success-text-contrast-color: #ffffff;
-
-  --playkit-danger-color: hsl(var(--playkit-danger-hsl-hue) var(--playkit-hsl-saturation) var(--playkit-hsl-lightness));
-  --playkit-danger-darker-color: hsl(var(--playkit-danger-hsl-hue) var(--playkit-hsl-saturation) calc(var(--playkit-hsl-lightness) - 15%));
-  --playkit-danger-brighter-color: hsl(var(--playkit-danger-hsl-hue) var(--playkit-hsl-saturation) calc(var(--playkit-hsl-lightness) + 15%));
-  --playkit-danger-text-contrast-color: #ffffff;
-
-  --playkit-warning-color: hsl(var(--playkit-warning-hsl-hue) var(--playkit-hsl-saturation) var(--playkit-hsl-lightness));
-  --playkit-warning-darker-color: hsl(var(--playkit-warning-hsl-hue) var(--playkit-hsl-saturation) calc(var(--playkit-hsl-lightness) - 15%));
-  --playkit-warning-brighter-color: hsl(var(--playkit-warning-hsl-hue) var(--playkit-hsl-saturation) calc(var(--playkit-hsl-lightness) + 15%));
-  --playkit-warning-text-contrast-color: #ffffff;
-
-  // Tone Ramp
-  --playkit-tone-1-color: #ffffff;
-  --playkit-tone-2-color: #cccccc;
-  --playkit-tone-3-color: #999999;
-  --playkit-tone-4-color: #888888;
-  --playkit-tone-5-color: #666666;
-  --playkit-tone-6-color: #444444;
-  --playkit-tone-7-color: #222222;
-  --playkit-tone-8-color: #000000;
-
-  --playkit-live-color: #e12536;
-  --playkit-player-background-color: #000000;
-  --playkit-tab-focus-color: var(--playkit-primary-color);
-  --playkit-tooltip-background-color: var(--playkit-tone-1-color);
-  --playkit-tooltip-color: var(--playkit-tone-7-color);
-  --playkit-ads-color: var(--playkit-secondary-color);
-}
+// ***************  Backward Compatibility - Deprecated  **************
+$brand-color: #006bff;     // - refs in playkit-ui and related-plugin
+$white: #ffffff;           // - refs in playkit-ui and related-plugin
+$new-live-color: #e12437;  // - refs in related-plugin
+// ********************************************************************
 
 :export {
-  brandColor: $brand-color;
-  white: $white;
+  primaryColor: $primary-color;
+  primaryDarkerColor: $primary-darker-color;
+  primaryBrighterColor: $primary-brighter-color;
+  primaryTextContrastColor: $primary-text-contrast-color;
+  secondaryColor: $secondary-color;
+  secondaryDarkerColor: $secondary-darker-color;
+  secondaryBrighterColor: $secondary-brighter-color;
+  secondaryTextContrastColor: $secondary-text-contrast-color;
+  successDarkerColor: $success-darker-color;
+  successBrighterColor: $success-brighter-color;
+  successTextContrastColor: $success-text-contrast-color;
+  dangerColor: $danger-color;
+  dangerDarkerColor: $danger-darker-color;
+  dangerBrighterColor: $danger-brighter-color;
+  danger-text-contrast-color: $danger-text-contrast-color;
+  warningColor: $warning-color;
+  warningDarkerColor: $warning-darker-color;
+  warningBrighterColor: $warning-brighter-color;
+  warningTextContrastColor: $warning-text-contrast-color;
+  tone1Color: $tone-1-color;
+  tone2Color: $tone-2-color;
+  tone3Color: $tone-3-color;
+  tone4Color: $tone-4-color;
+  tone5Color: $tone-5-color;
+  tone6Color: $tone-6-color;
+  tone7Color: $tone-7-color;
+  tone8Color: $tone-8-color;
+  liveColor: $live-color;
+  playerBackgroundColor: $player-background-color;
+  tabFocusColor: $tab-focus-color;
+  tooltipBackgroundColor: $tooltip-background-color;
+  tooltipColor: $tooltip-color;
+  adsColor: $ads-color;
   progressBarHeight: $progress-bar-height;
   progressBarBorderRadius: $progress-bar-border-radius;
   defaultTransitionTime: $default-transition-time;
   bottomBarMaxHeight: $bottom-bar-max-height;
+  // ***************  Backward Compatibility - Deprecated  **************
+  brandColor: $brand-color;
+  white: $white;
+  // ********************************************************************
 }

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -1,27 +1,20 @@
 @import 'exported';
 
-$brand-color: #006bff;
-$brand-color-dark: #004bb3;
-$brand-color-light: #4d89ff;
-$brand-color-text-contrast: #ffffff;
-$tab-focus-color: $brand-color;
-
-// Old version - deprecated
-$white: #ffffff;
-$grayscale1: #333;
-$grayscale2: #424242;
-$grayscale3: #999;
-$grayscale4: #cccccc;
+// Static (Compile time) Variables
+$brand-color: #006bff;      // - refs in code and related-plugin
+$white: #ffffff;            // - refs in code and related-plugin
+//$grayscale1: #333         - deprecated - no refs;
+//$grayscale2: #424242      - deprecated - no refs;
+//$grayscale3: #999         - deprecated - no refs;
+//$grayscale4: #cccccc      - deprecated - no refs;
+//$success-color: #009444;  - deprecated - no refs
+//$danger-color: #db1f26;   - deprecated - no refs
+//$ads-color: #f9a71b;      - deprecated - no refs
+//$live-color: #da1f26;     - deprecated - related-plugin ref
+//$new-live-color: #e12437; - deprecated - no refs
 
 $headline-font-size: 18px;
 $subheadline-font-size: 14px;
-$success-color: #009444;
-$danger-color: #db1f26;
-$ads-color: #f9a71b;
-$live-color: #da1f26;
-$new-live-color: #e12437;
-$tooltip-bg-color: $tone-1;
-$tooltip-color: $tone-7;
 $tooltip-margin: calc(100% + 10px);
 $tooltip-arrow-height: 4px;
 $tooltip-arrow-width: 5px;
@@ -32,7 +25,7 @@ $progress-bar-height: 4px;
 $progress-bar-border-radius: $progress-bar-height / 2;
 $spinner-circle-radius: 4px;
 $spinner-colors: rgb(218, 31, 38), rgb(6, 168, 133), rgb(0, 147, 68), rgb(248, 166, 26), rgb(27, 74, 151), rgb(0, 171, 204), rgb(177, 210, 56),
-  rgb(252, 210, 3);
+rgb(252, 210, 3);
 $default-transition-time: 500;
 $default-hovering-offset: 60px;
 $hover-animation-time: 100;
@@ -44,13 +37,67 @@ $gui-gutter: 16;
 $gui-small-gutter: 8;
 $blur: 16px;
 
-$color-tone1: #ffffff;
-$color-tone4: #888888;
-$color-tone6: #444444;
+// Dynamic (Runtime) Variables
+:root {
+  // HSL args
+  --playkit-primary-hsl-hue: #{hue($brand-color)};
+  //--playkit-primary-hsl-hue: 215deg;
+  --playkit-secondary-hsl-hue: 40deg;
+  --playkit-success-hsl-hue: 136deg;
+  --playkit-danger-hsl-hue: 355deg;
+  --playkit-warning-hsl-hue: 21deg;
+
+  --playkit-hsl-saturation: 100%;
+  --playkit-hsl-lightness: 50%;
+
+  // Accent Colors
+  --playkit-primary-color: hsl(var(--playkit-primary-hsl-hue) var(--playkit-hsl-saturation) var(--playkit-hsl-lightness));
+  --playkit-primary-darker-color: hsl(var(--playkit-primary-hsl-hue) var(--playkit-hsl-saturation) calc(var(--playkit-hsl-lightness) - 15%));
+  --playkit-primary-brighter-color: hsl(var(--playkit-primary-hsl-hue) var(--playkit-hsl-saturation) calc(var(--playkit-hsl-lightness) + 15%));
+  --playkit-primary-text-contrast-color: #ffffff;
+
+  --playkit-secondary-color: hsl(var(--playkit-secondary-hsl-hue) var(--playkit-hsl-saturation) var(--playkit-hsl-lightness));
+  --playkit-secondary-darker-color: hsl(var(--playkit-secondary-hsl-hue) var(--playkit-hsl-saturation) calc(var(--playkit-hsl-lightness) - 15%));
+  --playkit-secondary-brighter-color: hsl(var(--playkit-secondary-hsl-hue) var(--playkit-hsl-saturation) calc(var(--playkit-hsl-lightness) + 15%));
+  --playkit-secondary-text-contrast-color: #ffffff;
+
+  // Acknowledgement Colors
+  --playkit-success-color: hsl(var(--playkit-success-hsl-hue) var(--playkit-hsl-saturation) var(--playkit-hsl-lightness));
+  --playkit-success-darker-color: hsl(var(--playkit-success-hsl-hue) var(--playkit-hsl-saturation) calc(var(--playkit-hsl-lightness) - 15%));
+  --playkit-success-brighter-color: hsl(var(--playkit-success-hsl-hue) var(--playkit-hsl-saturation) calc(var(--playkit-hsl-lightness) + 15%));
+  --playkit-success-text-contrast-color: #ffffff;
+
+  --playkit-danger-color: hsl(var(--playkit-danger-hsl-hue) var(--playkit-hsl-saturation) var(--playkit-hsl-lightness));
+  --playkit-danger-darker-color: hsl(var(--playkit-danger-hsl-hue) var(--playkit-hsl-saturation) calc(var(--playkit-hsl-lightness) - 15%));
+  --playkit-danger-brighter-color: hsl(var(--playkit-danger-hsl-hue) var(--playkit-hsl-saturation) calc(var(--playkit-hsl-lightness) + 15%));
+  --playkit-danger-text-contrast-color: #ffffff;
+
+  --playkit-warning-color: hsl(var(--playkit-warning-hsl-hue) var(--playkit-hsl-saturation) var(--playkit-hsl-lightness));
+  --playkit-warning-darker-color: hsl(var(--playkit-warning-hsl-hue) var(--playkit-hsl-saturation) calc(var(--playkit-hsl-lightness) - 15%));
+  --playkit-warning-brighter-color: hsl(var(--playkit-warning-hsl-hue) var(--playkit-hsl-saturation) calc(var(--playkit-hsl-lightness) + 15%));
+  --playkit-warning-text-contrast-color: #ffffff;
+
+  // Tone Ramp
+  --playkit-tone-1-color: #ffffff;
+  --playkit-tone-2-color: #cccccc;
+  --playkit-tone-3-color: #999999;
+  --playkit-tone-4-color: #888888;
+  --playkit-tone-5-color: #666666;
+  --playkit-tone-6-color: #444444;
+  --playkit-tone-7-color: #222222;
+  --playkit-tone-8-color: #000000;
+
+  --playkit-live-color: #e12536;
+  --playkit-player-background-color: #000000;
+  --playkit-tab-focus-color: var(--playkit-primary-color);
+  --playkit-tooltip-background-color: var(--playkit-tone-1-color);
+  --playkit-tooltip-color: var(--playkit-tone-7-color);
+  --playkit-ads-color: var(--playkit-secondary-color);
+}
 
 :export {
   brandColor: $brand-color;
-  liveColor: $new-live-color;
+  //liveColor: $new-live-color;
   white: $white;
   progressBarHeight: $progress-bar-height;
   progressBarBorderRadius: $progress-bar-border-radius;

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -3,15 +3,7 @@
 // Static (Compile time) Variables
 $brand-color: #006bff;      // - refs in code and related-plugin
 $white: #ffffff;            // - refs in code and related-plugin
-//$grayscale1: #333         - deprecated - no refs;
-//$grayscale2: #424242      - deprecated - no refs;
-//$grayscale3: #999         - deprecated - no refs;
-//$grayscale4: #cccccc      - deprecated - no refs;
-//$success-color: #009444;  - deprecated - no refs
-//$danger-color: #db1f26;   - deprecated - no refs
-//$ads-color: #f9a71b;      - deprecated - no refs
 //$live-color: #da1f26;     - deprecated - related-plugin ref
-//$new-live-color: #e12437; - deprecated - no refs
 
 $headline-font-size: 18px;
 $subheadline-font-size: 14px;
@@ -38,7 +30,7 @@ $gui-small-gutter: 8;
 $blur: 16px;
 
 // Dynamic (Runtime) Variables
-:root {
+.player {
   // HSL args
   --playkit-primary-hsl-hue: #{hue($brand-color)};
   //--playkit-primary-hsl-hue: 215deg;
@@ -97,7 +89,6 @@ $blur: 16px;
 
 :export {
   brandColor: $brand-color;
-  //liveColor: $new-live-color;
   white: $white;
   progressBarHeight: $progress-bar-height;
   progressBarBorderRadius: $progress-bar-border-radius;

--- a/src/styles/dynamaic-variables.scss
+++ b/src/styles/dynamaic-variables.scss
@@ -1,0 +1,56 @@
+.player {
+  // HSL args
+  //--playkit-primary-hsl-hue: #{hue($brand-color)};
+  --playkit-primary-hsl-hue: 215deg;
+  --playkit-secondary-hsl-hue: 40deg;
+  --playkit-success-hsl-hue: 136deg;
+  --playkit-danger-hsl-hue: 355deg;
+  --playkit-warning-hsl-hue: 21deg;
+
+  --playkit-hsl-saturation: 100%;
+  --playkit-hsl-lightness: 50%;
+
+  // Accent Colors
+  --playkit-primary-color: hsl(var(--playkit-primary-hsl-hue) var(--playkit-hsl-saturation) var(--playkit-hsl-lightness));
+  --playkit-primary-darker-color: hsl(var(--playkit-primary-hsl-hue) var(--playkit-hsl-saturation) calc(var(--playkit-hsl-lightness) - 15%));
+  --playkit-primary-brighter-color: hsl(var(--playkit-primary-hsl-hue) var(--playkit-hsl-saturation) calc(var(--playkit-hsl-lightness) + 15%));
+  --playkit-primary-text-contrast-color: #ffffff;
+
+  --playkit-secondary-color: hsl(var(--playkit-secondary-hsl-hue) var(--playkit-hsl-saturation) var(--playkit-hsl-lightness));
+  --playkit-secondary-darker-color: hsl(var(--playkit-secondary-hsl-hue) var(--playkit-hsl-saturation) calc(var(--playkit-hsl-lightness) - 15%));
+  --playkit-secondary-brighter-color: hsl(var(--playkit-secondary-hsl-hue) var(--playkit-hsl-saturation) calc(var(--playkit-hsl-lightness) + 15%));
+  --playkit-secondary-text-contrast-color: #ffffff;
+
+  // Acknowledgement Colors
+  --playkit-success-color: hsl(var(--playkit-success-hsl-hue) var(--playkit-hsl-saturation) var(--playkit-hsl-lightness));
+  --playkit-success-darker-color: hsl(var(--playkit-success-hsl-hue) var(--playkit-hsl-saturation) calc(var(--playkit-hsl-lightness) - 15%));
+  --playkit-success-brighter-color: hsl(var(--playkit-success-hsl-hue) var(--playkit-hsl-saturation) calc(var(--playkit-hsl-lightness) + 15%));
+  --playkit-success-text-contrast-color: #ffffff;
+
+  --playkit-danger-color: hsl(var(--playkit-danger-hsl-hue) var(--playkit-hsl-saturation) var(--playkit-hsl-lightness));
+  --playkit-danger-darker-color: hsl(var(--playkit-danger-hsl-hue) var(--playkit-hsl-saturation) calc(var(--playkit-hsl-lightness) - 15%));
+  --playkit-danger-brighter-color: hsl(var(--playkit-danger-hsl-hue) var(--playkit-hsl-saturation) calc(var(--playkit-hsl-lightness) + 15%));
+  --playkit-danger-text-contrast-color: #ffffff;
+
+  --playkit-warning-color: hsl(var(--playkit-warning-hsl-hue) var(--playkit-hsl-saturation) var(--playkit-hsl-lightness));
+  --playkit-warning-darker-color: hsl(var(--playkit-warning-hsl-hue) var(--playkit-hsl-saturation) calc(var(--playkit-hsl-lightness) - 15%));
+  --playkit-warning-brighter-color: hsl(var(--playkit-warning-hsl-hue) var(--playkit-hsl-saturation) calc(var(--playkit-hsl-lightness) + 15%));
+  --playkit-warning-text-contrast-color: #ffffff;
+
+  // Tone Ramp
+  --playkit-tone-1-color: #ffffff;
+  --playkit-tone-2-color: #cccccc;
+  --playkit-tone-3-color: #999999;
+  --playkit-tone-4-color: #888888;
+  --playkit-tone-5-color: #666666;
+  --playkit-tone-6-color: #444444;
+  --playkit-tone-7-color: #222222;
+  --playkit-tone-8-color: #000000;
+
+  --playkit-live-color: #e12536;
+  --playkit-player-background-color: #000000;
+  --playkit-tab-focus-color: var(--playkit-primary-color);
+  --playkit-tooltip-background-color: var(--playkit-tone-1-color);
+  --playkit-tooltip-color: var(--playkit-tone-7-color);
+  --playkit-ads-color: var(--playkit-secondary-color);
+}

--- a/src/styles/exported.scss
+++ b/src/styles/exported.scss
@@ -1,2 +1,45 @@
 // Sass variables exported using the npm package for plugins usage
 
+// Accent Colors
+$primary-color: var(--playkit-primary-color);
+$primary-darker-color: var(--playkit-primary-darker-color);
+$primary-brighter-color: var(--playkit-primary-brighter-color);
+$primary-text-contrast-color: var(--playkit-primary-text-contrast-color);
+
+$secondary-color: var(--playkit-secondary-color);
+$secondary-darker-color: var(--playkit-secondary-darker-color);
+$secondary-brighter-color: var(--playkit-secondary-brighter-color);
+$secondary-text-contrast-color: var(--playkit-secondary-text-contrast-color);
+
+// Acknowledgement Colors
+$success-color: var(--playkit-success-color);
+$success-darker-color: var(--playkit-success-darker-color);
+$success-brighter-color: var(--playkit-success-brighter-color);
+$success-text-contrast-color: var(--playkit-success-text-contrast-color);
+
+$danger-color: var(--playkit-danger-color);
+$danger-darker-color: var(--playkit-danger-darker-color);
+$danger-brighter-color: var(--playkit-danger-brighter-color);
+$danger-text-contrast-color: var(--playkit-danger-text-contrast-color);
+
+$warning-color: var(--playkit-warning-color);
+$warning-darker-color: var(--playkit-warning-darker-color);
+$warning-brighter-color: var(--playkit-warning-brighter-color);
+$warning-text-contrast-color: var(--playkit-warning-text-contrast-color);
+
+// Tone Ramp
+$tone-1-color: var(--playkit-tone-1-color);
+$tone-2-color: var(--playkit-tone-2-color);
+$tone-3-color: var(--playkit-tone-3-color);
+$tone-4-color: var(--playkit-tone-4-color);
+$tone-5-color: var(--playkit-tone-5-color);
+$tone-6-color: var(--playkit-tone-6-color);
+$tone-7-color: var(--playkit-tone-7-color);
+$tone-8-color: var(--playkit-tone-8-color);
+
+$live-color: var(--playkit-live-color);
+$player-background-color: var(--playkit-player-background-color);
+$tab-focus-color: var(--playkit-tab-focus-color);
+$tooltip-background-color: var(--playkit-tooltip-background-color);
+$tooltip-color: var(--playkit-tooltip-color);
+$ads-color: var(--playkit-ads-color);

--- a/src/styles/exported.scss
+++ b/src/styles/exported.scss
@@ -1,11 +1,2 @@
 // Sass variables exported using the npm package for plugins usage
 
-// New version - upcoming
-$tone-1: #ffffff;
-$tone-2: #cccccc;
-$tone-3: #999999;
-$tone-4: #888888;
-$tone-5: #666666;
-$tone-6: #444444;
-$tone-7: #222222;
-$tone-8: #000000;

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -1,4 +1,6 @@
 // base
+@import 'dynamaic-variables';
+@import 'exported';
 @import 'variables';
 @import 'utils';
 @import 'inputs';

--- a/src/ui-manager.js
+++ b/src/ui-manager.js
@@ -44,6 +44,7 @@ class UIManager {
   _locale: string = 'en';
   _uiComponents: Array<KPUIComponent>;
   addComponent: (component: KPUIComponent) => Function;
+  _themesManager: ThemesManager;
 
   /**
    * Creates an instance of UIManager.

--- a/src/ui-manager.js
+++ b/src/ui-manager.js
@@ -28,6 +28,7 @@ import {middleware} from './middlewares';
 import './styles/style.scss';
 import {EventDispatcherProvider} from 'components/event-dispatcher';
 import {KeyboardEventProvider} from 'components/keyboard/keyboard-event-provider';
+import {ThemesManager} from 'utils/themes-manager';
 
 /**
  * API used for building UIs based on state conditions
@@ -58,6 +59,7 @@ class UIManager {
     this._createStore(config);
     this.setConfig(config);
     this._setLocaleTranslations(config);
+    this._themesManager = new ThemesManager(player, config.userTheme);
     setEnv(this.player.env);
   }
 
@@ -112,6 +114,7 @@ class UIManager {
       {template: props => presets.playbackUI(props)}
     ];
     this._buildUI(uis);
+    this._themesManager.applyUserTheme();
   }
 
   /**

--- a/src/utils/color-format-convertors.js
+++ b/src/utils/color-format-convertors.js
@@ -1,5 +1,9 @@
 // These color convertors based on https://www.npmjs.com/package/color-convert
-// eslint-disable-next-line require-jsdoc
+/**
+ * Convert css color form HEX to RGB format.
+ * @param {string} args  - css color in HEX format
+ * @returns {string} - css color in RGB format
+ */
 export function hexToRgb(args) {
   const match = args.toString().match(/[a-f0-9]{6}|[a-f0-9]{3}/i);
   if (!match) {
@@ -11,7 +15,7 @@ export function hexToRgb(args) {
   if (match[0].length === 3) {
     colorString = colorString
       .split('')
-      .map((char) => {
+      .map(char => {
         return char + char;
       })
       .join('');
@@ -25,7 +29,11 @@ export function hexToRgb(args) {
   return [r, g, b];
 }
 
-// eslint-disable-next-line require-jsdoc
+/**
+ * Convert css color form RGB to HSL format.
+ * @param {string} rgb  - css color in RGB format
+ * @returns {string} - css color in HSL format
+ */
 export function rgbToHsl(rgb) {
   const r = rgb[0] / 255;
   const g = rgb[1] / 255;
@@ -46,8 +54,6 @@ export function rgbToHsl(rgb) {
     h = 4 + (r - g) / delta;
   }
 
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
   h = Math.min(h * 60, 360);
 
   if (h < 0) {
@@ -67,7 +73,21 @@ export function rgbToHsl(rgb) {
   return [h, s * 100, l * 100];
 }
 
-// eslint-disable-next-line require-jsdoc
-export function hexToHsl(hex) {
+/**
+ * Convert css color form HEX to HSL format.
+ * @param {string} hex  - css color in HEX format
+ * @returns {string} - css color in HSL format
+ */
+function hexToHsl(hex) {
   return rgbToHsl(hexToRgb(hex));
+}
+
+/**
+ * Extract the Hue parameter from HSL color format.
+ * @param {string} hex  - css color in HEX format
+ * @returns {void}
+ */
+export function getHueComponentOfHEXColorFormat(hex) {
+  const hsl = hexToHsl(hex);
+  return hsl[0];
 }

--- a/src/utils/color-format-convertors.js
+++ b/src/utils/color-format-convertors.js
@@ -1,0 +1,73 @@
+// These color convertors based on https://www.npmjs.com/package/color-convert
+// eslint-disable-next-line require-jsdoc
+export function hexToRgb(args) {
+  const match = args.toString().match(/[a-f0-9]{6}|[a-f0-9]{3}/i);
+  if (!match) {
+    return [0, 0, 0];
+  }
+
+  let colorString = match[0];
+
+  if (match[0].length === 3) {
+    colorString = colorString
+      .split('')
+      .map((char) => {
+        return char + char;
+      })
+      .join('');
+  }
+
+  const integer = parseInt(colorString, 16);
+  const r = (integer >> 16) & 0xff;
+  const g = (integer >> 8) & 0xff;
+  const b = integer & 0xff;
+
+  return [r, g, b];
+}
+
+// eslint-disable-next-line require-jsdoc
+export function rgbToHsl(rgb) {
+  const r = rgb[0] / 255;
+  const g = rgb[1] / 255;
+  const b = rgb[2] / 255;
+  const min = Math.min(r, g, b);
+  const max = Math.max(r, g, b);
+  const delta = max - min;
+  let h;
+  let s;
+
+  if (max === min) {
+    h = 0;
+  } else if (r === max) {
+    h = (g - b) / delta;
+  } else if (g === max) {
+    h = 2 + (b - r) / delta;
+  } else if (b === max) {
+    h = 4 + (r - g) / delta;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  h = Math.min(h * 60, 360);
+
+  if (h < 0) {
+    h += 360;
+  }
+
+  const l = (min + max) / 2;
+
+  if (max === min) {
+    s = 0;
+  } else if (l <= 0.5) {
+    s = delta / (max + min);
+  } else {
+    s = delta / (2 - max - min);
+  }
+
+  return [h, s * 100, l * 100];
+}
+
+// eslint-disable-next-line require-jsdoc
+export function hexToHsl(hex) {
+  return rgbToHsl(hexToRgb(hex));
+}

--- a/src/utils/themes-manager.js
+++ b/src/utils/themes-manager.js
@@ -3,7 +3,7 @@
 import {getHueComponentOfHEXColorFormat} from './color-format-convertors';
 import {style} from '../index';
 
-const cssVarNames: ThemesManagerConfig = {
+const cssVarNames = {
   colors: {
     primary: '--playkit-primary-hsl-hue',
     secondary: '--playkit-secondary-hsl-hue',
@@ -30,7 +30,7 @@ export class ThemesManager {
   config: Object;
 
   // eslint-disable-next-line require-jsdoc
-  constructor(player: Object, config: UserTheme) {
+  constructor(player: Object, config: ?UserTheme) {
     this.player = player;
     this.config = config;
   }
@@ -47,10 +47,10 @@ export class ThemesManager {
 
   /**
    * Override the colors from config.
-   * @param {ThemesManagerConfig} config  -
+   * @param {UserTheme} config  -
    * @returns {void}
    */
-  setColors(config: ThemesManagerConfig): void {
+  setColors(config: UserTheme): void {
     if (config.colors.primary) {
       this.setSvgFillColor(config.colors.primary);
     }
@@ -68,7 +68,7 @@ export class ThemesManager {
    */
   setColor(cssVarName: string, color: string): void {
     const hue = getHueComponentOfHEXColorFormat(color);
-    document.querySelector<HTMLElement>(`.${style.player}`).style.setProperty(cssVarName, `${hue}deg`);
+    document.querySelector(`.${style.player}`)?.style.setProperty(cssVarName, `${hue}deg`);
   }
 
   /**
@@ -78,11 +78,10 @@ export class ThemesManager {
    */
   setSvgFillColor(color: string): void {
     for (const varName of dynamicColoredIconsSvgUrlVars) {
-      const svgUrl = getComputedStyle(document.querySelector(`.${style.player}`)).getPropertyValue(varName);
+      // $FlowFixMe
+      const svgUrl = getComputedStyle(document.querySelector(`.${style.player}`))?.getPropertyValue(varName);
       const newColor = color.replace('#', '%23');
-      document
-        .querySelector<HTMLElement>(`.${style.player}`)
-        .style.setProperty(varName, svgUrl.replace(/fill='%23([a-f0-9]{3}){1,2}\b'/, `fill='${newColor}'`));
+      document.querySelector(`.${style.player}`)?.style.setProperty(varName, svgUrl.replace(/fill='%23([a-f0-9]{3}){1,2}\b'/, `fill='${newColor}'`));
     }
   }
 }

--- a/src/utils/themes-manager.js
+++ b/src/utils/themes-manager.js
@@ -1,0 +1,79 @@
+//@flow
+
+import {hexToHsl} from './color-format-convertors';
+import {style} from '../index';
+
+const cssVarNames: ThemesManagerConfig = {
+  colors: {
+    primary: '--playkit-primary-hsl-hue',
+    secondary: '--playkit-secondary-hsl-hue',
+    success: '--playkit-success-hsl-hue',
+    danger: '--playkit-danger-hsl-hue',
+    warning: '--playkit-warning-hsl-hue',
+    live: '--playkit-live-color',
+    playerBackground: '--playkit-player-background-color'
+  }
+};
+
+const dynamicColoredIconsSvgUrlVars = [
+  '--playkit-icon-check-active-url',
+  '--playkit-icon-data-url',
+  '--playkit-icon-chromecast-url',
+  '--playkit-icon-quality-HD-active-url',
+  '--playkit-icon-quality-4K-active-url',
+  '--playkit-icon-quality-8K-active-url'
+];
+
+// eslint-disable-next-line require-jsdoc
+export class ThemesManager {
+  player: Object;
+  config: Object;
+
+  // eslint-disable-next-line require-jsdoc
+  constructor(player: Object, config: UserTheme) {
+    this.player = player;
+    this.config = config;
+  }
+
+  // eslint-disable-next-line require-jsdoc
+  applyUserTheme(): void {
+    if (this.config) {
+      this.setColors(this.config);
+    }
+  }
+
+  // eslint-disable-next-line require-jsdoc
+  getHueComponent(hex: string): number {
+    const hsl = hexToHsl(hex);
+    return hsl[0];
+  }
+
+  // eslint-disable-next-line require-jsdoc
+  setColors(config: ThemesManagerConfig): void {
+    if (config.colors.primary) {
+      // this.setColor(cssVarNames.colors.primary, config.colors.primary);
+      this.setSvgFillColor(config.colors.primary);
+    }
+
+    for (const color in config.colors) {
+      this.setColor(cssVarNames.colors[color], config.colors[color]);
+    }
+  }
+
+  // eslint-disable-next-line require-jsdoc
+  setColor(cssVarName: string, color: string): void {
+    const hue = this.getHueComponent(color);
+    document.querySelector<HTMLElement>('.playkit-player').style.setProperty(cssVarName, `${hue}deg`);
+  }
+
+  // eslint-disable-next-line require-jsdoc
+  setSvgFillColor(color: string): void {
+    for (const varName of dynamicColoredIconsSvgUrlVars) {
+      const svgUrl = getComputedStyle(document.querySelector(`.${style.player}`)).getPropertyValue(varName);
+      const newColor = color.replace('#', '%23');
+      document
+        .querySelector<HTMLElement>(`.${style.player}`)
+        .style.setProperty(varName, svgUrl.replace(/fill='%23([a-f0-9]{3}){1,2}\b'/, `fill='${newColor}'`));
+    }
+  }
+}

--- a/src/utils/themes-manager.js
+++ b/src/utils/themes-manager.js
@@ -1,6 +1,6 @@
 //@flow
 
-import {hexToHsl} from './color-format-convertors';
+import {getHueComponentOfHEXColorFormat} from './color-format-convertors';
 import {style} from '../index';
 
 const cssVarNames: ThemesManagerConfig = {
@@ -35,23 +35,23 @@ export class ThemesManager {
     this.config = config;
   }
 
-  // eslint-disable-next-line require-jsdoc
+  /**
+   * Apply the user theme from config (should be called only after the UI was build and the css vars are exist in the DOM).
+   * @returns {void}
+   */
   applyUserTheme(): void {
     if (this.config) {
       this.setColors(this.config);
     }
   }
 
-  // eslint-disable-next-line require-jsdoc
-  getHueComponent(hex: string): number {
-    const hsl = hexToHsl(hex);
-    return hsl[0];
-  }
-
-  // eslint-disable-next-line require-jsdoc
+  /**
+   * Override the colors from config.
+   * @param {ThemesManagerConfig} config  -
+   * @returns {void}
+   */
   setColors(config: ThemesManagerConfig): void {
     if (config.colors.primary) {
-      // this.setColor(cssVarNames.colors.primary, config.colors.primary);
       this.setSvgFillColor(config.colors.primary);
     }
 
@@ -60,13 +60,22 @@ export class ThemesManager {
     }
   }
 
-  // eslint-disable-next-line require-jsdoc
+  /**
+   * Override the specified css var value.
+   * @param {string} cssVarName -
+   * @param {string} color  -
+   * @returns {void}
+   */
   setColor(cssVarName: string, color: string): void {
-    const hue = this.getHueComponent(color);
-    document.querySelector<HTMLElement>('.playkit-player').style.setProperty(cssVarName, `${hue}deg`);
+    const hue = getHueComponentOfHEXColorFormat(color);
+    document.querySelector<HTMLElement>(`.${style.player}`).style.setProperty(cssVarName, `${hue}deg`);
   }
 
-  // eslint-disable-next-line require-jsdoc
+  /**
+   * Update the SVG url (of dynamic SVGs) with the new primary color.
+   * @param {string} color  -
+   * @returns {void}
+   */
   setSvgFillColor(color: string): void {
     for (const varName of dynamicColoredIconsSvgUrlVars) {
       const svgUrl = getComputedStyle(document.querySelector(`.${style.player}`)).getPropertyValue(varName);


### PR DESCRIPTION
### Description of the Changes

1. Organizing the player's palette (and add some new colors) 
2.  Moved all configurable colors from a static (sass) variable to dynamic (css) variable
3.  Added logic to calculate the secondary colors from the primary color (so that a user can only choose the primary color in the studio and the secondary ones will be derived from the primary one)
4. move the date-url of  dynamic SVG icons (Those whose color changes in active mode to the color of the main color) to a variable so they can be changed at runtime (our current icons infrastructures uses sass functions to generate the data-url which are not useful at runtime but only at compile time)
5. add theme manager service that get the user configured style and apply the style

related pr: https://github.com/kaltura/playkit-js-ui-managers/pull/18

solves: FEC-12700

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
