### PR TITLE
fix(FEC-12772): info content is not readable by screen reader

### DIFF
--- a/src/components/overlay-portal/overlay-portal.js
+++ b/src/components/overlay-portal/overlay-portal.js
@@ -29,7 +29,11 @@ class OverlayPortal extends Component {
    * @memberof OverlayPortal
    */
   render(props: any): React$Element<any> {
-    return <div className="overlay-portal">{props.children}</div>;
+    return (
+      <div className="overlay-portal" aria-live="polite">
+        {props.children}
+      </div>
+    );
   }
 }
 


### PR DESCRIPTION
### Description of the Changes

add `aria-live=polite` to allow the screen readers to read the content in overlay-portal.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
