### PR TITLE
fix(FEC-13188): volume bar a11y

### DIFF
--- a/src/components/volume/volume.js
+++ b/src/components/volume/volume.js
@@ -455,9 +455,7 @@ class Volume extends Component {
             onMouseUp={this.toggleMute}
             onTouchEnd={this.onTouchEnd}
             onKeyDown={this.onKeyDown}
-            onFocus={this.onFocus}
-            // onBlur={this.onBlur}
-          >
+            onFocus={this.onFocus}>
             <Icon type={IconType.VolumeBase} />
             <Icon type={IconType.VolumeWaves} />
             <Icon type={IconType.VolumeMute} />

--- a/src/components/volume/volume.js
+++ b/src/components/volume/volume.js
@@ -54,7 +54,8 @@ const translates = (props: any) => ({
     <Text id={'volume.volume_click_to_mute'} fields={{vol: (props.player.volume * 100).toFixed()}}>
       {`${props.player.volume * 100} volume. Click to mute`}
     </Text>
-  )
+  ),
+  sliderAriaLabel: <Text id="volume.volume_slider_aria_label">Volume control, use the arrows to control the volume</Text>
 });
 
 /**
@@ -267,6 +268,9 @@ class Volume extends Component {
         event.stopPropagation();
         this.handleKeydown(event);
         break;
+      case KeyMap.TAB:
+        // allow tabbing to progress bar
+        break;
       default:
         this.setState({hover: false});
         break;
@@ -397,6 +401,27 @@ class Volume extends Component {
   }
 
   /**
+   * on volume progress bar key down
+   *
+   * @param {KeyboardEvent} event - keyboardEvent event
+   * @method onProgressBarKeyDown
+   * @returns {void}
+   * @memberof Volume
+   */
+  onProgressBarKeyDown = (event: KeyboardEvent): void => {
+    switch (event.keyCode) {
+      case KeyMap.TAB:
+        this.setState({hover: false});
+        break;
+      default:
+        event.preventDefault();
+        event.stopPropagation();
+        this.handleKeydown(event);
+        break;
+    }
+  };
+
+  /**
    * render component
    *
    * @returns {React$Element} - component element
@@ -430,13 +455,18 @@ class Volume extends Component {
             onMouseUp={this.toggleMute}
             onTouchEnd={this.onTouchEnd}
             onKeyDown={this.onKeyDown}
-            onFocus={this.onFocus}>
+            onFocus={this.onFocus}
+            // onBlur={this.onBlur}
+          >
             <Icon type={IconType.VolumeBase} />
             <Icon type={IconType.VolumeWaves} />
             <Icon type={IconType.VolumeMute} />
           </Button>
         </Tooltip>
         <div
+          tabIndex="0"
+          aria-label={this.props.sliderAriaLabel}
+          onKeyDown={this.onProgressBarKeyDown}
           className={style.volumeControlBar}
           role="slider"
           aria-valuemin="0"

--- a/translations/en.i18n.json
+++ b/translations/en.i18n.json
@@ -39,7 +39,8 @@
       "seventy_percent": "seventy percent",
       "eighty_percent": "eighty percent",
       "ninety_percent": "ninety percent",
-      "one_hundred_percent": "one hundred percent"
+      "one_hundred_percent": "one hundred percent",
+      "volume_slider_aria_label": "Volume control, use the arrows to control the volume"
     },
     "copy": {
       "button": "Copy URL"


### PR DESCRIPTION
### Description of the Changes
a11y fix for volume bar slider.

- volume bar is focusable when tabbing from the volume control button
- when the volume bar is focused, SR is announcing "Volume control, use the arrows to control the volume"

Solves FEC-13188

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
