### PR TITLE
fix(FEC-12932): watermark, Logo config - When "Click through URL" is empty new tab is open

### DIFF
--- a/src/components/logo/logo.js
+++ b/src/components/logo/logo.js
@@ -54,7 +54,7 @@ class Logo extends Component {
     if (props.config.img && !invisibleMode) {
       return (
         <div
-          className={[style.controlButtonContainer, style.controlLogo].join(' ')}
+          className={[style.controlButtonContainer, !props.config.url ? style.emptyUrl : ''].join(' ')}
           aria-label={<Text id="controls.logo" />}
           title={props.config.text}>
           <a className={style.controlButton} href={props.config.url} target="_blank" rel="noopener noreferrer">

--- a/src/components/watermark/watermark.js
+++ b/src/components/watermark/watermark.js
@@ -96,6 +96,9 @@ class Watermark extends Component {
     props.config.placement.split('-').forEach(side => {
       styleClass.push(style[side]);
     });
+    if (!props.config.url) {
+      styleClass.push(style.emptyUrl);
+    }
     if (!this.state.show) {
       styleClass.push(style.hideWatermark);
     }

--- a/src/styles/_links.scss
+++ b/src/styles/_links.scss
@@ -11,3 +11,10 @@
     opacity: 0.7;
   }
 }
+
+.emptyUrl {
+  a {
+    cursor: auto;
+    pointer-events: none;
+  }
+}


### PR DESCRIPTION
### Description of the Changes

when the (click through) url config of watermark and logo components is empty and clicking on them, a new tab is open with the parent url.
The expected behavior is to make these components unclickable, in case the urls are empty.

- change the cursor to `auto` instead of `pointer`
- set `pointer-events` to `none` to prevent the clicks

Solves [FEC-12932](https://kaltura.atlassian.net/browse/FEC-12932)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[FEC-12932]: https://kaltura.atlassian.net/browse/FEC-12932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ