### PR TITLE
fix(SUP-38236): Advanced captions settings sample buttons

### DIFF
--- a/src/components/cvaa-overlay/sample-captions-style-button.js
+++ b/src/components/cvaa-overlay/sample-captions-style-button.js
@@ -32,8 +32,9 @@ const SampleCaptionsStyleButton = (props: any): React$Element<any> => {
 
   return (
     <div
-      role="button"
+      role="menuitemradio"
       tabIndex="0"
+      aria-checked={props.isActive ? 'true' : 'false'}
       ref={el => {
         _sampleCaptionsElRef = el;
         props.addAccessibleChild(el);


### PR DESCRIPTION
**the issue:**
in advanced captions settings option, screen reader only reads the name of the buttons and there is no indication whether it checked or not 

**the solution:**
change the role to menuitemradio and add aria-checked attribute 

solves SUP-38236

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
