### PR TITLE
fix(FEC-13209): [Audio Player] adjust full size player UI to entries of audio media type

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@babel/preset-flow": "^7.10.4",
     "@babel/register": "^7.10.5",
     "@playkit-js/playkit-js": "canary",
-    "@playkit-js/kaltura-player-js": "canary",
+    "@playkit-js/kaltura-player-js": "3.15.3-canary.0-51ca9be",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.1.0",
     "babel-plugin-istanbul": "^6.0.0",

--- a/src/components/audio-entry-details/_audio-entry-details.scss
+++ b/src/components/audio-entry-details/_audio-entry-details.scss
@@ -32,6 +32,14 @@
             
             .audio-entry-title {
                 font-size: 32px; 
+                
+                &.audio-entry-title-trimmed {
+                    -webkit-box-orient: vertical;
+                    -webkit-line-clamp: 1;
+                    display: -webkit-box; 
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                }
             }
             
             .audio-entry-description { 

--- a/src/components/audio-entry-details/_audio-entry-details.scss
+++ b/src/components/audio-entry-details/_audio-entry-details.scss
@@ -31,16 +31,11 @@
             }
             
             .audio-entry-title {
-                -webkit-line-clamp: 1; 
                 font-size: 32px; 
             }
             
-            .audio-entry-description {
-                -webkit-box-orient: vertical;
-                -webkit-line-clamp: 3; 
-                display: -webkit-box; 
+            .audio-entry-description { 
                 font-size: 14px; 
-                overflow: hidden; 
             }
         }
     }   

--- a/src/components/audio-entry-details/_audio-entry-details.scss
+++ b/src/components/audio-entry-details/_audio-entry-details.scss
@@ -1,0 +1,50 @@
+.player { 
+    .audio-entry-backdrop {
+        background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.7) 100%);
+        bottom: 0; 
+        padding-top: 128px; 
+        pointer-events: none;
+        position: absolute; 
+        width: 100%; 
+        
+        .audio-entry-details {
+            margin-left: 16px; 
+            margin-right: 16px; 
+            padding-bottom: 60px; 
+            left: 16px; 
+            color: white; 
+            
+            &.audio-entry-l {
+                max-width: 600px;
+            }
+            
+            &.audio-entry-m {
+                max-width: min(600px, 100%);
+            }
+            
+            &.audio-entry-s {
+                max-width: 100%;
+            }
+
+            &.audio-entry-t {
+                max-width: 0px;
+            }
+            
+            .audio-entry-title {
+                -webkit-box-orient: vertical;
+                -webkit-line-clamp: 1; 
+                display: -webkit-box; 
+                font-size: 32px; 
+                overflow: hidden; 
+            }
+            
+            .audio-entry-description {
+                -webkit-box-orient: vertical;
+                -webkit-line-clamp: 3; 
+                display: -webkit-box; 
+                font-size: 14px; 
+                overflow: hidden; 
+            }
+        }
+    }   
+}

--- a/src/components/audio-entry-details/_audio-entry-details.scss
+++ b/src/components/audio-entry-details/_audio-entry-details.scss
@@ -21,10 +21,6 @@
             &.audio-entry-m {
                 max-width: min(600px, 100%);
             }
-            
-            &.audio-entry-s {
-                max-width: 100%;
-            }
 
             &.audio-entry-t {
                 max-width: 0px;

--- a/src/components/audio-entry-details/_audio-entry-details.scss
+++ b/src/components/audio-entry-details/_audio-entry-details.scss
@@ -2,7 +2,6 @@
     .audio-entry-backdrop {
         background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.7) 100%);
         bottom: 0; 
-        height: 100%;
         position: absolute; 
         width: 100%;
         pointer-events: none;
@@ -11,15 +10,12 @@
         justify-content: flex-end;
         
         .audio-entry-details {
-            margin: 60px 16px; 
+            margin: 128px 16px 60px 16px; 
             left: 16px; 
             color: white;
             max-height: 100%;
             pointer-events: auto;
-
-            &.audio-entry-expanded {                
-                overflow: auto;
-            }
+            z-index: 1;
             
             &.audio-entry-l {
                 max-width: 600px;
@@ -51,6 +47,17 @@
             
             .audio-entry-description { 
                 font-size: 14px; 
+            }
+        }
+
+        &.audio-entry-expanded {                
+            overflow: auto;
+            background: rgba(0, 0, 0, 0.7);
+            height: 100%;
+
+            .audio-entry-details {
+                overflow: auto;
+                margin: 60px 16px;
             }
         }
     }   

--- a/src/components/audio-entry-details/_audio-entry-details.scss
+++ b/src/components/audio-entry-details/_audio-entry-details.scss
@@ -2,17 +2,24 @@
     .audio-entry-backdrop {
         background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.7) 100%);
         bottom: 0; 
-        padding-top: 128px; 
-        pointer-events: none;
+        height: 100%;
         position: absolute; 
-        width: 100%; 
+        width: 100%;
+        pointer-events: none;
+        display: flex;
+        flex-direction: column;
+        justify-content: flex-end;
         
         .audio-entry-details {
-            margin-left: 16px; 
-            margin-right: 16px; 
-            padding-bottom: 60px; 
+            margin: 60px 16px; 
             left: 16px; 
-            color: white; 
+            color: white;
+            max-height: 100%;
+            pointer-events: auto;
+
+            &.audio-entry-expanded {                
+                overflow: auto;
+            }
             
             &.audio-entry-l {
                 max-width: 600px;

--- a/src/components/audio-entry-details/_audio-entry-details.scss
+++ b/src/components/audio-entry-details/_audio-entry-details.scss
@@ -31,11 +31,8 @@
             }
             
             .audio-entry-title {
-                -webkit-box-orient: vertical;
                 -webkit-line-clamp: 1; 
-                display: -webkit-box; 
                 font-size: 32px; 
-                overflow: hidden; 
             }
             
             .audio-entry-description {

--- a/src/components/audio-entry-details/_audio-entry-details.scss
+++ b/src/components/audio-entry-details/_audio-entry-details.scss
@@ -24,6 +24,10 @@
 
             &.audio-entry-t {
                 max-width: 0px;
+
+                .audio-entry-description { 
+                    font-size: 0; 
+                }
             }
             
             .audio-entry-title {

--- a/src/components/audio-entry-details/audio-entry-details.js
+++ b/src/components/audio-entry-details/audio-entry-details.js
@@ -6,6 +6,8 @@ import {h, Component} from 'preact';
 import {PLAYER_SIZE} from '../shell/shell';
 import {withPlayer} from '../player';
 
+import {ExpandableText} from '../expandable-text/expandable-text';
+
 /**
  * mapping state to props
  * @param {*} state - redux store state
@@ -64,10 +66,28 @@ class AudioEntryDetails extends Component {
       <div className={style.audioEntryBackdrop}>
         <div className={`${style.audioEntryDetails} ${sizeClass}`}>
           <div className={style.audioEntryTitle}>{name}</div>
-          <div className={style.audioEntryDescription}>{description ? description : ''}</div>
+          <div className={style.audioEntryDescription}>
+            <ExpandableText text={description} lines={3}>
+              {description}
+            </ExpandableText>
+          </div>
+
+          {/* <ExpandableText text={name} lines={3}>
+            <div className={style.audioEntryTitle}>{name}</div>
+            {description && <div className={style.audioEntryDescription}>{description}</div>}
+          </ExpandableText> */}
         </div>
       </div>
     );
+
+    // return (
+    //   <div className={style.audioEntryBackdrop}>
+    //     <div className={`${style.audioEntryDetails} ${sizeClass}`}>
+    //       <div className={style.audioEntryTitle}>{name}</div>
+    //       <div className={style.audioEntryDescription}>{description ? description : ''}</div>
+    //     </div>
+    //   </div>
+    // );
   }
 }
 

--- a/src/components/audio-entry-details/audio-entry-details.js
+++ b/src/components/audio-entry-details/audio-entry-details.js
@@ -47,10 +47,6 @@ const AudioEntryDetails = connect(mapStateToProps)(
           return style.audioEntryL;
         case PLAYER_SIZE.MEDIUM:
           return style.audioEntryM;
-        case PLAYER_SIZE.SMALL:
-        case PLAYER_SIZE.EXTRA_SMALL:
-          return style.audioEntryS;
-        case PLAYER_SIZE.TINY:
         default:
           return style.audioEntryT;
       }

--- a/src/components/audio-entry-details/audio-entry-details.js
+++ b/src/components/audio-entry-details/audio-entry-details.js
@@ -87,8 +87,8 @@ const AudioEntryDetails = connect(mapStateToProps)(
     };
 
     return (
-      <div className={style.audioEntryBackdrop}>
-        <div className={`${style.audioEntryDetails} ${sizeClass} ${expandedClass}`}>
+      <div className={`${style.audioEntryBackdrop} ${expandedClass}`}>
+        <div className={`${style.audioEntryDetails} ${sizeClass}`}>
           <Scrollable isVertical={true}>
             <div className={style.audioEntryContent}>
               <div ref={textRef} className={titleClass}>

--- a/src/components/audio-entry-details/audio-entry-details.js
+++ b/src/components/audio-entry-details/audio-entry-details.js
@@ -67,9 +67,7 @@ class AudioEntryDetails extends Component {
         <div className={`${style.audioEntryDetails} ${sizeClass}`}>
           <div className={style.audioEntryTitle}>{name}</div>
           <div className={style.audioEntryDescription}>
-            <ExpandableText text={description} lines={3}>
-              {description}
-            </ExpandableText>
+            <ExpandableText text={description} lines={3}></ExpandableText>
           </div>
 
           {/* <ExpandableText text={name} lines={3}>

--- a/src/components/audio-entry-details/audio-entry-details.js
+++ b/src/components/audio-entry-details/audio-entry-details.js
@@ -9,7 +9,8 @@ import {useState, useLayoutEffect, useRef} from 'preact/hooks';
 import {PLAYER_SIZE} from '../shell/shell';
 import {withPlayer} from '../player';
 
-import {ExpandableText} from '../expandable-text/expandable-text';
+import {ExpandableText} from '../expandable-text';
+import {Scrollable} from '../scrollable';
 
 interface AudioEntryDetailsProps {
   player: any;
@@ -78,22 +79,33 @@ const AudioEntryDetails = connect(mapStateToProps)(
     const sizeClass = getSizeClass(props.playerSize);
     const titleClass = `${style.audioEntryTitle} ${isTitleTrimmed ? style.audioEntryTitleTrimmed : ''}`;
 
+    let expandedClass = isTitleTrimmed ? '' : style.audioEntryExpanded;
+
+    // eslint-disable-next-line require-jsdoc
+    const onClick = () => {
+      setIsTitleTrimmed(!isTitleTrimmed);
+    };
+
     return (
       <div className={style.audioEntryBackdrop}>
-        <div className={`${style.audioEntryDetails} ${sizeClass}`}>
-          <div ref={textRef} className={titleClass}>
-            {name}
-          </div>
-          {isFinalized ? undefined : (
-            <div ref={comparisonTextRef} className={`${style.audioEntryTitle} ${style.audioEntryTitleTrimmed}`}>
-              {name}
+        <div className={`${style.audioEntryDetails} ${sizeClass} ${expandedClass}`}>
+          <Scrollable isVertical={true}>
+            <div className={style.audioEntryContent}>
+              <div ref={textRef} className={titleClass}>
+                {name}
+              </div>
+              {isFinalized ? undefined : (
+                <div ref={comparisonTextRef} className={`${style.audioEntryTitle} ${style.audioEntryTitleTrimmed}`}>
+                  {name}
+                </div>
+              )}
+              <div className={style.audioEntryDescription}>
+                <ExpandableText text={description} lines={3} onClick={onClick} forceShowMore={forceShowMore}>
+                  {description}
+                </ExpandableText>
+              </div>
             </div>
-          )}
-          <div className={style.audioEntryDescription}>
-            <ExpandableText text={description} lines={3} onClick={() => setIsTitleTrimmed(!isTitleTrimmed)} forceShowMore={forceShowMore}>
-              {description}
-            </ExpandableText>
-          </div>
+          </Scrollable>
         </div>
       </div>
     );

--- a/src/components/audio-entry-details/audio-entry-details.js
+++ b/src/components/audio-entry-details/audio-entry-details.js
@@ -1,0 +1,75 @@
+//@flow
+import style from '../../styles/style.scss';
+
+import {connect} from 'react-redux';
+import {h, Component} from 'preact';
+import {PLAYER_SIZE} from '../shell/shell';
+import {withPlayer} from '../player';
+
+/**
+ * mapping state to props
+ * @param {*} state - redux store state
+ * @returns {Object} - mapped state to this component
+ */
+const mapStateToProps = state => ({
+  isAudio: state.engine.isAudio,
+  playerSize: state.shell.playerSize
+});
+
+const COMPONENT_NAME = 'AudioEntryDetails';
+
+/**
+ * AudioEntryDetails component
+ *
+ * @class AudioEntryDetails
+ * @example <AudioEntryDetails />
+ * @extends {Component}
+ */
+@connect(mapStateToProps)
+@withPlayer
+class AudioEntryDetails extends Component {
+  // eslint-disable-next-line require-jsdoc
+  getSizeClass(playerSize: typeof PLAYER_SIZE) {
+    switch (playerSize) {
+      case PLAYER_SIZE.EXTRA_LARGE:
+      case PLAYER_SIZE.LARGE:
+        return style.audioEntryL;
+      case PLAYER_SIZE.MEDIUM:
+        return style.audioEntryM;
+      case PLAYER_SIZE.SMALL:
+      case PLAYER_SIZE.EXTRA_SMALL:
+        return style.audioEntryS;
+      case PLAYER_SIZE.TINY:
+      default:
+        return style.audioEntryT;
+    }
+  }
+
+  /**
+   * render component
+   *
+   * @param {*} props - component props
+   * @returns {?React$Element} - component element
+   * @memberof Cast
+   */
+  render(props: any): ?React$Element<any> {
+    if (!props.isAudio || !props.player.sources?.metadata?.name) {
+      return undefined;
+    }
+
+    const {name, description} = props.player.sources.metadata;
+    const sizeClass = this.getSizeClass(props.playerSize);
+
+    return (
+      <div className={style.audioEntryBackdrop}>
+        <div className={`${style.audioEntryDetails} ${sizeClass}`}>
+          <div className={style.audioEntryTitle}>{name}</div>
+          <div className={style.audioEntryDescription}>{description ? description : ''}</div>
+        </div>
+      </div>
+    );
+  }
+}
+
+AudioEntryDetails.displayName = COMPONENT_NAME;
+export {AudioEntryDetails};

--- a/src/components/audio-entry-details/index.js
+++ b/src/components/audio-entry-details/index.js
@@ -1,0 +1,1 @@
+export {AudioEntryDetails} from './audio-entry-details';

--- a/src/components/engine-connector/engine-connector.js
+++ b/src/components/engine-connector/engine-connector.js
@@ -54,8 +54,7 @@ class EngineConnector extends Component {
       this.props.updateIsVr(player.isVr());
       this.props.updateIsImg(player.isUntimedImg());
 
-      // TODO use top level API
-      this.props.updateIsAudio(player._localPlayer.isAudio());
+      this.props.updateIsAudio(player.isAudio());
 
       this.props.updateIsInPictureInPicture(player.isInPictureInPicture());
       if (player.config.playback.autoplay) {

--- a/src/components/engine-connector/engine-connector.js
+++ b/src/components/engine-connector/engine-connector.js
@@ -53,6 +53,10 @@ class EngineConnector extends Component {
       this.props.updateIsLive(player.isLive());
       this.props.updateIsVr(player.isVr());
       this.props.updateIsImg(player.isUntimedImg());
+
+      // TODO use top level API
+      this.props.updateIsAudio(player._localPlayer.isAudio());
+
       this.props.updateIsInPictureInPicture(player.isInPictureInPicture());
       if (player.config.playback.autoplay) {
         this.props.updateLoadingSpinnerState(true);

--- a/src/components/expandable-text/_expandable-text.scss
+++ b/src/components/expandable-text/_expandable-text.scss
@@ -5,9 +5,12 @@
         -webkit-box-orient: vertical;
         display: -webkit-box; 
     }
-
+    
     .more-button-text {
         pointer-events: auto;
         cursor: pointer;
+        position: relative;
+        z-index: 1;
+        width: fit-content;
     }
 }

--- a/src/components/expandable-text/_expandable-text.scss
+++ b/src/components/expandable-text/_expandable-text.scss
@@ -1,7 +1,6 @@
 .player {
-    .text {
+    .expandable-text {
         text-overflow: ellipsis;
-        white-space: nowrap;
         overflow: hidden;
         -webkit-box-orient: vertical;
         display: -webkit-box; 

--- a/src/components/expandable-text/_expandable-text.scss
+++ b/src/components/expandable-text/_expandable-text.scss
@@ -1,0 +1,14 @@
+.player {
+    .text {
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        overflow: hidden;
+        -webkit-box-orient: vertical;
+        display: -webkit-box; 
+    }
+
+    .more-button-text {
+        pointer-events: auto;
+        cursor: pointer;
+    }
+}

--- a/src/components/expandable-text/expandable-text.js
+++ b/src/components/expandable-text/expandable-text.js
@@ -1,15 +1,27 @@
-/* eslint-disable no-console */
-/* eslint-disable require-jsdoc */
 //@flow
+import {h, ComponentChildren} from 'preact';
+import {withText} from 'preact-i18n';
 
-import {h} from 'preact';
 import {useState, useRef, useLayoutEffect} from 'preact/hooks';
 
 import styles from '../../styles/style.scss';
 
 const COMPONENT_NAME = 'ExpandableText';
 
-const ExpandableText = (props: any) => {
+interface ExpandableTextProps {
+  text: string;
+  lines: number;
+  forceShowMore: boolean;
+  onClick?: () => void;
+  readMoreLabel?: string;
+  readLessLabel?: string;
+  children: ComponentChildren;
+}
+
+const ExpandableText = withText({
+  readMoreLabel: 'controls.readMore',
+  readLessLabel: 'controls.readLess'
+})((props: ExpandableTextProps) => {
   const [isTextExpanded, setIsTextExpanded] = useState(false);
   const [isTextTrimmed, setIsTextTrimmed] = useState(false);
   const [isFinalized, setIsFinalized] = useState(false);
@@ -24,7 +36,16 @@ const ExpandableText = (props: any) => {
     }
   }, [isFinalized]);
 
-  if (!isTextTrimmed) {
+  // eslint-disable-next-line require-jsdoc
+  const onClick = () => {
+    if (props.onClick) {
+      props.onClick();
+    }
+
+    setIsTextExpanded(!isTextExpanded);
+  };
+
+  if (!isTextTrimmed && !props.forceShowMore) {
     return (
       <div className={styles.contentText}>
         <div className={styles.titleWrapper}>
@@ -44,18 +65,18 @@ const ExpandableText = (props: any) => {
   return (
     <div>
       {isTextExpanded ? (
-        props.text
+        props.children
       ) : (
         <div className={styles.expandableText} style={{'-webkit-line-clamp': props.lines}}>
           {props.text}
         </div>
       )}
-      <div className={styles.moreButtonText} onClick={() => setIsTextExpanded(!isTextExpanded)}>
-        {isTextExpanded ? 'Less' : 'More'}
+      <div className={styles.moreButtonText} onClick={onClick}>
+        {isTextExpanded ? props.readLessLabel : props.readMoreLabel}
       </div>
     </div>
   );
-};
+});
 
 ExpandableText.displayName = COMPONENT_NAME;
 export {ExpandableText};

--- a/src/components/expandable-text/expandable-text.js
+++ b/src/components/expandable-text/expandable-text.js
@@ -1,0 +1,89 @@
+/* eslint-disable require-jsdoc */
+//@flow
+
+import {h, Component} from 'preact';
+import styles from '../../styles/style.scss';
+// import {ShowMoreToggle} from './show-more-toggle';
+
+// interface ExpandableTextProps {
+//   text: string;
+//   children?: ComponentChildren[];
+//   lines: number;
+// }
+
+// interface ExpandableTextState {
+//   isTextTrimmed: boolean;
+//   isTextExpanded: boolean;
+// }
+
+const COMPONENT_NAME = 'ExpandableText';
+
+class ExpandableText extends Component {
+  _textRef: HTMLElement | null;
+  _textContainerRef: HTMLElement | null;
+
+  componentDidMount() {
+    // TODO copy calculation from related
+    let isTextTrimmed = false;
+    if (this._textRef && this._textContainerRef) {
+      //$FlowFixMe
+      isTextTrimmed = this._textRef.getBoundingClientRect().width > this._textContainerRef.getBoundingClientRect().width;
+    }
+
+    this.setState({isTextExpanded: false, isTextTrimmed});
+  }
+
+  _updateIsExpanded() {
+    this.setState({...this.state, isTextExpanded: !this.state.isTextExpanded});
+  }
+
+  render() {
+    const {text} = this.props;
+    if (!text) return undefined;
+
+    const {isTextTrimmed, isTextExpanded} = this.state;
+
+    if (!isTextTrimmed) {
+      return (
+        <div
+          className={styles.contentText}
+          ref={node => {
+            this._textContainerRef = node;
+          }}>
+          <div className={styles.titleWrapper}>
+            <div className={styles.text}>
+              <span
+                ref={node => {
+                  this._textRef = node;
+                }}>
+                {text}
+              </span>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    const linesStyle = {'-webkit-line-clamp': this.props.lines};
+
+    // TODO
+    return (
+      <div>
+        {isTextExpanded ? (
+          this.props.children
+        ) : (
+          <div className={styles.text} style={linesStyle}>
+            {text}
+          </div>
+        )}
+        <div className={styles.moreButtonText} onClick={this._updateIsExpanded.bind(this)}>
+          {isTextExpanded ? 'Less' : 'More'}
+        </div>
+        {/* <ShowMoreToggle title={text} onClick={}></ShowMoreToggle> */}
+      </div>
+    );
+  }
+}
+
+ExpandableText.displayName = COMPONENT_NAME;
+export {ExpandableText};

--- a/src/components/expandable-text/expandable-text.js
+++ b/src/components/expandable-text/expandable-text.js
@@ -1,89 +1,61 @@
+/* eslint-disable no-console */
 /* eslint-disable require-jsdoc */
 //@flow
 
-import {h, Component} from 'preact';
+import {h} from 'preact';
+import {useState, useRef, useLayoutEffect} from 'preact/hooks';
+
 import styles from '../../styles/style.scss';
-// import {ShowMoreToggle} from './show-more-toggle';
-
-// interface ExpandableTextProps {
-//   text: string;
-//   children?: ComponentChildren[];
-//   lines: number;
-// }
-
-// interface ExpandableTextState {
-//   isTextTrimmed: boolean;
-//   isTextExpanded: boolean;
-// }
 
 const COMPONENT_NAME = 'ExpandableText';
 
-class ExpandableText extends Component {
-  _textRef: HTMLElement | null;
-  _textContainerRef: HTMLElement | null;
+const ExpandableText = (props: any) => {
+  const [isTextExpanded, setIsTextExpanded] = useState(false);
+  const [isTextTrimmed, setIsTextTrimmed] = useState(false);
+  const [isFinalized, setIsFinalized] = useState(false);
 
-  componentDidMount() {
-    // TODO copy calculation from related
-    let isTextTrimmed = false;
-    if (this._textRef && this._textContainerRef) {
-      //$FlowFixMe
-      isTextTrimmed = this._textRef.getBoundingClientRect().width > this._textContainerRef.getBoundingClientRect().width;
+  const comparisonTextRef = useRef(null);
+  const textRef = useRef(null);
+
+  useLayoutEffect(() => {
+    if (textRef?.current && comparisonTextRef?.current) {
+      setIsFinalized(true);
+      setIsTextTrimmed(textRef?.current?.getBoundingClientRect().height < comparisonTextRef?.current?.getBoundingClientRect().height);
     }
+  }, [isFinalized]);
 
-    this.setState({isTextExpanded: false, isTextTrimmed});
-  }
-
-  _updateIsExpanded() {
-    this.setState({...this.state, isTextExpanded: !this.state.isTextExpanded});
-  }
-
-  render() {
-    const {text} = this.props;
-    if (!text) return undefined;
-
-    const {isTextTrimmed, isTextExpanded} = this.state;
-
-    if (!isTextTrimmed) {
-      return (
-        <div
-          className={styles.contentText}
-          ref={node => {
-            this._textContainerRef = node;
-          }}>
-          <div className={styles.titleWrapper}>
-            <div className={styles.text}>
-              <span
-                ref={node => {
-                  this._textRef = node;
-                }}>
-                {text}
-              </span>
-            </div>
-          </div>
-        </div>
-      );
-    }
-
-    const linesStyle = {'-webkit-line-clamp': this.props.lines};
-
-    // TODO
+  if (!isTextTrimmed) {
     return (
-      <div>
-        {isTextExpanded ? (
-          this.props.children
-        ) : (
-          <div className={styles.text} style={linesStyle}>
-            {text}
+      <div className={styles.contentText}>
+        <div className={styles.titleWrapper}>
+          <div ref={textRef} style={{'-webkit-line-clamp': props.lines}} className={styles.expandableText}>
+            {props.text}
           </div>
-        )}
-        <div className={styles.moreButtonText} onClick={this._updateIsExpanded.bind(this)}>
-          {isTextExpanded ? 'Less' : 'More'}
+          {!isFinalized ? (
+            <div ref={comparisonTextRef} style={{'-webkit-line-clamp': props.lines + 1}} className={styles.expandableText}>
+              {props.text}
+            </div>
+          ) : undefined}
         </div>
-        {/* <ShowMoreToggle title={text} onClick={}></ShowMoreToggle> */}
       </div>
     );
   }
-}
+
+  return (
+    <div>
+      {isTextExpanded ? (
+        props.text
+      ) : (
+        <div className={styles.expandableText} style={{'-webkit-line-clamp': props.lines}}>
+          {props.text}
+        </div>
+      )}
+      <div className={styles.moreButtonText} onClick={() => setIsTextExpanded(!isTextExpanded)}>
+        {isTextExpanded ? 'Less' : 'More'}
+      </div>
+    </div>
+  );
+};
 
 ExpandableText.displayName = COMPONENT_NAME;
 export {ExpandableText};

--- a/src/components/expandable-text/index.js
+++ b/src/components/expandable-text/index.js
@@ -1,0 +1,1 @@
+export {ExpandableText} from './expandable-text';

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -8,6 +8,7 @@ import {Settings} from './settings';
 import {Volume} from './volume';
 import {VrStereo} from './vr-stereo';
 import {ClosedCaptions} from './closed-captions';
+import {ExpandableText} from './expandable-text';
 
 export {AdLearnMore} from './ad-learn-more';
 export {AdSkip} from './ad-skip';
@@ -77,3 +78,4 @@ export {Settings, Settings as SettingsControl};
 export {Volume, Volume as VolumeControl};
 export {VrStereo, VrStereo as VrStereoControl};
 export {ClosedCaptions, ClosedCaptions as ClosedCaptionsControl};
+export {ExpandableText};

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -8,7 +8,6 @@ import {Settings} from './settings';
 import {Volume} from './volume';
 import {VrStereo} from './vr-stereo';
 import {ClosedCaptions} from './closed-captions';
-import {ExpandableText} from './expandable-text';
 
 export {AdLearnMore} from './ad-learn-more';
 export {AdSkip} from './ad-skip';
@@ -61,6 +60,8 @@ export {CaptionsMenu} from './captions-menu';
 export {SpeedMenu} from './speed-menu';
 export {QualityMenu, HeightResolution, getLabelBadgeType} from './quality-menu';
 export {AdvancedAudioDescToggle} from './advanced-audio-desc-toggle';
+export {ExpandableText} from './expandable-text';
+export {Scrollable} from './scrollable';
 
 export {PlayerArea, withPlayerPreset, Remove} from './player-area';
 export {VideoArea} from './video-area';
@@ -78,4 +79,3 @@ export {Settings, Settings as SettingsControl};
 export {Volume, Volume as VolumeControl};
 export {VrStereo, VrStereo as VrStereoControl};
 export {ClosedCaptions, ClosedCaptions as ClosedCaptionsControl};
-export {ExpandableText};

--- a/src/components/scrollable/index.js
+++ b/src/components/scrollable/index.js
@@ -1,0 +1,1 @@
+export {Scrollable} from './scrollable.js';

--- a/src/components/scrollable/scrollable.js
+++ b/src/components/scrollable/scrollable.js
@@ -1,0 +1,53 @@
+//@flow
+
+import {ComponentChildren, h} from 'preact';
+import {useState, useRef, useMemo} from 'preact/hooks';
+import styles from '../../styles/style.scss';
+
+const SCROLL_BAR_TIMEOUT = 250;
+
+/**
+ * Wraps around child components and displays a styled scrollbar with vertical or horizontal orientation.
+ *
+ * @param {object} props Component props.
+ * @param {ComponentChildren} props.children Child components.
+ * @param {boolean} props.isVertical If true, scrollbar has vertical orientation, otherwise - it has horizontal orientation.
+ * @returns {any} Scrollable component
+ */
+const Scrollable = ({children, isVertical}: {children: ComponentChildren, isVertical: boolean}) => {
+  const ref = useRef(null);
+  const [scrolling, setScrolling] = useState(false);
+  const [scrollTimeoutId, setScrollTimeoutId] = useState(-1);
+
+  // eslint-disable-next-line require-jsdoc
+  const handleScroll = () => {
+    clearTimeout(scrollTimeoutId);
+    setScrolling(true);
+    setScrollTimeoutId(
+      window.setTimeout(() => {
+        setScrolling(false);
+      }, SCROLL_BAR_TIMEOUT)
+    );
+  };
+
+  // eslint-disable-next-line require-jsdoc
+  const handleWheel = (e: WheelEvent) => {
+    e.preventDefault();
+    if (ref?.current) {
+      ref.current.scrollLeft += e.deltaY;
+      handleScroll();
+    }
+  };
+
+  const scrollableParams = useMemo(() => (isVertical ? {onScroll: handleScroll} : {onWheel: handleWheel, ref}), [isVertical]);
+
+  return (
+    <div
+      className={`${styles.scrollable} ${scrolling ? styles.scrolling : ''} ${isVertical ? styles.vertical : styles.horizontal}`}
+      {...scrollableParams}>
+      {children}
+    </div>
+  );
+};
+
+export {Scrollable};

--- a/src/components/scrollable/scrollable.scss
+++ b/src/components/scrollable/scrollable.scss
@@ -1,0 +1,31 @@
+.scrollable {
+    display: flex;
+    width: 100%;
+
+    &.horizontal {
+        flex-direction: row;
+        overflow: auto hidden;
+    }
+    &.vertical {
+        flex-direction: column;
+        height: 100%;
+        overflow: hidden auto;
+    }
+    &::-webkit-scrollbar {
+        height: 4px;
+        width: 4px;
+    }
+    &::-webkit-scrollbar-track {
+        background: rgba(33, 33, 33, 0.9);
+        visibility: hidden;
+    }
+    &::-webkit-scrollbar-thumb {
+        background-color: rgba(255, 255, 255, 0.3);
+        border-radius: 3px;
+        visibility: hidden;
+    }
+    &.scrolling::-webkit-scrollbar-track,
+    &.scrolling::-webkit-scrollbar-thumb {
+        visibility: visible;
+    }
+}

--- a/src/components/scrollable/scrollable.scss
+++ b/src/components/scrollable/scrollable.scss
@@ -16,7 +16,6 @@
         width: 4px;
     }
     &::-webkit-scrollbar-track {
-        background: rgba(33, 33, 33, 0.9);
         visibility: hidden;
     }
     &::-webkit-scrollbar-thumb {

--- a/src/reducers/engine.js
+++ b/src/reducers/engine.js
@@ -35,6 +35,7 @@ export const types = {
   UPDATE_AD_IS_BUMPER: `${component}/UPDATE_AD_IS_BUMPER`,
   UPDATE_AD_CONTENT_TYPE: `${component}/UPDATE_AD_CONTENT_TYPE`,
   UPDATE_PLAYER_POSTER: `${component}/UPDATE_PLAYER_POSTER`,
+  UPDATE_IS_AUDIO: `${component}/UPDATE_IS_AUDIO`,
   UPDATE_IS_LIVE: `${component}/UPDATE_IS_LIVE`,
   UPDATE_IS_DVR: `${component}/UPDATE_IS_DVR`,
   UPDATE_IS_IMG: `${component}/UPDATE_IS_IMG`,
@@ -88,6 +89,7 @@ export const initialState = {
   isLive: false,
   isDvr: false,
   isImg: false,
+  isAudio: false,
   adProgress: {
     currentTime: 0,
     duration: 0
@@ -296,6 +298,12 @@ export default (state: Object = initialState, action: Object) => {
         poster: action.poster
       };
 
+    case types.UPDATE_IS_AUDIO:
+      return {
+        ...state,
+        isAudio: action.isAudio
+      };
+
     case types.UPDATE_IS_LIVE:
       return {
         ...state,
@@ -434,6 +442,7 @@ export const actions = {
   updateAdIsBumper: (adIsBumper: boolean) => ({type: types.UPDATE_AD_IS_BUMPER, adIsBumper}),
   updateAdContentType: (adContentType: string) => ({type: types.UPDATE_AD_CONTENT_TYPE, adContentType}),
   updatePlayerPoster: (poster: string) => ({type: types.UPDATE_PLAYER_POSTER, poster}),
+  updateIsAudio: (isAudio: boolean) => ({type: types.UPDATE_IS_AUDIO, isAudio}),
   updateIsLive: (isLive: boolean) => ({type: types.UPDATE_IS_LIVE, isLive}),
   updateIsDvr: (isDvr: boolean) => ({type: types.UPDATE_IS_DVR, isDvr}),
   updateIsImg: (isImg: boolean) => ({type: types.UPDATE_IS_IMG, isImg}),

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -59,3 +59,4 @@
 @import '../components/toggle-switch/toggle-switch';
 @import '../components/audio-entry-details/audio-entry-details';
 @import "../components/expandable-text/expandable-text";
+@import "../components/scrollable/scrollable";

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -57,3 +57,4 @@
 @import '../components/gui-area/gui-area';
 @import '../components/spinner/spinner';
 @import '../components/toggle-switch/toggle-switch';
+@import '../components/audio-entry-details/audio-entry-details';

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -58,3 +58,4 @@
 @import '../components/spinner/spinner';
 @import '../components/toggle-switch/toggle-switch';
 @import '../components/audio-entry-details/audio-entry-details';
+@import "../components/expandable-text/expandable-text";

--- a/src/ui-presets/playback.js
+++ b/src/ui-presets/playback.js
@@ -31,6 +31,7 @@ import {withKeyboardEvent} from 'components/keyboard';
 import {VideoArea} from '../components/video-area';
 import {GuiArea} from '../components/gui-area';
 import {ClosedCaptions} from '../components/closed-captions';
+import {AudioEntryDetails} from '../components/audio-entry-details';
 
 const PRESET_NAME = 'Playback';
 
@@ -70,6 +71,7 @@ class PlaybackUI extends Component {
             <VideoArea />
             <GuiArea>
               <Fragment>
+                <AudioEntryDetails />
                 <UnmuteIndication />
                 <Loading />
                 <OverlayPortal />

--- a/translations/de.i18n.json
+++ b/translations/de.i18n.json
@@ -22,7 +22,9 @@
       "pictureInPictureExit": "Bild in Bild verlassen",
       "pictureInPictureExpand": "Erweitern",
       "logo": "Logo",
-      "seekBarSlider": "Suchleiste"
+      "seekBarSlider": "Suchleiste",
+      "readLess": "Weniger",
+      "readMore": "Mehr"
     },
     "unmute": {
       "unmute": "Ton an"
@@ -47,7 +49,6 @@
     },
     "error": {
       "default_error": "Etwas ist schiefgegangen"
-    
     },
     "ads": {
       "ad_notice": "Anzeige",

--- a/translations/en.i18n.json
+++ b/translations/en.i18n.json
@@ -23,8 +23,8 @@
       "pictureInPictureExpand": "Expand",
       "logo": "Logo",
       "seekBarSlider": "Seek slider",
-      "readMore": "More",
-      "readLess": "Less"
+      "readLess": "Less",
+      "readMore": "More"
     },
     "unmute": {
       "unmute": "Unmute"

--- a/translations/en.i18n.json
+++ b/translations/en.i18n.json
@@ -22,7 +22,9 @@
       "pictureInPictureExit": "Exit picture in picture",
       "pictureInPictureExpand": "Expand",
       "logo": "Logo",
-      "seekBarSlider": "Seek slider"
+      "seekBarSlider": "Seek slider",
+      "readMore": "More",
+      "readLess": "Less"
     },
     "unmute": {
       "unmute": "Unmute"

--- a/translations/es.i18n.json
+++ b/translations/es.i18n.json
@@ -22,7 +22,9 @@
       "pictureInPictureExit": "Salir de imagen en imagen",
       "pictureInPictureExpand": "Expandir",
       "logo": "Logotipo",
-      "seekBarSlider": "Buscar control deslizante"
+      "seekBarSlider": "Buscar control deslizante",
+      "read_less": "Menos",
+      "read_more": "Más"
     },
     "unmute": {
       "unmute": "Dejar de silenciar"

--- a/translations/es.i18n.json
+++ b/translations/es.i18n.json
@@ -23,8 +23,8 @@
       "pictureInPictureExpand": "Expandir",
       "logo": "Logotipo",
       "seekBarSlider": "Buscar control deslizante",
-      "read_less": "Menos",
-      "read_more": "Más"
+      "readLess": "Menos",
+      "readMore": "Más"
     },
     "unmute": {
       "unmute": "Dejar de silenciar"

--- a/translations/fi.i18n.json
+++ b/translations/fi.i18n.json
@@ -22,7 +22,9 @@
       "pictureInPictureExit": "Poistu kuva-kuvassa-toiminnosta",
       "pictureInPictureExpand": "Laajenna",
       "logo": "Logo",
-      "seekBarSlider": "Hae liukusäädin"
+      "seekBarSlider": "Hae liukusäädin",
+      "readLess": "Vähemmän",
+      "readMore": "Lisää"
     },
     "unmute": {
       "unmute": "Poista mykistys"

--- a/translations/fr.i18n.json
+++ b/translations/fr.i18n.json
@@ -22,7 +22,9 @@
       "pictureInPictureExit": "Quitter le mode Image-dans-Image",
       "pictureInPictureExpand": "Agrandir",
       "logo": "Logo",
-      "seekBarSlider": "Diapositive"
+      "seekBarSlider": "Diapositive",
+      "readLess": "Moins",
+      "readMore": "Plus"
     },
     "unmute": {
       "unmute": "Son"

--- a/translations/fr_ca.i18n.json
+++ b/translations/fr_ca.i18n.json
@@ -22,7 +22,9 @@
       "pictureInPictureExit": "Quitter fenêtre dans fenêtre",
       "pictureInPictureExpand": "RETOUR (au mode normal)",
       "logo": "Logo",
-      "seekBarSlider": "Curseur"
+      "seekBarSlider": "Curseur",
+      "readLess": "Moins",
+      "readMore": "Plus"
     },
     "unmute": {
       "unmute": "Réactiver"

--- a/translations/it.i18n.json
+++ b/translations/it.i18n.json
@@ -22,7 +22,9 @@
       "pictureInPictureExit": "Esci dalla modalità Picture in Picture",
       "pictureInPictureExpand": "Ingrandisci",
       "logo": "Logo",
-      "seekBarSlider": "Cursore di ricerca"
+      "seekBarSlider": "Cursore di ricerca",
+      "readLess": "Meno",
+      "readMore": "Altro"
     },
     "unmute": {
       "unmute": "Annulla silenziamento"

--- a/translations/ja.i18n.json
+++ b/translations/ja.i18n.json
@@ -22,7 +22,9 @@
       "pictureInPictureExit": "ピクチャーインピクチャーを終了する",
       "pictureInPictureExpand": "拡大",
       "logo": "ロゴ",
-      "seekBarSlider": "シーク スライダー"
+      "seekBarSlider": "シーク スライダー",
+      "readLess": "折りたたみ表示",
+      "readMore": "詳細"
     },
     "unmute": {
       "unmute": "ミュート解除"

--- a/translations/ko.i18n.json
+++ b/translations/ko.i18n.json
@@ -22,7 +22,9 @@
       "pictureInPictureExit": "화면 속 화면 끝내기",
       "pictureInPictureExpand": "확장",
       "logo": "로고",
-      "seekBarSlider": "슬라이더"
+      "seekBarSlider": "슬라이더",
+      "readLess": "간단히 보기",
+      "readMore": "자세히 보기"
     },
     "unmute": {
       "unmute": "음소거 해제"

--- a/translations/nl.i18n.json
+++ b/translations/nl.i18n.json
@@ -22,7 +22,9 @@
       "pictureInPictureExit": "Modus Afbeelding in afbeelding verlaten",
       "pictureInPictureExpand": "Uitbreiden",
       "logo": "Logo",
-      "seekBarSlider": "Zoekschuifregelaar"
+      "seekBarSlider": "Zoekschuifregelaar",
+      "readLess": "Minder",
+      "readMore": "Meer"
     },
     "unmute": {
       "unmute": "Dempen ongedaan maken"

--- a/translations/pt_br.i18n.json
+++ b/translations/pt_br.i18n.json
@@ -22,7 +22,9 @@
       "pictureInPictureExit": "Sair do Picture in picture",
       "pictureInPictureExpand": "Expandir",
       "logo": "Logo",
-      "seekBarSlider": "Controle deslizante"
+      "seekBarSlider": "Controle deslizante",
+      "readLess": "Menos",
+      "readMore": "Mais"
     },
     "unmute": {
       "unmute": "Cancelar silenciamento"

--- a/translations/ru.i18n.json
+++ b/translations/ru.i18n.json
@@ -22,7 +22,9 @@
       "pictureInPictureExit": "Выйти из режима «картинка в картинке»",
       "pictureInPictureExpand": "Развернуть",
       "logo": "Логотип",
-      "seekBarSlider": "Слайдер навигации"
+      "seekBarSlider": "Слайдер навигации",
+      "readLess": "Меньше",
+      "readMore": "Дополнительно"
     },
     "unmute": {
       "unmute": "Включить звук"

--- a/translations/zh_cn.i18n.json
+++ b/translations/zh_cn.i18n.json
@@ -22,7 +22,9 @@
       "pictureInPictureExit": "退出画中画",
       "pictureInPictureExpand": "扩展",
       "logo": "标识",
-      "seekBarSlider": "搜寻滑块"
+      "seekBarSlider": "搜寻滑块",
+      "readLess": "收起",
+      "readMore": "展开"
     },
     "unmute": {
       "unmute": "取消静音"

--- a/translations/zh_tw.i18n.json
+++ b/translations/zh_tw.i18n.json
@@ -22,7 +22,9 @@
       "pictureInPictureExit": "退出畫中畫",
       "pictureInPictureExpand": "擴展",
       "logo": "圖標",
-      "seekBarSlider": "進行輪播"
+      "seekBarSlider": "進行輪播",
+      "readLess": "更少",
+      "readMore": "更多"
     },
     "unmute": {
       "unmute": "終止靜音"

--- a/yarn.lock
+++ b/yarn.lock
@@ -941,49 +941,57 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.2.tgz#26520bf09abe4a5644cd5414e37125a8954241dd"
   integrity sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==
 
-"@playkit-js/kaltura-player-js@canary":
-  version "3.14.3-canary.0-4128316"
-  resolved "https://registry.yarnpkg.com/@playkit-js/kaltura-player-js/-/kaltura-player-js-3.14.3-canary.0-4128316.tgz#0b0d07e9f06e92391afd84d5ac7219d476278299"
-  integrity sha512-QV4v6cOKsc+qUEIdTV4zJGHGRgkL9kr9YIhNJgWLCZvhEq5pw09kZ6gktp+QV7dEQ3YfknatTJOsMeVW3tmVpQ==
+"@playkit-js/kaltura-player-js@3.15.3-canary.0-51ca9be":
+  version "3.15.3-canary.0-51ca9be"
+  resolved "https://registry.yarnpkg.com/@playkit-js/kaltura-player-js/-/kaltura-player-js-3.15.3-canary.0-51ca9be.tgz#fbd4e1eb6733b1d5acfbd853c454c5563e23dce3"
+  integrity sha512-96SdLVoZuTSpEF08UJjsiMRNGnbyoe+xuZERTXqrWKr/xvH+Vq0GsW/CQPFRw2ZkuH+wCzrvWTBohVdhavvPbQ==
   dependencies:
     "@babel/polyfill" "^7.0.0"
-    "@playkit-js/playkit-js" "^0.82.3-canary.0-f0d3180"
-    "@playkit-js/playkit-js-dash" "^1.34.1-canary.0-9422826"
-    "@playkit-js/playkit-js-hls" "^1.32.3-canary.0-5a35881"
-    "@playkit-js/playkit-js-providers" "^2.39.3-canary.0-e04b57d"
-    "@playkit-js/playkit-js-ui" "^0.77.2-canary.0-ee0e6eb"
+    "@playkit-js/playkit-js" "0.82.7-canary.0-76e938d"
+    "@playkit-js/playkit-js-dash" "1.35.0-canary.0-799d1b8"
+    "@playkit-js/playkit-js-hls" "1.32.8-canary.0-671f986"
+    "@playkit-js/playkit-js-providers" "2.39.5-canary.0-9ee39ec"
+    "@playkit-js/playkit-js-ui" "0.77.7-canary.0-cc6f5a9"
     "@types/preact-i18n" "^2.3.1"
-    hls.js "1.3.5"
+    hls.js "1.4.11"
     intersection-observer "^0.12.0"
     proxy-polyfill "^0.3.0"
-    shaka-player "4.3.5"
+    shaka-player "4.3.7"
 
-"@playkit-js/playkit-js-dash@^1.34.1-canary.0-9422826":
-  version "1.34.1"
-  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js-dash/-/playkit-js-dash-1.34.1.tgz#c57bab1c6c15336834601cc36fde5e5a93e7ec7b"
-  integrity sha512-oxRBuWJE4pTvYoH4qleMD3yDUXi2bt/D+9bUhrmsMPtYIfCUccYvNHKL3+YJwy9FjLBvHXmpYK91VDDRQrYf1Q==
+"@playkit-js/playkit-js-dash@1.35.0-canary.0-799d1b8":
+  version "1.35.0-canary.0-799d1b8"
+  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js-dash/-/playkit-js-dash-1.35.0-canary.0-799d1b8.tgz#d88106596cf84ae4a448dcf352b7124d3381524b"
+  integrity sha512-6CMiyPoI57Tkybs8qkCDFwaPqzRezD7tZC69WWztIjhpiSZEjqMFHp6C0/Ez3LG/MMuR8gxWW37606ioiLtHMw==
 
-"@playkit-js/playkit-js-hls@^1.32.3-canary.0-5a35881":
-  version "1.32.3"
-  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js-hls/-/playkit-js-hls-1.32.3.tgz#285667bfbe6117e060502ab1d69b0f03d28e45f1"
-  integrity sha512-wwqCZQ1B3IGISYi0Lp91eGayvo3eMwoVcFssMKwdh19JBUS2r/nRkd+NQl1ozqqUGQRwD9hwdPnOiKkwzressw==
+"@playkit-js/playkit-js-hls@1.32.8-canary.0-671f986":
+  version "1.32.8-canary.0-671f986"
+  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js-hls/-/playkit-js-hls-1.32.8-canary.0-671f986.tgz#49c89593128c8b6aa6a1cecd694377b5c9a611db"
+  integrity sha512-dUzOSsXorNxaeeujPEqeJToaFonr57JtgUoQWurI9T5ukaxjw/L4OsjpF75oF/tiNdamopfQnVlqjlTgMg8Fgg==
 
-"@playkit-js/playkit-js-providers@^2.39.3-canary.0-e04b57d":
-  version "2.39.3-canary.0-e04b57d"
-  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js-providers/-/playkit-js-providers-2.39.3-canary.0-e04b57d.tgz#055ba43c3f2f3b4c2fa0c72e8263ae8262226db3"
-  integrity sha512-d6EOT3YUyTP7V1u2roQNoPTY+kToHEkW8jo5+9cfOPLi0Cl7TtJ/loZls9KL4iVse4wIJK1WicpLf2xorYwLUw==
+"@playkit-js/playkit-js-providers@2.39.5-canary.0-9ee39ec":
+  version "2.39.5-canary.0-9ee39ec"
+  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js-providers/-/playkit-js-providers-2.39.5-canary.0-9ee39ec.tgz#58f7f0f0e72eb7b98f3bb9f2af53ea78e0a57771"
+  integrity sha512-CvMgRnQEiAoL64SGY5lKNwxoox8nQjS6Nt/vvEgK/kaksSXYDvccktH+rOFK32+WgCaE4Q2YEkXKjdJIU6eBEw==
 
-"@playkit-js/playkit-js-ui@^0.77.2-canary.0-ee0e6eb":
-  version "0.77.2-canary.0-ee0e6eb"
-  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js-ui/-/playkit-js-ui-0.77.2-canary.0-ee0e6eb.tgz#e39ca4c16b8588e58d72b919092dff9f01900ef5"
-  integrity sha512-5uA7W1mhi7YGoZY7NhDr9WgXNxVmQOz0BON8WJIbBKGBtDQAERxefIUFQIK7jvBsH8Y4G0F0wcGbzovPOGLAbw==
+"@playkit-js/playkit-js-ui@0.77.7-canary.0-cc6f5a9":
+  version "0.77.7-canary.0-cc6f5a9"
+  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js-ui/-/playkit-js-ui-0.77.7-canary.0-cc6f5a9.tgz#ec015705188591845b24bdc45c3429fc092e6b13"
+  integrity sha512-ZOgAN8stZ2NxovBh2SY+Ww1K0LFlzKxre1Q0WShUK9RVVsXAcSUFIMpyhMdFMY4sA0UbETOvCbBrEXxad31tTQ==
   dependencies:
     preact "^10.3.4"
     preact-i18n "^2.0.0-preactx.2"
     react-redux "^7.2.0"
     redux "^4.0.5"
 
-"@playkit-js/playkit-js@^0.82.3-canary.0-f0d3180", "@playkit-js/playkit-js@canary":
+"@playkit-js/playkit-js@0.82.7-canary.0-76e938d":
+  version "0.82.7-canary.0-76e938d"
+  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js/-/playkit-js-0.82.7-canary.0-76e938d.tgz#682d5f579476e207bfb8cb1c241d52138d3cf318"
+  integrity sha512-CerNLq98qhSqjFlNfVwRZSrwdTUsL3JbiqaXmg7N4umCCKkcviQuSf+M+rBMhEg98pNDeORfeUkL+2cm9Ohk+g==
+  dependencies:
+    js-logger "^1.6.0"
+    ua-parser-js "1.0.2"
+
+"@playkit-js/playkit-js@canary":
   version "0.82.3-canary.0-f0d3180"
   resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js/-/playkit-js-0.82.3-canary.0-f0d3180.tgz#bd976cf382a38797a6c025d6bf654a62b1a8c086"
   integrity sha512-3co6fH/2F3uOkxC1+3Of40fubl7qwzPa5zGwa8QSczwwNFnoovHVXi1MnNsTSvKmt7FJxFS+Lw+SzVknhSZhZA==
@@ -4558,10 +4566,10 @@ he@1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-hls.js@1.3.5:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/hls.js/-/hls.js-1.3.5.tgz#0e8b0799ecf2feb7ba199f5e95f35ba9552e04f4"
-  integrity sha512-uybAvKS6uDe0MnWNEPnO0krWVr+8m2R0hJ/viql8H3MVK+itq8gGQuIYoFHL3rECkIpNH98Lw8YuuWMKZxp3Ew==
+hls.js@1.4.11:
+  version "1.4.11"
+  resolved "https://registry.yarnpkg.com/hls.js/-/hls.js-1.4.11.tgz#6ca2d7ab56f2725f27bb5f2e3c7982c6ec287118"
+  integrity sha512-rhPSUMACcIBbcUnwWnIcRgGXqJJt0xBRxvhzl99XpGHtnnLKjbczmmBmUuQueAQcbL3SdN7D5peAObR18VrhvQ==
 
 hmac-drbg@^1.0.0:
   version "1.0.1"
@@ -7996,10 +8004,10 @@ sha.js@^2.4.0, sha.js@^2.4.8:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-shaka-player@4.3.5:
-  version "4.3.5"
-  resolved "https://registry.yarnpkg.com/shaka-player/-/shaka-player-4.3.5.tgz#304d60ad867fb7a0780b850b32a9614296b842db"
-  integrity sha512-WkqvHm8QHOsQ71d/qoc2Wa6Z5rBrG3Zgsc6ho9I9e8Xwa0io+MeREgqBuG0z6qoXK55sTImipFhDoERrkmDdUg==
+shaka-player@4.3.7:
+  version "4.3.7"
+  resolved "https://registry.yarnpkg.com/shaka-player/-/shaka-player-4.3.7.tgz#beebf492afa4cd3036eb10d6d9d2b610c17f6e6e"
+  integrity sha512-3aeRb/AdVnGJKI1i23pD+b2e4eXljjJflxW+RLeWrSGHNRt/givvV3DyGIzpNQ9icUDatUyOtSkx8AdTXZWYXQ==
   dependencies:
     eme-encryption-scheme-polyfill "^2.1.1"
 


### PR DESCRIPTION
### Description of the Changes

Add ExpandableText component
Add AudioEntryDetails component

Related PRs:
https://github.com/kaltura/kaltura-player-js/pull/646
https://github.com/kaltura/playkit-js-navigation/pull/334

Resolves FEC-13209

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
