### PR TITLE
fix(SUP-38205):Youtube IVQ missing welcome screen

### DIFF
--- a/src/components/pre-playback-play-overlay/_pre-playback-play-overlay.scss
+++ b/src/components/pre-playback-play-overlay/_pre-playback-play-overlay.scss
@@ -6,7 +6,7 @@
   height: 100%;
 
   .pre-playback-play-button {
-    z-index: 1;
+    z-index: 2;
     position: absolute;
     top: 50%;
     left: 50%;


### PR DESCRIPTION
issue:
on youtube video with quiz the welcome screen didnt display

solution:
add z-index for welcome screen and update z-index for play button so the welcome screen will be show on top on the video
