### PR TITLE
fix(FEC-12763): Volume slider is inaccessible for JAWS screen reader

### DIFF
--- a/src/components/volume/volume.js
+++ b/src/components/volume/volume.js
@@ -400,6 +400,7 @@ class Volume extends Component {
 
     return (
       <ButtonControl
+        role="application"
         name={COMPONENT_NAME}
         ref={c => (c ? (this._volumeControlElement = c) : undefined)}
         className={controlButtonClasses}


### PR DESCRIPTION
### Description of the Changes

**the issue:**
JAWS and NVDA screen readers wasn't able to open the volume slider by up/down arrow

**the root cause:**
JWAS and NVDA have default behavior for the up/down keyboard events. so it doesn't recognize our handling 

**the solution:**
add role='application' to enable non-default behavior for keyboard events

solves FEC-12763

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
