### PR TITLE
fix(FEV-1542): countdown shows 10 sec after reaching to 0 and after seeking

### DIFF
--- a/src/components/playlist-countdown/playlist-countdown.js
+++ b/src/components/playlist-countdown/playlist-countdown.js
@@ -66,7 +66,8 @@ class PlaylistCountdown extends Component {
       props.playlist.next &&
       props.playlist.next.sources &&
       props.player.playlist.countdown.showing &&
-      (props.player.playlist.options.autoContinue || props.player.playlist.options.loop)
+      (props.player.playlist.options.autoContinue || props.player.playlist.options.loop) &&
+      props.currentTime > 0
     );
   }
 

--- a/src/components/playlist-countdown/playlist-countdown.js
+++ b/src/components/playlist-countdown/playlist-countdown.js
@@ -62,12 +62,12 @@ class PlaylistCountdown extends Component {
    */
   _shouldRender(props: any): boolean {
     return (
+      this.state.timeToShow &&
       props.playlist &&
       props.playlist.next &&
       props.playlist.next.sources &&
       props.player.playlist.countdown.showing &&
-      (props.player.playlist.options.autoContinue || props.player.playlist.options.loop) &&
-      props.currentTime > 0
+      (props.player.playlist.options.autoContinue || props.player.playlist.options.loop)
     );
   }
 


### PR DESCRIPTION
### Description of the Changes

**the issue:**
countdown component shows 10 sec when it shouldn't. see below use-cases:
1. when the player is about to switch to the next media, countdown reaches to 0 and then shows 10 before it disappears.
2. when the countdown comp is rendered (seek to almost the end of the video so it will show for example 7 sec) and performing seeking to a position that the comp should not be rendered (seek to somewhere in the beginning of the video)- countdown shows 10 sec before it disappears.

**solution:**
add a validation to `shouldRender()` func -> check the value of `timeToShow` state.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
