### PR TITLE
fix(SUP-37036): Videos not conserving the player customization

### DIFF
--- a/src/ui-manager.js
+++ b/src/ui-manager.js
@@ -60,7 +60,7 @@ class UIManager {
     this._createStore(config);
     this.setConfig(config);
     this._setLocaleTranslations(config);
-    this._themesManager = new ThemesManager(player, config.userTheme);
+    this._themesManager = new ThemesManager(player, config.userTheme, config.targetId);
     setEnv(this.player.env);
   }
 

--- a/src/utils/themes-manager.js
+++ b/src/utils/themes-manager.js
@@ -30,11 +30,13 @@ const dynamicColoredIconsSvgUrlVars = [
 export class ThemesManager {
   player: Object;
   config: Object;
+  playerElement: HTMLElement;
 
   // eslint-disable-next-line require-jsdoc
-  constructor(player: Object, config: ?UserTheme) {
+  constructor(player: Object, config: ?UserTheme, targetId: string) {
     this.player = player;
     this.config = config;
+    this.playerElement = document.querySelector(`#${targetId}`);
   }
 
   /**
@@ -74,10 +76,14 @@ export class ThemesManager {
    */
   setAccentOrAcknowledgementColor(colorTitle: string, color: string): void {
     const [hue, saturation, lightness] = hexToHsl(color);
-    document.querySelector(`.${style.player}`)?.style.setProperty(ACTUAL_USED_CSS_VAR.replace('{name}', colorTitle), color);
-    document.querySelector(`.${style.player}`)?.style.setProperty(HSL_HUE_CSS_VAR.replace('{name}', colorTitle), `${Math.round(hue)}deg`);
-    document.querySelector(`.${style.player}`)?.style.setProperty(HSL_SATURATION_CSS_VAR.replace('{name}', colorTitle), `${Math.round(saturation)}%`);
-    document.querySelector(`.${style.player}`)?.style.setProperty(HSL_LIGHTNESS_CSS_VAR.replace('{name}', colorTitle), `${Math.round(lightness)}%`);
+    this.playerElement.querySelector(`.${style.player}`)?.style.setProperty(ACTUAL_USED_CSS_VAR.replace('{name}', colorTitle), color);
+    this.playerElement.querySelector(`.${style.player}`)?.style.setProperty(HSL_HUE_CSS_VAR.replace('{name}', colorTitle), `${Math.round(hue)}deg`);
+    this.playerElement
+      .querySelector(`.${style.player}`)
+      ?.style.setProperty(HSL_SATURATION_CSS_VAR.replace('{name}', colorTitle), `${Math.round(saturation)}%`);
+    this.playerElement
+      .querySelector(`.${style.player}`)
+      ?.style.setProperty(HSL_LIGHTNESS_CSS_VAR.replace('{name}', colorTitle), `${Math.round(lightness)}%`);
   }
 
   /**
@@ -87,7 +93,7 @@ export class ThemesManager {
    * @returns {void}
    */
   setColor(cssVarName: string, color: string): void {
-    document.querySelector(`.${style.player}`)?.style.setProperty(cssVarName, color);
+    this.playerElement.querySelector(`.${style.player}`)?.style.setProperty(cssVarName, color);
   }
 
   /**
@@ -98,9 +104,11 @@ export class ThemesManager {
   setSvgFillColor(color: string): void {
     for (const varName of dynamicColoredIconsSvgUrlVars) {
       // $FlowFixMe
-      const svgUrl = getComputedStyle(document.querySelector(`.${style.player}`))?.getPropertyValue(varName);
+      const svgUrl = getComputedStyle(this.playerElement.querySelector(`.${style.player}`)).getPropertyValue(varName);
       const newColor = color.replace('#', '%23');
-      document.querySelector(`.${style.player}`)?.style.setProperty(varName, svgUrl.replace(/fill='%23([a-f0-9]{3}){1,2}\b'/, `fill='${newColor}'`));
+      this.playerElement
+        .querySelector(`.${style.player}`)
+        ?.style.setProperty(varName, svgUrl.replace(/fill='%23([a-f0-9]{3}){1,2}\b'/, `fill='${newColor}'`));
     }
   }
 }

--- a/src/utils/themes-manager.js
+++ b/src/utils/themes-manager.js
@@ -30,7 +30,7 @@ const dynamicColoredIconsSvgUrlVars = [
 export class ThemesManager {
   player: Object;
   config: Object;
-  playerContainerElement: HTMLElement;
+  playerContainerElement: HTMLElement | null;
 
   // eslint-disable-next-line require-jsdoc
   constructor(player: Object, config: ?UserTheme, targetId: string) {

--- a/src/utils/themes-manager.js
+++ b/src/utils/themes-manager.js
@@ -76,13 +76,13 @@ export class ThemesManager {
    */
   setAccentOrAcknowledgementColor(colorTitle: string, color: string): void {
     const [hue, saturation, lightness] = hexToHsl(color);
-    this.playerElement.querySelector(`.${style.player}`)?.style.setProperty(ACTUAL_USED_CSS_VAR.replace('{name}', colorTitle), color);
-    this.playerElement.querySelector(`.${style.player}`)?.style.setProperty(HSL_HUE_CSS_VAR.replace('{name}', colorTitle), `${Math.round(hue)}deg`);
+    this.playerElement?.querySelector(`.${style.player}`)?.style.setProperty(ACTUAL_USED_CSS_VAR.replace('{name}', colorTitle), color);
+    this.playerElement?.querySelector(`.${style.player}`)?.style.setProperty(HSL_HUE_CSS_VAR.replace('{name}', colorTitle), `${Math.round(hue)}deg`);
     this.playerElement
-      .querySelector(`.${style.player}`)
+      ?.querySelector(`.${style.player}`)
       ?.style.setProperty(HSL_SATURATION_CSS_VAR.replace('{name}', colorTitle), `${Math.round(saturation)}%`);
     this.playerElement
-      .querySelector(`.${style.player}`)
+      ?.querySelector(`.${style.player}`)
       ?.style.setProperty(HSL_LIGHTNESS_CSS_VAR.replace('{name}', colorTitle), `${Math.round(lightness)}%`);
   }
 
@@ -93,7 +93,7 @@ export class ThemesManager {
    * @returns {void}
    */
   setColor(cssVarName: string, color: string): void {
-    this.playerElement.querySelector(`.${style.player}`)?.style.setProperty(cssVarName, color);
+    this.playerElement?.querySelector(`.${style.player}`)?.style.setProperty(cssVarName, color);
   }
 
   /**
@@ -104,10 +104,10 @@ export class ThemesManager {
   setSvgFillColor(color: string): void {
     for (const varName of dynamicColoredIconsSvgUrlVars) {
       // $FlowFixMe
-      const svgUrl = getComputedStyle(this.playerElement.querySelector(`.${style.player}`)).getPropertyValue(varName);
+      const svgUrl = getComputedStyle(this.playerElement?.querySelector(`.${style.player}`)).getPropertyValue(varName);
       const newColor = color.replace('#', '%23');
       this.playerElement
-        .querySelector(`.${style.player}`)
+        ?.querySelector(`.${style.player}`)
         ?.style.setProperty(varName, svgUrl.replace(/fill='%23([a-f0-9]{3}){1,2}\b'/, `fill='${newColor}'`));
     }
   }

--- a/src/utils/themes-manager.js
+++ b/src/utils/themes-manager.js
@@ -30,13 +30,13 @@ const dynamicColoredIconsSvgUrlVars = [
 export class ThemesManager {
   player: Object;
   config: Object;
-  playerElement: HTMLElement;
+  playerContainerElement: HTMLElement;
 
   // eslint-disable-next-line require-jsdoc
   constructor(player: Object, config: ?UserTheme, targetId: string) {
     this.player = player;
     this.config = config;
-    this.playerElement = document.querySelector(`#${targetId}`);
+    this.playerContainerElement = document.querySelector(`#${targetId}`);
   }
 
   /**
@@ -76,12 +76,14 @@ export class ThemesManager {
    */
   setAccentOrAcknowledgementColor(colorTitle: string, color: string): void {
     const [hue, saturation, lightness] = hexToHsl(color);
-    this.playerElement?.querySelector(`.${style.player}`)?.style.setProperty(ACTUAL_USED_CSS_VAR.replace('{name}', colorTitle), color);
-    this.playerElement?.querySelector(`.${style.player}`)?.style.setProperty(HSL_HUE_CSS_VAR.replace('{name}', colorTitle), `${Math.round(hue)}deg`);
-    this.playerElement
+    this.playerContainerElement?.querySelector(`.${style.player}`)?.style.setProperty(ACTUAL_USED_CSS_VAR.replace('{name}', colorTitle), color);
+    this.playerContainerElement
+      ?.querySelector(`.${style.player}`)
+      ?.style.setProperty(HSL_HUE_CSS_VAR.replace('{name}', colorTitle), `${Math.round(hue)}deg`);
+    this.playerContainerElement
       ?.querySelector(`.${style.player}`)
       ?.style.setProperty(HSL_SATURATION_CSS_VAR.replace('{name}', colorTitle), `${Math.round(saturation)}%`);
-    this.playerElement
+    this.playerContainerElement
       ?.querySelector(`.${style.player}`)
       ?.style.setProperty(HSL_LIGHTNESS_CSS_VAR.replace('{name}', colorTitle), `${Math.round(lightness)}%`);
   }
@@ -93,7 +95,7 @@ export class ThemesManager {
    * @returns {void}
    */
   setColor(cssVarName: string, color: string): void {
-    this.playerElement?.querySelector(`.${style.player}`)?.style.setProperty(cssVarName, color);
+    this.playerContainerElement?.querySelector(`.${style.player}`)?.style.setProperty(cssVarName, color);
   }
 
   /**
@@ -104,9 +106,9 @@ export class ThemesManager {
   setSvgFillColor(color: string): void {
     for (const varName of dynamicColoredIconsSvgUrlVars) {
       // $FlowFixMe
-      const svgUrl = getComputedStyle(this.playerElement?.querySelector(`.${style.player}`)).getPropertyValue(varName);
+      const svgUrl = getComputedStyle(this.playerContainerElement?.querySelector(`.${style.player}`)).getPropertyValue(varName);
       const newColor = color.replace('#', '%23');
-      this.playerElement
+      this.playerContainerElement
         ?.querySelector(`.${style.player}`)
         ?.style.setProperty(varName, svgUrl.replace(/fill='%23([a-f0-9]{3}){1,2}\b'/, `fill='${newColor}'`));
     }


### PR DESCRIPTION
**issue:**
In the case of several players on a page, the first player is always colored and **only** the first player is colored.

**solution:**
select the player div element from the dom by the targetId and then select the another elements from the player and not directly from the dom.

solves [SUP-37036](https://kaltura.atlassian.net/browse/SUP-37036)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[SUP-37036]: https://kaltura.atlassian.net/browse/SUP-37036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ