### PR TITLE
fix(FEC-12497): Background color of plugin icon should not changed on focus state

### DIFF
--- a/src/styles/_plugin-button.scss
+++ b/src/styles/_plugin-button.scss
@@ -18,7 +18,7 @@
     opacity: 1;
   }
 
-  &:focus {
+  &:active {
     background-color: $tone-6;
     opacity: 1;
   }


### PR DESCRIPTION
### Description of the Changes

Background color of plugin icon should not changed on focus state

solves FEC-12497

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
