### PR TITLE
fix(FEC-13206): Live Multi audio Language selector is not presented if no video tracks

### DIFF
--- a/src/components/settings/settings.js
+++ b/src/components/settings/settings.js
@@ -142,7 +142,7 @@ class Settings extends Component {
     const showSpeedMenu = props.showSpeedMenu && props.player.playbackRates.length > 1 && !props.isLive;
 
     if (!(showAudioMenu || showCaptionsMenu || showQualityMenu || showSpeedMenu)) return undefined;
-    if (props.isLive && props.videoTracks.length <= 1) return undefined;
+    if (props.isLive && props.videoTracks.length <= 1 && !showAudioMenu && !showCaptionsMenu) return undefined;
     const buttonBadgeType: string = this.getButtonBadgeType() || '';
 
     const targetId = document.getElementById(this.props.player.config.targetId) || document;


### PR DESCRIPTION
after merging gear and globe icon need to support tracks selection on live with no video tracks selection

### Description of the Changes

fixes: FEC-13206

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
