### PR TITLE
fix(FEC-13255): adding protection to active track

### DIFF
--- a/src/components/quality-menu/quality-menu.js
+++ b/src/components/quality-menu/quality-menu.js
@@ -15,6 +15,8 @@ const HeightResolution = {
   UHD_8K: 4320
 };
 
+const DEFAULT_VIDEO_TRACK_LABEL = '360p';
+
 /**
  * Determines the badge icon type of the quality option based on the height of the resolution.
  *
@@ -132,18 +134,19 @@ class QualityMenu extends Component {
 
     // Progressive playback doesn't support auto
     if (qualityOptions.length > 1 && props.player.streamType !== 'progressive') {
-      const activeTrack: Object = qualityOptions.find(track => track.value.active === true).value;
+      const activeTrack: Object = qualityOptions.find(track => track.value.active === true)?.value;
+      const label = activeTrack?.label || DEFAULT_VIDEO_TRACK_LABEL;
       let qualityLabel;
       if (rtlLanguages.includes(this.props.player._localPlayer._config.ui.locale)) {
-        qualityLabel = activeTrack.label + ' - ' + this.props.qualityAutoLabelText;
+        qualityLabel = label + ' - ' + this.props.qualityAutoLabelText;
       } else {
-        qualityLabel = this.props.qualityAutoLabelText + ' - ' + activeTrack.label;
+        qualityLabel = this.props.qualityAutoLabelText + ' - ' + label;
       }
       qualityOptions.unshift({
         label: this.props.qualityAutoLabelText,
         dropdownOptions: {
           label: qualityLabel,
-          badgeType: getLabelBadgeType(activeTrack.height)
+          badgeType: getLabelBadgeType(activeTrack?.height || 360)
         },
         active: props.player.isAdaptiveBitrateEnabled(),
         value: 'auto'

--- a/src/components/quality-menu/quality-menu.js
+++ b/src/components/quality-menu/quality-menu.js
@@ -15,7 +15,7 @@ const HeightResolution = {
   UHD_8K: 4320
 };
 
-const DEFAULT_VIDEO_TRACK_LABEL = '360p';
+const DEFAULT_VIDEO_TRACK = 360;
 
 /**
  * Determines the badge icon type of the quality option based on the height of the resolution.
@@ -135,7 +135,7 @@ class QualityMenu extends Component {
     // Progressive playback doesn't support auto
     if (qualityOptions.length > 1 && props.player.streamType !== 'progressive') {
       const activeTrack: Object = qualityOptions.find(track => track.value.active === true)?.value;
-      const label = activeTrack?.label || DEFAULT_VIDEO_TRACK_LABEL;
+      const label = activeTrack?.label || `${DEFAULT_VIDEO_TRACK}p`;
       let qualityLabel;
       if (rtlLanguages.includes(this.props.player._localPlayer._config.ui.locale)) {
         qualityLabel = label + ' - ' + this.props.qualityAutoLabelText;
@@ -146,7 +146,7 @@ class QualityMenu extends Component {
         label: this.props.qualityAutoLabelText,
         dropdownOptions: {
           label: qualityLabel,
-          badgeType: getLabelBadgeType(activeTrack?.height || 360)
+          badgeType: getLabelBadgeType(activeTrack?.height || DEFAULT_VIDEO_TRACK)
         },
         active: props.player.isAdaptiveBitrateEnabled(),
         value: 'auto'


### PR DESCRIPTION
### Description of the Changes

**the issue:**
in some times, the `videoTracks` state is not getting updated fast enough before rendering the quality menu, which means that not always we have an activeTrack- which causes an error and bad behavior.

**solution:**
adding protection to finding the activeTrack and a fallback to the video track label.

Related to ticket [FEC-13255](https://kaltura.atlassian.net/browse/FEC-13255)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[FEC-13255]: https://kaltura.atlassian.net/browse/FEC-13255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ