### PR TITLE
fix(FEC-13118):  pause/play playback using keyboard - A11Y issue

### DIFF
--- a/src/components/play-pause/play-pause.js
+++ b/src/components/play-pause/play-pause.js
@@ -57,12 +57,14 @@ class PlayPause extends Component {
    */
   componentDidMount(): void {
     const {eventManager, player} = this.props;
+    // $FlowFixMe.
+    const playerContainer: HTMLDivElement = document.getElementById(player.config.ui.targetId);
     eventManager.listen(player, player.Event.Core.PLAY, () => {
-      document.getElementById(player.config.ui.targetId).focus();
+      playerContainer.focus();
     });
     eventManager.listen(document, 'keydown', event => {
       if (event.code === 'Space') {
-        if (document.activeElement === document.getElementById(player.config.ui.targetId)) {
+        if (document.activeElement === playerContainer) {
           event.preventDefault();
           this.props.isPlayingAdOrPlayback ? this.props.updateOverlayActionIcon(IconType.Pause) : this.props.updateOverlayActionIcon(IconType.Play);
           this.togglePlayPause();

--- a/src/components/play-pause/play-pause.js
+++ b/src/components/play-pause/play-pause.js
@@ -8,8 +8,6 @@ import {isPlayingAdOrPlayback} from '../../reducers/getters';
 import {withPlayer} from '../player';
 import {withEventDispatcher} from 'components/event-dispatcher';
 import {withLogger} from 'components/logger';
-import {KeyMap} from 'utils/key-map';
-import {withKeyboardEvent} from 'components/keyboard';
 import {bindActions} from 'utils/bind-actions';
 import {actions as settingActions} from 'reducers/settings';
 import {actions as overlayIconActions} from 'reducers/overlay-action';
@@ -17,6 +15,7 @@ import {Tooltip} from 'components/tooltip';
 import {Button} from 'components/button';
 import {actions as shellActions} from 'reducers/shell';
 import {ButtonControl} from 'components/button-control';
+import {withEventManager} from 'event';
 
 /**
  * mapping state to props
@@ -41,28 +40,15 @@ const COMPONENT_NAME = 'PlayPause';
  */
 @connect(mapStateToProps, bindActions({...shellActions, ...settingActions, ...overlayIconActions}))
 @withPlayer
-@withKeyboardEvent(COMPONENT_NAME)
 @withLogger(COMPONENT_NAME)
 @withEventDispatcher(COMPONENT_NAME)
+@withEventManager
 @withText({
   startOverText: 'controls.startOver',
   pauseText: 'controls.pause',
   playText: 'controls.play'
 })
 class PlayPause extends Component {
-  _keyboardEventHandlers: Array<KeyboardEventHandlers> = [
-    {
-      key: {
-        code: KeyMap.SPACE
-      },
-      action: () => {
-        this.props.isPlayingAdOrPlayback ? this.props.updateOverlayActionIcon(IconType.Pause) : this.props.updateOverlayActionIcon(IconType.Play);
-        this.togglePlayPause();
-        this.props.updatePlayerHoverState(true);
-      }
-    }
-  ];
-
   /**
    * component mounted
    *
@@ -70,7 +56,20 @@ class PlayPause extends Component {
    * @memberof PlayPause
    */
   componentDidMount(): void {
-    this.props.registerKeyboardEvents(this._keyboardEventHandlers);
+    const {eventManager, player} = this.props;
+    eventManager.listen(player, player.Event.Core.PLAY, () => {
+      document.getElementById(player.config.ui.targetId).focus();
+    });
+    eventManager.listen(document, 'keydown', event => {
+      if (event.code === 'Space') {
+        if (document.activeElement === document.getElementById(player.config.ui.targetId)) {
+          event.preventDefault();
+          this.props.isPlayingAdOrPlayback ? this.props.updateOverlayActionIcon(IconType.Pause) : this.props.updateOverlayActionIcon(IconType.Play);
+          this.togglePlayPause();
+          this.props.updatePlayerHoverState(true);
+        }
+      }
+    });
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

solves FEC-13118

**issue:**  the keyboard event listener is listening only to events within the player container element scope 

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
