### PR TITLE
ADA-25:[V7-Acc] remove the redundant word "Slider" from the aria-labe…

### DIFF
--- a/translations/en.i18n.json
+++ b/translations/en.i18n.json
@@ -22,7 +22,7 @@
       "pictureInPictureExit": "Exit picture in picture",
       "pictureInPictureExpand": "Expand",
       "logo": "Logo",
-      "seekBarSlider": "Seek slider"
+      "seekBarSlider": "Seek bar"
     },
     "unmute": {
       "unmute": "Unmute"


### PR DESCRIPTION
issue:
the work "slider" appears in role and in aria label for the seek bar

solution:
in aria label change "seek slider" to "seek bar"