### PR TITLE
fix(FEC-12909): volume control a11y

### DIFF
--- a/translations/en.i18n.json
+++ b/translations/en.i18n.json
@@ -27,6 +27,10 @@
     "unmute": {
       "unmute": "Unmute"
     },
+    "volume": {
+      "muted": "Muted. Click to unmute",
+      "unmuted": "{{vol}}% volume. Click to mute"
+    },
     "copy": {
       "button": "Copy URL"
     },


### PR DESCRIPTION
### Description of the Changes

- when using tab keyboard to navigate to volume control button- open the progress bar
- when using up/down keyboard arrows to inc/dec volume- the right icon should be rendered in the center of the player
- make screenreader announce the current percentage of the volume when changing it using up/down keyboards
- make screenreader announce mute/unmute when clicking space/enter keyboards

Solves FEC-12909

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
