### PR TITLE
fix(FEC-13112): on mobiles web the volume bar stays open once clicking on another area

### DIFF
--- a/src/components/volume/volume.js
+++ b/src/components/volume/volume.js
@@ -280,7 +280,7 @@ class Volume extends Component {
    * @memberof Volume
    */
   onFocus = (): void => {
-    if (!this.state.hover) {
+    if (!this.props.isMobile && !this.state.hover) {
       this.setState({hover: true});
     }
   };


### PR DESCRIPTION
### Description of the Changes
- bug fix.

**the issue:**
on mobile & web, clicking on the volume control opens the volume bar but it is not possible to close it.

**root cause:**
seems like a regression- original behavior was that on mobiles we do not open the volume bar, while current behavior is opening the volume bar onFocus.

**solution:**
if using mobile- do not allow to open the volume bar onFocus; back to the original behavior.

Solves FEC-13112

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
