### PR TITLE
fix(FEV-1539): inconsistency between the tool tips styles of the dualscreen buttons

### DIFF
--- a/src/styles/_shell.scss
+++ b/src/styles/_shell.scss
@@ -12,11 +12,7 @@
   user-select: none;
   -webkit-tap-highlight-color: transparent;
   cursor: none;
-
-  .playback-gui-wrapper,
-  .ad-gui-wrapper {
-    font-family: $font-family;
-  }
+  font-family: $font-family;
 
   &:-webkit-full-screen {
     width: 100%;


### PR DESCRIPTION
### Description of the Changes

move the font-family to player class so it will be applied on side-by-side videos.

Solves [FEV-1539](https://kaltura.atlassian.net/browse/FEV-1539)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[FEV-1539]: https://kaltura.atlassian.net/browse/FEV-1539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ