### PR TITLE
feat(FEC-13114): add chapters as segments to seekbar

### DIFF
--- a/src/components/progress-bar.js
+++ b/src/components/progress-bar.js
@@ -37,10 +37,10 @@ class ProgressBar extends Component {
     const bufferedWidth = `${Math.round(props.getBufferedPercent())}%`;
     const progressWidth = `${props.player.isLive() && props.player.isOnLiveEdge() ? 100 : (props.currentTime / props.duration) * 100}%`;
     return (
-      <>
+      <Fragment>
         <div className={style.buffered} style={{width: bufferedWidth}} />
         {props.dataLoaded ? <div className={style.progress} style={{width: progressWidth}} /> : undefined}
-      </>
+      </Fragment>
     );
   }
 }

--- a/src/components/progress-bar.js
+++ b/src/components/progress-bar.js
@@ -1,0 +1,49 @@
+//@flow
+import {h, Fragment, Component} from 'preact';
+import style from '../styles/style.scss';
+import {connect} from 'react-redux';
+import {withPlayer} from './player';
+
+/**
+ * mapping state to props
+ * @param {*} state - redux store state
+ * @returns {Object} - mapped state to this component
+ */
+const mapStateToProps = state => ({
+  dataLoaded: state.engine.dataLoaded,
+  currentTime: state.seekbar.currentTime,
+  duration: state.engine.duration,
+  isMobile: state.shell.isMobile,
+  adBreak: state.engine.adBreak
+});
+
+/**
+ * SeekBar component
+ *
+ * @class SeekBar
+ * @extends {Component}
+ */
+@connect(mapStateToProps)
+@withPlayer
+class ProgressBar extends Component {
+  /**
+   * render component
+   *
+   * @param {*} props - component props
+   * @returns {React$Element} - component
+   * @memberof ProgressBar
+   */
+  render(props: any): React$Element<any> {
+    const bufferedWidth = `${Math.round(props.getBufferedPercent())}%`;
+    const progressWidth = `${props.player.isLive() && props.player.isOnLiveEdge() ? 100 : (props.currentTime / props.duration) * 100}%`;
+    return (
+      <>
+        <div className={style.buffered} style={{width: bufferedWidth}} />
+        {props.dataLoaded ? <div className={style.progress} style={{width: progressWidth}} /> : undefined}
+      </>
+    );
+  }
+}
+
+ProgressBar.displayName = 'ProgressBar';
+export {ProgressBar};

--- a/src/components/progress-bar.js
+++ b/src/components/progress-bar.js
@@ -18,9 +18,9 @@ const mapStateToProps = state => ({
 });
 
 /**
- * SeekBar component
+ * ProgressBar component
  *
- * @class SeekBar
+ * @class ProgressBar
  * @extends {Component}
  */
 @connect(mapStateToProps)

--- a/src/components/progress-indicator/_progress-indicator.scss
+++ b/src/components/progress-indicator/_progress-indicator.scss
@@ -1,0 +1,37 @@
+.player .seek-bar {
+  &.ad-break {
+    cursor: initial;
+
+    .progress-bar .progress {
+      background-color: $ads-color;
+    }
+  }
+
+  &.live {
+    .progress-bar .progress {
+      background-color: $live-color;
+    }
+  }
+
+  .progress-bar {
+    .progress {
+      position: absolute;
+      top: 0;
+      left: 0;
+      height: 100%;
+      border-radius: inherit;
+      background-color: $primary-color;
+    }
+    .buffered {
+      position: absolute;
+      top: 0;
+      left: 0;
+      height: 100%;
+      border-radius: inherit;
+      background-color: rgba(255, 255, 255, 0.3);
+    }
+  }
+}
+
+
+

--- a/src/components/progress-indicator/index.js
+++ b/src/components/progress-indicator/index.js
@@ -1,0 +1,1 @@
+export {ProgressIndicator} from './progress-indicator';

--- a/src/components/progress-indicator/progress-indicator.js
+++ b/src/components/progress-indicator/progress-indicator.js
@@ -1,8 +1,8 @@
 //@flow
 import {h, Fragment, Component} from 'preact';
-import style from '../styles/style.scss';
+import style from '../../styles/style.scss';
 import {connect} from 'react-redux';
-import {withPlayer} from './player';
+import {withPlayer} from '../player';
 
 /**
  * mapping state to props
@@ -20,21 +20,37 @@ const mapStateToProps = state => ({
 /**
  * ProgressBar component
  *
- * @class ProgressBar
+ * @class ProgressIndicator
  * @extends {Component}
  */
 @connect(mapStateToProps)
 @withPlayer
-class ProgressBar extends Component {
+class ProgressIndicator extends Component {
+  /**
+   * get current buffered percent from the player
+   *
+   * @returns {number} - current buffered percent
+   * @memberof ProgressIndicator
+   */
+  getBufferedPercent(): number {
+    const {player} = this.props;
+    if (this.props.duration > 0 && player.buffered.length > 0) {
+      const buffered = player.isLive() ? player.buffered.end(0) - player.getStartTimeOfDvrWindow() : player.buffered.end(0);
+      const bufferedPercent = (buffered / this.props.duration) * 100;
+      return bufferedPercent < 100 ? bufferedPercent : 100;
+    }
+    return 0;
+  }
+
   /**
    * render component
    *
    * @param {*} props - component props
    * @returns {React$Element} - component
-   * @memberof ProgressBar
+   * @memberof ProgressIndicator
    */
   render(props: any): React$Element<any> {
-    const bufferedWidth = `${Math.round(props.getBufferedPercent())}%`;
+    const bufferedWidth = `${Math.round(this.getBufferedPercent())}%`;
     const progressWidth = `${props.player.isLive() && props.player.isOnLiveEdge() ? 100 : (props.currentTime / props.duration) * 100}%`;
     return (
       <Fragment>
@@ -45,5 +61,5 @@ class ProgressBar extends Component {
   }
 }
 
-ProgressBar.displayName = 'ProgressBar';
-export {ProgressBar};
+ProgressIndicator.displayName = 'ProgressIndicator';
+export {ProgressIndicator};

--- a/src/components/seekbar/_seekbar.scss
+++ b/src/components/seekbar/_seekbar.scss
@@ -40,7 +40,13 @@
     border-radius: $progress-bar-border-radius;
     position: absolute;
     transition: height 200ms ease, transform 200ms ease;
-
+    &.chapters {
+      background-color: transparent;
+      .virtual-progress-indicator {
+        height: 8px;
+        transform: translateY(-2px);
+      }
+    }
     .progress {
       position: absolute;
       top: 0;
@@ -77,7 +83,7 @@
       cursor: pointer;
       display: block;
       top: -8px + calc($progress-bar-height / 2);
-      right: -8px;
+      left: -6px;
       border-radius: 8px;
       height: 16px;
       width: 16px;
@@ -132,7 +138,7 @@
 .player:not(.touch):not(.size-ty) .seek-bar {
   &:hover,
   &.hover {
-    .progress-bar {
+    .progress-bar:not(.chapters) {
       height: 2 * $progress-bar-height;
       border-radius: 2 * $progress-bar-border-radius;
       transform: translateY(calc($progress-bar-height / -2));

--- a/src/components/seekbar/_seekbar.scss
+++ b/src/components/seekbar/_seekbar.scss
@@ -21,16 +21,6 @@
 
   &.ad-break {
     cursor: initial;
-
-    .progress-bar .progress {
-      background-color: $ads-color;
-    }
-  }
-
-  &.live {
-    .progress-bar .progress {
-      background-color: $live-color;
-    }
   }
 
   .progress-bar {
@@ -47,28 +37,15 @@
         transform: translateY(-2px);
       }
     }
-    .progress {
-      position: absolute;
-      top: 0;
-      left: 0;
-      height: 100%;
-      border-radius: inherit;
-      background-color: $primary-color;
-    }
     .virtual-progress {
       display: none;
     }
-    .buffered,
     .virtual-progress {
       position: absolute;
       top: 0;
       left: 0;
       height: 100%;
       border-radius: inherit;
-    }
-
-    .buffered {
-      background-color: rgba(255, 255, 255, 0.3);
     }
 
     .virtual-progress-indicator {

--- a/src/components/seekbar/seekbar.js
+++ b/src/components/seekbar/seekbar.js
@@ -563,6 +563,7 @@ class SeekBar extends Component {
    */
   render(props: any, state: Object): React$Element<any> {
     const virtualProgressWidth = `${(props.virtualTime / props.duration) * 100}%`;
+    const scrubberProgressPosition = `${(props.currentTime / props.duration) * this._seekBarElement?.clientWidth}px`;
     const seekbarStyleClass = [style.seekBar];
     if (props.adBreak) seekbarStyleClass.push(style.adBreak);
     if (props.isDvr) seekbarStyleClass.push(style.live);
@@ -597,7 +598,7 @@ class SeekBar extends Component {
             {props.adBreak ? undefined : (
               <div
                 id={'scrubber-container'}
-                style={`transform: translateX(${(props.currentTime / props.duration) * this._seekBarElement?.clientWidth}px)`}>
+                style={`transform: translateX(${scrubberProgressPosition})`}>
                 <div id={'scrubber'} className={style.scrubber} />
               </div>
             )}

--- a/src/components/seekbar/seekbar.js
+++ b/src/components/seekbar/seekbar.js
@@ -15,6 +15,7 @@ import {PlayerArea} from '../player-area';
 import {withEventManager} from 'event/with-event-manager';
 import {FakeEvent} from 'event/fake-event';
 import {SeekBarPreview} from '../seekbar-preview';
+import {ProgressBar} from '../progress-bar';
 
 /**
  * mapping state to props
@@ -26,7 +27,8 @@ const mapStateToProps = state => ({
   isMobile: state.shell.isMobile,
   previewHoverActive: state.seekbar.previewHoverActive,
   hidePreview: state.seekbar.hidePreview,
-  hideTimeBubble: state.seekbar.hideTimeBubble
+  hideTimeBubble: state.seekbar.hideTimeBubble,
+  segments: state.seekbar.segments
 });
 
 const COMPONENT_NAME = 'SeekBar';
@@ -561,8 +563,6 @@ class SeekBar extends Component {
    */
   render(props: any, state: Object): React$Element<any> {
     const virtualProgressWidth = `${(props.virtualTime / props.duration) * 100}%`;
-    const progressWidth = `${props.forceFullProgress ? 100 : (props.currentTime / props.duration) * 100}%`;
-    const bufferedWidth = `${Math.round(this.getBufferedPercent())}%`;
     const seekbarStyleClass = [style.seekBar];
     if (props.adBreak) seekbarStyleClass.push(style.adBreak);
     if (props.isDvr) seekbarStyleClass.push(style.live);
@@ -593,12 +593,14 @@ class SeekBar extends Component {
           <PlayerArea name={'SeekBar'} shouldUpdate={true}>
             {this.renderFramePreview()}
             {this.renderTimeBubble()}
-            <div className={style.buffered} style={{width: bufferedWidth}} />
-            {props.dataLoaded ? (
-              <div className={style.progress} style={{width: progressWidth}}>
-                {props.adBreak ? undefined : <a className={style.scrubber} />}
+            <ProgressBar getBufferedPercent={() => this.getBufferedPercent} />
+            {props.adBreak ? undefined : (
+              <div
+                id={'scrubber-container'}
+                style={`transform: translateX(${(props.currentTime / props.duration) * this._seekBarElement?.clientWidth}px)`}>
+                <div id={'scrubber'} className={style.scrubber} />
               </div>
-            ) : undefined}
+            )}
             <div className={style.virtualProgress} style={{width: virtualProgressWidth}}>
               <div className={style.virtualProgressIndicator} />
             </div>

--- a/src/components/seekbar/seekbar.js
+++ b/src/components/seekbar/seekbar.js
@@ -596,9 +596,7 @@ class SeekBar extends Component {
             {this.renderTimeBubble()}
             <ProgressBar getBufferedPercent={() => this.getBufferedPercent} />
             {props.adBreak ? undefined : (
-              <div
-                id={'scrubber-container'}
-                style={`transform: translateX(${scrubberProgressPosition})`}>
+              <div id={'scrubber-container'} style={`transform: translateX(${scrubberProgressPosition})`}>
                 <div id={'scrubber'} className={style.scrubber} />
               </div>
             )}

--- a/src/components/seekbar/seekbar.js
+++ b/src/components/seekbar/seekbar.js
@@ -15,7 +15,7 @@ import {PlayerArea} from '../player-area';
 import {withEventManager} from 'event/with-event-manager';
 import {FakeEvent} from 'event/fake-event';
 import {SeekBarPreview} from '../seekbar-preview';
-import {ProgressBar} from '../progress-bar';
+import {ProgressIndicator} from '../progress-indicator';
 
 /**
  * mapping state to props
@@ -451,22 +451,6 @@ class SeekBar extends Component {
   }
 
   /**
-   * get current buffered percent from the player
-   *
-   * @returns {number} - current buffered percent
-   * @memberof SeekBar
-   */
-  getBufferedPercent(): number {
-    const {player} = this.props;
-    if (this.props.duration > 0 && player.buffered.length > 0) {
-      const buffered = player.isLive() ? player.buffered.end(0) - player.getStartTimeOfDvrWindow() : player.buffered.end(0);
-      const bufferedPercent = (buffered / this.props.duration) * 100;
-      return bufferedPercent < 100 ? bufferedPercent : 100;
-    }
-    return 0;
-  }
-
-  /**
    * get the left position the frame preview element should be in
    *
    * @returns {number} left position
@@ -594,7 +578,7 @@ class SeekBar extends Component {
           <PlayerArea name={'SeekBar'} shouldUpdate={true}>
             {this.renderFramePreview()}
             {this.renderTimeBubble()}
-            <ProgressBar getBufferedPercent={() => this.getBufferedPercent} />
+            <ProgressIndicator />
             {props.adBreak ? undefined : (
               <div id={'scrubber-container'} style={`transform: translateX(${scrubberProgressPosition})`}>
                 <div id={'scrubber'} className={style.scrubber} />

--- a/src/reducers/seekbar.js
+++ b/src/reducers/seekbar.js
@@ -7,7 +7,10 @@ export const types = {
   UPDATE_HIDE_SEEKBAR_PREVIEW: 'seekbar/UPDATE_HIDE_SEEKBAR_PREVIEW',
   UPDATE_HIDE_SEEKBAR_TIME_BUBBLE: 'seekbar/UPDATE_HIDE_SEEKBAR_TIME_BUBBLE',
   UPDATE_CURRENT_TIME: 'seekbar/UPDATE_CURRENT_TIME',
-  UPDATE_VIRTUAL_TIME: 'seekbar/UPDATE_VIRTUAL_TIME'
+  UPDATE_VIRTUAL_TIME: 'seekbar/UPDATE_VIRTUAL_TIME',
+  UPDATE_HOVERED_SEGMENT: 'seekbar/UPDATE_HOVERED_SEGMENT',
+  UPDATE_SEEKBAR_SEGMENTS: 'seekbar/UPDATE_SEEKBAR_SEGMENTS',
+  UPDATE_SEGMENT_END_TIME: 'seekbar/UPDATE_SEGMENT_END_TIME'
 };
 
 export const initialState = {
@@ -18,7 +21,8 @@ export const initialState = {
   previewHoverActive: false,
   clientRect: {x: 0, y: 0, width: 0, height: 0, top: 0, right: 0, bottom: 0, left: 0},
   hidePreview: false,
-  hideTimeBubble: false
+  hideTimeBubble: false,
+  segments: []
 };
 
 export default (state: Object = initialState, action: Object) => {
@@ -71,6 +75,24 @@ export default (state: Object = initialState, action: Object) => {
         virtualTime: action.virtualTime
       };
 
+    case types.UPDATE_HOVERED_SEGMENT:
+      return {
+        ...state,
+        segments: state.segments.map(segment => (segment.id === action.id ? {...segment, isHovered: action.isHovered} : segment))
+      };
+
+    case types.UPDATE_SEEKBAR_SEGMENTS:
+      return {
+        ...state,
+        segments: action.segments
+      };
+
+    case types.UPDATE_SEGMENT_END_TIME:
+      return {
+        ...state,
+        segments: state.segments.map(segment => (segment.id === action.id ? {...segment, endTime: action.endTime} : segment))
+      };
+
     default:
       return state;
   }
@@ -99,5 +121,8 @@ export const actions = {
     hideTimeBubble
   }),
   updateCurrentTime: (currentTime: number) => ({type: types.UPDATE_CURRENT_TIME, currentTime}),
-  updateVirtualTime: (virtualTime: number) => ({type: types.UPDATE_VIRTUAL_TIME, virtualTime})
+  updateVirtualTime: (virtualTime: number) => ({type: types.UPDATE_VIRTUAL_TIME, virtualTime}),
+  updateHoveredSegment: (id: string, isHovered: boolean) => ({type: types.UPDATE_HOVERED_SEGMENT, id, isHovered}),
+  updateSegmentEndTime: (id: string, endTime: number) => ({type: types.UPDATE_SEGMENT_END_TIME, id, endTime}),
+  updateSeekbarSegments: (segments: any[]) => ({type: types.UPDATE_SEEKBAR_SEGMENTS, segments})
 };

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -21,6 +21,7 @@
 @import '../components/volume/volume';
 @import '../components/fullscreen/fullscreen';
 @import '../components/seekbar/seekbar';
+@import '../components/progress-indicator/progress-indicator';
 @import '../components/seekbar-preview/seekbar-preview';
 @import '../components/time-display/time-display';
 @import '../components/video-playing-title/video-playing-title';


### PR DESCRIPTION
### Description of the Changes

part of the Advanced Timeline feature.
this PR contains changes and new code for supporting segments on the seekbar, whenever there are chapters.

- extracting the progress & buffered element to a new comp named ProgressBar
- add new state `segments` to seekbar
- add new actions for updating the segments

**related PR-** https://github.com/kaltura/playkit-js-timeline/pull/11

Solves FEC-13114

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
