### PR TITLE
fix(FEC-12881): Inside playlist when autoContinue is true, the square up next video in the middle of the screen is briefly displayed.

### DIFF
--- a/src/components/playlist-next-screen/playlist-next-screen.js
+++ b/src/components/playlist-next-screen/playlist-next-screen.js
@@ -57,7 +57,13 @@ class PlaylistNextScreen extends Component {
    * @returns {boolean} - component element
    */
   _shouldRender(props: any): boolean {
-    return !!(props.playlist && props.playlist.next && props.playlist.next.sources && props.isPlaybackEnded);
+    return !!(
+      props.playlist &&
+      props.playlist.next &&
+      props.playlist.next.sources &&
+      props.isPlaybackEnded &&
+      !props.player.playlist.options.autoContinue
+    );
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

Hide playlist up next screen when autocontinue is true

Resolves FEC-12881

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
