### PR TITLE
fix(FEC-13320): minimized dualscreen is overlaying seekbar preview

### DIFF
--- a/src/components/seekbar/_seekbar.scss
+++ b/src/components/seekbar/_seekbar.scss
@@ -2,6 +2,7 @@
   padding: 12px 0 12px 0;
   cursor: pointer;
   position: relative;
+  z-index: 1;
 
   &:hover,
   &.hover {


### PR DESCRIPTION
### Description of the Changes

- bug fix

**the issue:**
when dualscreen is minimized, it overlays the seekbar frame preview.

**solution:**
add `z-index` to the seekbar comp.

Solves FEC-13320

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
