### PR TITLE
feat(FEC-13249): Customising the “something went wrong” slate

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -4,3 +4,4 @@
 - [Loading](./components/loading/README.md)
 - [Seekbar](./components/seekbar/README.md)
 - [Time Display](./components/time-display/README.md)
+- [Error Overlay](./components/error-overlay/README.md)

--- a/docs/components/error-overlay/README.md
+++ b/docs/components/error-overlay/README.md
@@ -1,0 +1,43 @@
+# ErrorOverlay
+
+Component that renders to indicate user when player got an error
+
+## Props
+
+| Prop      | Description                                                          |
+| --------- | -------------------------------------------------------------------- |
+| errorHead | Valid Preact node                                                    |
+| permanent | Render ErrorOverlay component despite if player got and error or not |
+
+## Player configuration
+
+in order to override error-overlay background or error message
+
+> This guide assumes you are using the [Kaltura Player]
+
+[kaltura player]: https://github.com/kaltura/kaltura-player-js/
+
+### ErrorOverlay config example
+
+```js
+const config = {
+    ...
+    ui: {
+        errorOverlay: {
+            backgroundUrl: "https://custom-error-overlay-image",
+            errorMessage: "Custom error message"
+        }
+    }
+    ...
+}
+
+const player = KalturaPlayer.setup(config);
+```
+
+## Usage Example
+
+```html
+//@flow import { h, ErrorOverlay } from 'playkit-js-ui'; export default function customUIPreset(props: any) { return (
+<ErrorOverlay />
+) }
+```

--- a/docs/components/error-overlay/README.md
+++ b/docs/components/error-overlay/README.md
@@ -1,6 +1,6 @@
 # ErrorOverlay
 
-Component that renders to indicate user when player got an error
+Component that renders to indicate user when Kaltura player got an error
 
 ## Props
 
@@ -11,21 +11,18 @@ Component that renders to indicate user when player got an error
 
 ## Player configuration
 
-in order to override error-overlay background or error message
-
 > This guide assumes you are using the [Kaltura Player]
 
 [kaltura player]: https://github.com/kaltura/kaltura-player-js/
 
-### ErrorOverlay config example
+In order to override error-overlay background add `backgroundUrl` link to player config
 
 ```js
 const config = {
     ...
     ui: {
         errorOverlay: {
-            backgroundUrl: "https://custom-error-overlay-image",
-            errorMessage: "Custom error message"
+            backgroundUrl: "https://custom-error-overlay-image-url"
         }
     }
     ...
@@ -37,7 +34,11 @@ const player = KalturaPlayer.setup(config);
 ## Usage Example
 
 ```html
-//@flow import { h, ErrorOverlay } from 'playkit-js-ui'; export default function customUIPreset(props: any) { return (
-<ErrorOverlay />
-) }
+//@flow import { h, ErrorOverlay } from 'playkit-js-ui';
+
+export default function customUIPreset(props: any) {
+    return (
+        <ErrorOverlay />
+    );
+}
 ```

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -41,7 +41,8 @@ A sample English dictionary may look like:
   "error": {
     "default_error": "Something went wrong",
     "default_session_text": "Session ID",
-    "retry": "Retry"
+    "retry": "Try again",
+    "network_error": "No internet connection check your network"
   },
   "ads": {
     "ad_notice": "Advertisement",

--- a/src/components/error-overlay/_error-overlay.scss
+++ b/src/components/error-overlay/_error-overlay.scss
@@ -30,6 +30,7 @@
     font-size: 20px;
     line-height: 22px;
     margin: 0 0 8px 0;
+    text-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
   }
 
   .error-session {
@@ -46,6 +47,7 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    text-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
   }
 
   .retry-btn {
@@ -55,10 +57,15 @@
     padding: 0 8px;
     border-radius: 4px;
     color: $tone-1-color;
+    border: none;
+    background-color: rgba(0, 0, 0, 0.6);
     font-size: 15px;
     font-weight: bold;
     line-height: 32px;
     cursor: pointer;
+    &:hover {
+      background-color: rgba(0, 0, 0, 0.7);
+    }
   }
 
   .error-text {

--- a/src/components/error-overlay/_error-overlay.scss
+++ b/src/components/error-overlay/_error-overlay.scss
@@ -3,8 +3,8 @@
   font-size: 0em;
 }
 
-.overlay-contents .error-overlay {
-  padding-top: 20px;
+.custom-error-slate .overlay.error-overlay .overlay-contents {
+  padding: 0;
 }
 
 .error-overlay {
@@ -14,53 +14,46 @@
   align-items: center;
   flex-direction: column;
   height: 100%;
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-position: center center;
 
   .copy-url-row {
     display: flex;
-    margin-bottom: 10px;
-  }
-
-  .svg-container {
-    flex: 4;
-    display: flex;
-    justify-content: space-around;
-    flex-flow: column;
+    align-items: center;
+    margin-bottom: 16px;
   }
 
   .headline {
     color: $tone-1-color;
-    font-size: $headline-font-size;
-    margin: 10px 0 14px 0;
-    flex: 1;
+    font-weight: 700;
+    font-size: 20px;
+    line-height: 22px;
+    margin: 0 0 8px 0;
   }
 
   .error-session {
     font-size: $subheadline-font-size;
-    color: $tone-2-color;
-    margin: auto;
+    color: $tone-1-color;
+    font-style: normal;
+    font-weight: 400;
+    line-height: 18px;
     user-select: text;
     -webkit-user-select: text;
     -moz-user-select: text;
     -ms-user-select: text;
-    max-width: 300px;
+    max-width: 310px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    flex: 1 1 auto;
-  }
-
-  .control-button-container {
-    flex: 5;
   }
 
   .retry-btn {
-    height: 36px;
+    height: 32px;
     width: auto;
     min-width: 120px;
     padding: 0 8px;
-    border: 2px solid $tone-7-color;
-    border-radius: 18px;
-    background-color: black;
+    border-radius: 4px;
     color: $tone-1-color;
     font-size: 15px;
     font-weight: bold;

--- a/src/components/error-overlay/error-overlay.js
+++ b/src/components/error-overlay/error-overlay.js
@@ -95,7 +95,7 @@ class ErrorOverlay extends Component {
     if (this.props.player.getMediaInfo()) {
       return (
         <div className={style.controlButtonContainer} onClick={this.handleClick}>
-          <Button className={[style.btnBorderless, style.retryBtn].join(' ')}>
+          <Button className={style.retryBtn}>
             <Text id="error.retry" />
           </Button>
         </div>
@@ -107,17 +107,12 @@ class ErrorOverlay extends Component {
   /**
    * render the error head
    *
-   * @param {string | null} errorMessage - custom error message
    * @returns {React$Element} - main state element
    * @memberof ErrorOverlay
    */
-  renderErrorHead(errorMessage: string | null): React$Element<any> | void {
-    if (errorMessage === null) {
-      return undefined;
-    }
-    const defaultErrorMessage = navigator.onLine ? 'error.default_error' : 'error.network_error';
-    const errorContent = errorMessage || <Text id={defaultErrorMessage} />;
-    return <div className={style.headline}>{this.props.errorHead ? this.props.errorHead : errorContent}</div>;
+  renderErrorHead(): React$Element<any> | void {
+    const errorMessage = navigator.onLine ? 'error.default_error' : 'error.network_error';
+    return <div className={style.headline}>{this.props.errorHead ? this.props.errorHead : <Text id={errorMessage} />}</div>;
   }
 
   /**
@@ -130,14 +125,14 @@ class ErrorOverlay extends Component {
     if ((this.props && this.props.hasError) || this.props.permanent) {
       const {player} = this.props;
       const errorOverlaConfig = (player && player.config && player.config.ui && player.config.ui.errorOverlay) || {};
-      const {backgroundUrl, errorMessage} = errorOverlaConfig;
+      const {backgroundUrl} = errorOverlaConfig;
       const errorOverlayStyles = backgroundUrl ? {backgroundImage: `url(${backgroundUrl})`} : null;
       return (
         <div className={['overlay-portal', backgroundUrl ? style.customErrorSlate : ''].join(' ')}>
           <Overlay open permanent={true} type="error">
             <div className={style.errorOverlay} style={errorOverlayStyles}>
               <p className={style.errorText} />
-              {this.renderErrorHead(errorMessage)}
+              {this.renderErrorHead()}
               {this.renderSessionID()}
               {this.renderRetryButton()}
             </div>

--- a/src/components/error-overlay/error-overlay.js
+++ b/src/components/error-overlay/error-overlay.js
@@ -95,7 +95,7 @@ class ErrorOverlay extends Component {
     if (this.props.player.getMediaInfo()) {
       return (
         <div className={style.controlButtonContainer} onClick={this.handleClick}>
-          <Button className={[style.controlButton, style.retryBtn].join(' ')}>
+          <Button className={[style.btnBorderless, style.retryBtn].join(' ')}>
             <Text id="error.retry" />
           </Button>
         </div>
@@ -105,61 +105,39 @@ class ErrorOverlay extends Component {
   }
 
   /**
+   * render the error head
+   *
+   * @param {string | null} errorMessage - custom error message
+   * @returns {React$Element} - main state element
+   * @memberof ErrorOverlay
+   */
+  renderErrorHead(errorMessage: string | null): React$Element<any> | void {
+    if (errorMessage === null) {
+      return undefined;
+    }
+    const defaultErrorMessage = navigator.onLine ? 'error.default_error' : 'error.network_error';
+    const errorContent = errorMessage || <Text id={defaultErrorMessage} />;
+    return <div className={style.headline}>{this.props.errorHead ? this.props.errorHead : errorContent}</div>;
+  }
+
+  /**
    * render main state
    *
    * @returns {?React$Element} - main state element
    * @memberof ErrorOverlay
    */
   render(): ?React$Element<any> {
-    if (this.props && this.props.hasError) {
+    if ((this.props && this.props.hasError) || this.props.permanent) {
+      const {player} = this.props;
+      const errorOverlaConfig = (player && player.config && player.config.ui && player.config.ui.errorOverlay) || {};
+      const {backgroundUrl, errorMessage} = errorOverlaConfig;
+      const errorOverlayStyles = backgroundUrl ? {backgroundImage: `url(${backgroundUrl})`} : null;
       return (
-        <div className="overlay-portal">
+        <div className={['overlay-portal', backgroundUrl ? style.customErrorSlate : ''].join(' ')}>
           <Overlay open permanent={true} type="error">
-            <div className={style.errorOverlay}>
+            <div className={style.errorOverlay} style={errorOverlayStyles}>
               <p className={style.errorText} />
-              <div className={style.svgContainer}>
-                <svg width="124" height="110" viewBox="0 0 124 110" xmlns="http://www.w3.org/2000/svg" xmlnsXlink="http://www.w3.org/1999/xlink">
-                  <defs>
-                    <polygon
-                      id="path-1"
-                      points="58.0906294 70 50.7492774 88.8201923 60.1881585 88.8201923 54.22331 107 73.8876457 84.2307692 64.0554779 84.2307692 70.6102564 70"
-                    />
-                  </defs>
-                  <g id="Player-v3" fill="none" fillRule="evenodd">
-                    <g id="Desktop---Default---Error" transform="translate(-365 -103)">
-                      <g id="Cloud" transform="translate(366 104)">
-                        <path
-                          d="M63.5662942,30.179068 C61.0506558,29.4162424 58.3339083,29 55.5,29 C42.5213084,29 32,37.7304474 32,48.5 C32,48.6497107 32.0020332,48.7990274 32.0060779,48.947932 L32.0060779,48.947932 C20.975194,51.4855427 13,58.8323573 13,67.5 C13,71.2164926 14.4662425,74.6901504 17.0109182,77.6459815 C17.3714483,67.0552274 26.624181,58.1393462 39.3259742,55.0194402 L39.3259742,55.0194402 C39.3212229,54.8326784 39.3188345,54.6453999 39.3188345,54.4576271 C39.3188345,41.956968 49.9040267,31.6467441 63.5662942,30.179068 Z"
-                          id="Combined-Shape"
-                          fillOpacity=".08"
-                          fill="#2E2E2E"
-                        />
-                        <path
-                          d="M31.0032591,48.1614253 C31.2192187,36.9518144 42.1402046,28 55.5,28 C64.749856,28 73.0886419,32.3249294 77.2653132,39.0733535 C84.8537029,39.7078593 90.7909537,44.3809769 90.9945979,50.1913309 C102.911627,51.5069936 112,59.4322556 112,69 C112,79.5603607 100.981582,88 87.5,88 C84.4639246,88 81.503099,87.5724513 78.7283559,86.7489741 C74.6488476,88.1943213 69.4726739,89 64,89 C58.7323857,89 53.737093,88.2538247 49.7263698,86.9058736 C46.7827225,87.6274324 43.6763865,88 40.5,88 C24.8190401,88 12,78.9101352 12,67.5 C12,58.659353 19.7679337,51.004786 31.0032591,48.1614253 Z"
-                          id="Combined-Shape"
-                          stroke="#666"
-                          strokeWidth="2"
-                        />
-                        <g id="Path-8" strokeLinecap="round" strokeLinejoin="round">
-                          <use fill="#666" xlinkHref="#path-1" />
-                          <path
-                            stroke="#1D1D1D"
-                            strokeWidth="2"
-                            d="M65.6170644,83.2307692 L76.0725949,83.2307692 L51.7165365,111.432521 L58.8076053,89.8201923 L49.2858112,89.8201923 L57.4073201,69 L72.1718429,69 L65.6170644,83.2307692 Z"
-                          />
-                        </g>
-                        <path
-                          d="M59.9991166,0 L59.9991166,7.04768642 C59.9991166,7.59997117 60.4468318,8.04768642 60.9991166,8.04768642 C61.5514013,8.04768642 61.9991166,7.59997117 61.9991166,7.04768642 L61.9991166,0 C61.9991166,-0.55228475 61.5514013,-1 60.9991166,-1 C60.4468318,-1 59.9991166,-0.55228475 59.9991166,0 Z M95.3084192,8.85153517 L90.7782537,14.2503762 C90.4232519,14.6734508 90.4784359,15.3042064 90.9015106,15.6592082 C91.3245852,16.01421 91.9553408,15.9590261 92.3103426,15.5359514 L96.8405081,10.1371104 C97.1955099,9.71403572 97.140326,9.08328013 96.7172513,8.72827833 C96.2941766,8.37327654 95.663421,8.4284605 95.3084192,8.85153517 Z M121.628196,36.6783398 L114.687579,37.9021577 C114.143685,37.9980609 113.780517,38.5167193 113.87642,39.0606136 C113.972323,39.6045079 114.490981,39.9676764 115.034876,39.8717732 L121.975492,38.6479553 C122.519386,38.552052 122.882555,38.0333936 122.786652,37.4894993 C122.690748,36.945605 122.17209,36.5824365 121.628196,36.6783398 Z M0.0227411046,38.6479553 L6.96335733,39.8717732 C7.50725163,39.9676764 8.02591002,39.6045079 8.12181326,39.0606136 C8.2177165,38.5167193 7.85454799,37.9980609 7.31065368,37.9021577 L0.37003746,36.6783398 C-0.173856844,36.5824365 -0.69251523,36.945605 -0.788418471,37.4894993 C-0.884321711,38.0333936 -0.521153199,38.552052 0.0227411046,38.6479553 Z M25.157725,10.1371104 L29.6878905,15.5359514 C30.0428923,15.9590261 30.6736479,16.01421 31.0967226,15.6592082 C31.5197972,15.3042064 31.5749812,14.6734508 31.2199794,14.2503762 L26.6898139,8.85153517 C26.3348121,8.4284605 25.7040565,8.37327654 25.2809818,8.72827833 C24.8579072,9.08328013 24.8027232,9.71403572 25.157725,10.1371104 Z"
-                          id="Path-9"
-                          fill="#666"
-                          fillRule="nonzero"
-                        />
-                      </g>
-                    </g>
-                  </g>
-                </svg>
-              </div>
-              <div className={style.headline}>{this.props.errorHead ? this.props.errorHead : <Text id={'error.default_error'} />}</div>
+              {this.renderErrorHead(errorMessage)}
               {this.renderSessionID()}
               {this.renderRetryButton()}
             </div>

--- a/translations/ar.i18n.json
+++ b/translations/ar.i18n.json
@@ -47,8 +47,7 @@
     },
     "error": {
       "default_error": "حدث خطأ ما",
-      "default_session_text": "معرّف الجلسة",
-      "retry": "إعادة المحاولة"
+      "default_session_text": "معرّف الجلسة"
     },
     "ads": {
       "ad_notice": "إعلان",

--- a/translations/de.i18n.json
+++ b/translations/de.i18n.json
@@ -47,8 +47,7 @@
     },
     "error": {
       "default_error": "Etwas ist schiefgegangen",
-      "default_session_text": "Sitzungs-ID",
-      "retry": "Erneut versuchen"
+      "default_session_text": "Sitzungs-ID"
     },
     "ads": {
       "ad_notice": "Anzeige",

--- a/translations/en.i18n.json
+++ b/translations/en.i18n.json
@@ -63,8 +63,9 @@
     },
     "error": {
       "default_error": "Something went wrong",
+      "network_error": "No internet connection check your network",
       "default_session_text": "Session ID",
-      "retry": "Retry"
+      "retry": "Try again"
     },
     "ads": {
       "ad_notice": "Advertisement",

--- a/translations/es.i18n.json
+++ b/translations/es.i18n.json
@@ -47,8 +47,7 @@
     },
     "error": {
       "default_error": "Algo salió mal.",
-      "default_session_text": "ID de la sesión",
-      "retry": "Reintentar"
+      "default_session_text": "ID de la sesión"
     },
     "ads": {
       "ad_notice": "Anuncio",

--- a/translations/fi.i18n.json
+++ b/translations/fi.i18n.json
@@ -47,8 +47,7 @@
     },
     "error": {
       "default_error": "Jokin meni pieleen",
-      "default_session_text": "Istunnon tunnus",
-      "retry": "Yritä uudelleen"
+      "default_session_text": "Istunnon tunnus"
     },
     "ads": {
       "ad_notice": "Mainos",

--- a/translations/fr.i18n.json
+++ b/translations/fr.i18n.json
@@ -47,8 +47,7 @@
     },
     "error": {
       "default_error": "Un problème est survenu",
-      "default_session_text": "ID de la session",
-      "retry": "Réessayer"
+      "default_session_text": "ID de la session"
     },
     "ads": {
       "ad_notice": "Publicité",

--- a/translations/fr_ca.i18n.json
+++ b/translations/fr_ca.i18n.json
@@ -47,8 +47,7 @@
     },
     "error": {
       "default_error": "Un problème est survenu",
-      "default_session_text": "ID de session",
-      "retry": "Réessayer"
+      "default_session_text": "ID de session"
     },
     "ads": {
       "ad_notice": "Publicité",

--- a/translations/he.i18n.json
+++ b/translations/he.i18n.json
@@ -47,8 +47,7 @@
     },
     "error": {
       "default_error": "משהו השתבש",
-      "default_session_text": "מזהה הפעלה",
-      "retry": "נסה שוב"
+      "default_session_text": "מזהה הפעלה"
     },
     "ads": {
       "ad_notice": "פרסומת",

--- a/translations/hi_in.i18n.json
+++ b/translations/hi_in.i18n.json
@@ -47,8 +47,7 @@
     },
     "error": {
       "default_error": "कुछ गलत हुआ",
-      "default_session_text": "सत्र ID",
-      "retry": "पुनः प्रयास करें"
+      "default_session_text": "सत्र ID"
     },
     "ads": {
       "ad_notice": "विज्ञापन",

--- a/translations/it.i18n.json
+++ b/translations/it.i18n.json
@@ -47,8 +47,7 @@
     },
     "error": {
       "default_error": "Qualcosa è andato storto",
-      "default_session_text": "ID sessione",
-      "retry": "Riprova"
+      "default_session_text": "ID sessione"
     },
     "ads": {
       "ad_notice": "Pubblicità",

--- a/translations/ja.i18n.json
+++ b/translations/ja.i18n.json
@@ -47,8 +47,7 @@
     },
     "error": {
       "default_error": "問題が発生しました",
-      "default_session_text": "セッション ID",
-      "retry": "再試行"
+      "default_session_text": "セッション ID"
     },
     "ads": {
       "ad_notice": "広告",

--- a/translations/ko.i18n.json
+++ b/translations/ko.i18n.json
@@ -47,8 +47,7 @@
     },
     "error": {
       "default_error": "오류가 발생했습니다",
-      "default_session_text": "강연 ID",
-      "retry": "재시도"
+      "default_session_text": "강연 ID"
     },
     "ads": {
       "ad_notice": "광고",

--- a/translations/nl.i18n.json
+++ b/translations/nl.i18n.json
@@ -47,8 +47,7 @@
     },
     "error": {
       "default_error": "Er is iets fout gegaan",
-      "default_session_text": "Sessie-ID",
-      "retry": "Opnieuw proberen"
+      "default_session_text": "Sessie-ID"
     },
     "ads": {
       "ad_notice": "Advertentie",

--- a/translations/pt_br.i18n.json
+++ b/translations/pt_br.i18n.json
@@ -47,8 +47,7 @@
     },
     "error": {
       "default_error": "Ocorreu um erro",
-      "default_session_text": "ID da sessão",
-      "retry": "Tentar Novamente"
+      "default_session_text": "ID da sessão"
     },
     "ads": {
       "ad_notice": "Publicidade",

--- a/translations/ru.i18n.json
+++ b/translations/ru.i18n.json
@@ -47,8 +47,7 @@
     },
     "error": {
       "default_error": "Что-то пошло не так",
-      "default_session_text": "Идентификатор сессии",
-      "retry": "Повторить попытку"
+      "default_session_text": "Идентификатор сессии"
     },
     "ads": {
       "ad_notice": "Реклама",

--- a/translations/zh_cn.i18n.json
+++ b/translations/zh_cn.i18n.json
@@ -47,8 +47,7 @@
     },
     "error": {
       "default_error": "发生错误",
-      "default_session_text": "回话 ID",
-      "retry": "重试"
+      "default_session_text": "回话 ID"
     },
     "ads": {
       "ad_notice": "广告",

--- a/translations/zh_tw.i18n.json
+++ b/translations/zh_tw.i18n.json
@@ -47,8 +47,7 @@
     },
     "error": {
       "default_error": "出現錯誤",
-      "default_session_text": "作業階段 ID",
-      "retry": "重試"
+      "default_session_text": "作業階段 ID"
     },
     "ads": {
       "ad_notice": "廣告",


### PR DESCRIPTION
### Description of the Changes

Solves: https://kaltura.atlassian.net/browse/FEC-13249

1. New designs for ErrorOverlay component;
2. add `permanent` boolean property to ErrorOverlay that force it render error slate regardless of Kaltura-player error state;
3. add `errorOverlay` configuration to Kaltura-player conf object;

<img width="659" alt="Screenshot 2023-07-31 at 18 30 11" src="https://github.com/kaltura/playkit-js-ui/assets/51074448/d559a1e2-411c-4c86-b288-4a4257a5cc06">
<img width="677" alt="Screenshot 2023-07-31 at 18 30 27" src="https://github.com/kaltura/playkit-js-ui/assets/51074448/2497c550-da49-4da0-b85a-7ec4b15b0b00">

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
