### PR TITLE
fix(FEC-12728): Buttons for caption customization do not have descriptive names (they all say, "sample")

### DIFF
--- a/src/components/cvaa-overlay/main-captions_window.js
+++ b/src/components/cvaa-overlay/main-captions_window.js
@@ -86,7 +86,7 @@ class MainCaptionsWindow extends Component {
             changeCaptionsStyle={props.changeCaptionsStyle}
             captionsStyle={this.captionsStyleDefault}
             player={props.player}
-            buttonNumber={'1'}
+            sampleNumber={'1'}
           />
           <SampleCaptionsStyleButton
             addAccessibleChild={props.addAccessibleChild}
@@ -94,7 +94,7 @@ class MainCaptionsWindow extends Component {
             changeCaptionsStyle={props.changeCaptionsStyle}
             captionsStyle={this.captionsStyleBlackBG}
             player={props.player}
-            buttonNumber={'2'}
+            sampleNumber={'2'}
           />
           <SampleCaptionsStyleButton
             addAccessibleChild={props.addAccessibleChild}
@@ -102,7 +102,7 @@ class MainCaptionsWindow extends Component {
             changeCaptionsStyle={props.changeCaptionsStyle}
             captionsStyle={this.captionsStyleYellow}
             player={props.player}
-            buttonNumber={'3'}
+            sampleNumber={'3'}
           />
         </div>
         {!this.isAdvancedStyleApplied() ? (

--- a/src/components/cvaa-overlay/main-captions_window.js
+++ b/src/components/cvaa-overlay/main-captions_window.js
@@ -86,6 +86,7 @@ class MainCaptionsWindow extends Component {
             changeCaptionsStyle={props.changeCaptionsStyle}
             captionsStyle={this.captionsStyleDefault}
             player={props.player}
+            buttonNumber={'1'}
           />
           <SampleCaptionsStyleButton
             addAccessibleChild={props.addAccessibleChild}
@@ -93,6 +94,7 @@ class MainCaptionsWindow extends Component {
             changeCaptionsStyle={props.changeCaptionsStyle}
             captionsStyle={this.captionsStyleBlackBG}
             player={props.player}
+            buttonNumber={'2'}
           />
           <SampleCaptionsStyleButton
             addAccessibleChild={props.addAccessibleChild}
@@ -100,6 +102,7 @@ class MainCaptionsWindow extends Component {
             changeCaptionsStyle={props.changeCaptionsStyle}
             captionsStyle={this.captionsStyleYellow}
             player={props.player}
+            buttonNumber={'3'}
           />
         </div>
         {!this.isAdvancedStyleApplied() ? (

--- a/src/components/cvaa-overlay/sample-captions-style-button.js
+++ b/src/components/cvaa-overlay/sample-captions-style-button.js
@@ -38,7 +38,7 @@ const SampleCaptionsStyleButton = (props: any): React$Element<any> => {
       className={props.classNames.join(' ')}
       onClick={changeCaptionsStyle}
       onKeyDown={onKeyDown}>
-      <Text id={'cvaa.sample_caption_tag'} />
+      <Text id={'cvaa.sample_caption_tag'} fields={{number: props.buttonNumber}} />
       {props.player.textStyle.isEqual(props.captionsStyle) ? (
         <div className={style.activeTick}>
           <Icon type={IconType.Check} />

--- a/src/components/cvaa-overlay/sample-captions-style-button.js
+++ b/src/components/cvaa-overlay/sample-captions-style-button.js
@@ -38,7 +38,7 @@ const SampleCaptionsStyleButton = (props: any): React$Element<any> => {
       className={props.classNames.join(' ')}
       onClick={changeCaptionsStyle}
       onKeyDown={onKeyDown}>
-      <Text id={'cvaa.sample_caption_tag'} fields={{number: props.buttonNumber}} />
+      <Text id={'cvaa.sample_caption_tag'} fields={{number: props.sampleNumber}} />
       {props.player.textStyle.isEqual(props.captionsStyle) ? (
         <div className={style.activeTick}>
           <Icon type={IconType.Check} />

--- a/translations/ar.i18n.json
+++ b/translations/ar.i18n.json
@@ -59,7 +59,7 @@
     },
     "cvaa": {
       "title": "الإعدادات المتقدمة للتسميات التوضيحية",
-      "sample_caption_tag": "عينة",
+      "sample_caption_tag": "{{number}} عينة",
       "sample_custom_caption_tag": "تسميات توضيحية مخصصة",
       "set_custom_caption": "تعيين تسمية توضيحية مخصصة",
       "edit_caption": "تحرير تسمية توضيحية",

--- a/translations/de.i18n.json
+++ b/translations/de.i18n.json
@@ -59,7 +59,7 @@
     },
     "cvaa": {
       "title": "Erweiterte Einstellungen für Untertitel",
-      "sample_caption_tag": "Beispiel",
+      "sample_caption_tag": "Beispiel {{number}}",
       "sample_custom_caption_tag": "Benutzerdefinierte Untertitel",
       "set_custom_caption": "Benutzerdefinierte Untertitel auswählen",
       "edit_caption": "Untertitel bearbeiten",

--- a/translations/en.i18n.json
+++ b/translations/en.i18n.json
@@ -59,7 +59,7 @@
     },
     "cvaa": {
       "title": "Advanced captions settings",
-      "sample_caption_tag": "Sample",
+      "sample_caption_tag": "Sample {{number}}",
       "sample_custom_caption_tag": "Custom captions",
       "set_custom_caption": "Set custom caption",
       "edit_caption": "Edit caption",

--- a/translations/es.i18n.json
+++ b/translations/es.i18n.json
@@ -59,7 +59,7 @@
     },
     "cvaa": {
       "title": "Configuración avanzada de los subtítulos",
-      "sample_caption_tag": "Ejemplo",
+      "sample_caption_tag": "Ejemplo {{number}}",
       "sample_custom_caption_tag": "Personalizar subtítulos",
       "set_custom_caption": "Configurar subtítulos personalizados",
       "edit_caption": "Editar subtítulo",

--- a/translations/fi.i18n.json
+++ b/translations/fi.i18n.json
@@ -59,7 +59,7 @@
     },
     "cvaa": {
       "title": "Tekstityksen lisäasetukset",
-      "sample_caption_tag": "Esimerkki",
+      "sample_caption_tag": "Esimerkki {{number}}",
       "sample_custom_caption_tag": "Mukautetut tekstitykset",
       "set_custom_caption": "Aseta mukautettu tekstitys",
       "edit_caption": "Muokkaa tekstitystä",

--- a/translations/fr.i18n.json
+++ b/translations/fr.i18n.json
@@ -59,7 +59,7 @@
     },
     "cvaa": {
       "title": "Paramètres avancés de sous-titres",
-      "sample_caption_tag": "Échantillon",
+      "sample_caption_tag": "Échantillon {{number}}",
       "sample_custom_caption_tag": "Sous-titres personnalisés",
       "set_custom_caption": "Régler les sous-titres personnalisées",
       "edit_caption": "Modifier le sous-titre",

--- a/translations/fr_ca.i18n.json
+++ b/translations/fr_ca.i18n.json
@@ -59,7 +59,7 @@
     },
     "cvaa": {
       "title": "Paramètres avancés de sous-titres",
-      "sample_caption_tag": "Échantillon",
+      "sample_caption_tag": "Échantillon {{number}}",
       "sample_custom_caption_tag": "Sous-titres personnalisés",
       "set_custom_caption": "Paramétrer les sous-titres personnalisés",
       "edit_caption": "Modifier les sous-titres",

--- a/translations/he.i18n.json
+++ b/translations/he.i18n.json
@@ -59,7 +59,7 @@
     },
     "cvaa": {
       "title": "הגדרות כתוביות מתקדמות",
-      "sample_caption_tag": "דוגמה",
+      "sample_caption_tag": "{{number}} דוגמה",
       "sample_custom_caption_tag": "כתוביות מותאמות אישית",
       "set_custom_caption": "הגדר כתוביות מותאמות אישית",
       "edit_caption": "ערוך כתוביות",

--- a/translations/hi_in.i18n.json
+++ b/translations/hi_in.i18n.json
@@ -59,7 +59,7 @@
     },
     "cvaa": {
       "title": "उन्नत कैप्शन सेंटिंग",
-      "sample_caption_tag": "सैम्पल",
+      "sample_caption_tag": "सैम्पल {{number}}",
       "sample_custom_caption_tag": "कस्टम कैप्शन",
       "set_custom_caption": "कस्टम कैप्शन सेट करें",
       "edit_caption": "कैप्शन संपादित करें",

--- a/translations/it.i18n.json
+++ b/translations/it.i18n.json
@@ -59,7 +59,7 @@
     },
     "cvaa": {
       "title": "Impostazioni didascalie avanzate",
-      "sample_caption_tag": "Campione",
+      "sample_caption_tag": "Campione {{number}}",
       "sample_custom_caption_tag": "Didascalie personalizzate",
       "set_custom_caption": "Imposta didascalia personalizzata",
       "edit_caption": "Modifica didascalia",

--- a/translations/ja.i18n.json
+++ b/translations/ja.i18n.json
@@ -59,7 +59,7 @@
     },
     "cvaa": {
       "title": "キャプションの詳細設定",
-      "sample_caption_tag": "サンプル",
+      "sample_caption_tag": "サンプル {{number}}",
       "sample_custom_caption_tag": "カスタム キャプション",
       "set_custom_caption": "カスタム キャプションの設定",
       "edit_caption": "キャプションを編集する",

--- a/translations/ko.i18n.json
+++ b/translations/ko.i18n.json
@@ -59,7 +59,7 @@
     },
     "cvaa": {
       "title": "고급 자막 설정",
-      "sample_caption_tag": "샘플",
+      "sample_caption_tag": "샘플 {{number}}",
       "sample_custom_caption_tag": "자막 변경",
       "set_custom_caption": "자막 설정하기",
       "edit_caption": "자막 편집",

--- a/translations/nl.i18n.json
+++ b/translations/nl.i18n.json
@@ -59,7 +59,7 @@
     },
     "cvaa": {
       "title": "Geavanceerde instellingen voor onderschriften",
-      "sample_caption_tag": "Voorbeeld",
+      "sample_caption_tag": "Voorbeeld {{number}}",
       "sample_custom_caption_tag": "Aangepaste onderschriften",
       "set_custom_caption": "Aangepast onderschrift instellen",
       "edit_caption": "Onderschrift bewerken",

--- a/translations/pt_br.i18n.json
+++ b/translations/pt_br.i18n.json
@@ -59,7 +59,7 @@
     },
     "cvaa": {
       "title": "Configurações avançadas de legendas",
-      "sample_caption_tag": "Amostra",
+      "sample_caption_tag": "Amostra {{number}}",
       "sample_custom_caption_tag": "Legendas personalizadas",
       "set_custom_caption": "Definir legenda personalizada",
       "edit_caption": "Editar legenda",

--- a/translations/ru.i18n.json
+++ b/translations/ru.i18n.json
@@ -59,7 +59,7 @@
     },
     "cvaa": {
       "title": "Расширенные настройки субтитров",
-      "sample_caption_tag": "Образец",
+      "sample_caption_tag": "Образец {{number}}",
       "sample_custom_caption_tag": "Индивидуальные субтитры",
       "set_custom_caption": "Установить индивидуальные субтитры",
       "edit_caption": "Редактировать субтитры",

--- a/translations/zh_cn.i18n.json
+++ b/translations/zh_cn.i18n.json
@@ -59,7 +59,7 @@
     },
     "cvaa": {
       "title": "高级字幕设置",
-      "sample_caption_tag": "范例",
+      "sample_caption_tag": "范例 {{number}}",
       "sample_custom_caption_tag": "自定义字幕",
       "set_custom_caption": "设置自定义字幕",
       "edit_caption": " 编辑字幕",

--- a/translations/zh_tw.i18n.json
+++ b/translations/zh_tw.i18n.json
@@ -59,7 +59,7 @@
     },
     "cvaa": {
       "title": "進階字幕設定",
-      "sample_caption_tag": "樣本",
+      "sample_caption_tag": "樣本 {{number}}",
       "sample_custom_caption_tag": "自訂字幕",
       "set_custom_caption": "設定自訂字幕",
       "edit_caption": "编辑字幕",


### PR DESCRIPTION
### Description of the Changes

in "Advanced captions settings" change the button names to Sample 1, Sample 2, Sample 3

solves FEC-12728

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
