### PR TITLE
fix(FEC-12911): keyboard Navigation - Advanced Captions modal

### DIFF
--- a/src/components/cvaa-overlay/main-captions_window.js
+++ b/src/components/cvaa-overlay/main-captions_window.js
@@ -83,27 +83,24 @@ class MainCaptionsWindow extends Component {
           <SampleCaptionsStyleButton
             addAccessibleChild={props.addAccessibleChild}
             classNames={[style.sample]}
-            changeCaptionsStyle={props.changeCaptionsStyle}
-            captionsStyle={this.captionsStyleDefault}
-            player={props.player}
-            sampleNumber={'1'}
-          />
+            changeCaptionsStyle={() => props.changeCaptionsStyle(this.captionsStyleDefault)}
+            isActive={props.player.textStyle.isEqual(this.captionsStyleDefault)}>
+            <Text id={'cvaa.sample_caption_tag'} fields={{number: '1'}} />
+          </SampleCaptionsStyleButton>
           <SampleCaptionsStyleButton
             addAccessibleChild={props.addAccessibleChild}
             classNames={[style.sample, style.blackBg]}
-            changeCaptionsStyle={props.changeCaptionsStyle}
-            captionsStyle={this.captionsStyleBlackBG}
-            player={props.player}
-            sampleNumber={'2'}
-          />
+            changeCaptionsStyle={() => props.changeCaptionsStyle(this.captionsStyleBlackBG)}
+            isActive={props.player.textStyle.isEqual(this.captionsStyleBlackBG)}>
+            <Text id={'cvaa.sample_caption_tag'} fields={{number: '2'}} />
+          </SampleCaptionsStyleButton>
           <SampleCaptionsStyleButton
             addAccessibleChild={props.addAccessibleChild}
             classNames={[style.sample, style.yellowText]}
-            changeCaptionsStyle={props.changeCaptionsStyle}
-            captionsStyle={this.captionsStyleYellow}
-            player={props.player}
-            sampleNumber={'3'}
-          />
+            changeCaptionsStyle={() => props.changeCaptionsStyle(this.captionsStyleYellow)}
+            isActive={props.player.textStyle.isEqual(this.captionsStyleYellow)}>
+            <Text id={'cvaa.sample_caption_tag'} fields={{number: '3'}} />
+          </SampleCaptionsStyleButton>
         </div>
         {!this.isAdvancedStyleApplied() ? (
           <a

--- a/src/components/cvaa-overlay/sample-captions-style-button.js
+++ b/src/components/cvaa-overlay/sample-captions-style-button.js
@@ -1,9 +1,9 @@
 //@flow
 import {KeyMap} from '../../utils/key-map';
-import {Text} from 'preact-i18n';
 import style from '../../styles/style.scss';
 import {default as Icon, IconType} from '../icon';
 import {h} from 'preact';
+import {useEffect, useRef} from 'preact/compat';
 
 /**
  * renders a default style pick button
@@ -11,12 +11,7 @@ import {h} from 'preact';
  * @returns {React$Element} - component element
  */
 const SampleCaptionsStyleButton = (props: any): React$Element<any> => {
-  /**
-   * @returns {void}
-   */
-  const changeCaptionsStyle = (): void => {
-    props.changeCaptionsStyle(props.captionsStyle);
-  };
+  let _sampleCaptionsElRef = useRef(null);
 
   /**
    * @param {KeyboardEvent} e - keyboard event
@@ -24,22 +19,30 @@ const SampleCaptionsStyleButton = (props: any): React$Element<any> => {
    */
   const onKeyDown = (e: KeyboardEvent): void => {
     if (e.keyCode === KeyMap.ENTER) {
-      changeCaptionsStyle();
+      props.changeCaptionsStyle();
     }
   };
+
+  useEffect(() => {
+    // force focus to active sample button once mounted
+    if (props.isActive) {
+      _sampleCaptionsElRef?.focus();
+    }
+  }, []);
 
   return (
     <div
       role="button"
       tabIndex="0"
       ref={el => {
+        _sampleCaptionsElRef = el;
         props.addAccessibleChild(el);
       }}
       className={props.classNames.join(' ')}
-      onClick={changeCaptionsStyle}
+      onClick={props.changeCaptionsStyle}
       onKeyDown={onKeyDown}>
-      <Text id={'cvaa.sample_caption_tag'} fields={{number: props.sampleNumber}} />
-      {props.player.textStyle.isEqual(props.captionsStyle) ? (
+      {props.children}
+      {props.isActive ? (
         <div className={style.activeTick}>
           <Icon type={IconType.Check} />
         </div>

--- a/src/components/language/language.js
+++ b/src/components/language/language.js
@@ -304,6 +304,7 @@ class AdvancedCaptionsAnchor extends Component {
     switch (e.keyCode) {
       case KeyMap.ENTER:
         this.props.onMenuChosen();
+        e.preventDefault();
         e.stopPropagation();
         break;
     }


### PR DESCRIPTION
### Description of the Changes

**the issue:**
current issue is that when navigating to cvaa overlay, the focus should be on the active Sample button, but the focus is actually on a language button element (the globe).

**root cause:**
this happens because the a11yKeyboard wrapper is triggering unmount for the language smart container, after a11yKeyboard didMount for the cvaa overlay.

**solution:**
add useEffect to the sample button component to focus to the active element, once mounted.
In addition, did some minor changes to make sampleCaptions component cleaner.

Solves FEC-12911

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
