### PR TITLE
fix(ADA-31): [V7-Acc] advanced captions modal heading marking correction

### DIFF
--- a/src/components/cvaa-overlay/cvaa-overlay.js
+++ b/src/components/cvaa-overlay/cvaa-overlay.js
@@ -11,6 +11,7 @@ import {withEventDispatcher} from 'components/event-dispatcher';
 import {withLogger} from 'components/logger';
 import {MainCaptionsWindow} from 'components/cvaa-overlay/main-captions_window';
 import {CustomCaptionsWindow} from 'components/cvaa-overlay/custom-captions-window';
+import {withText} from 'preact-i18n';
 
 /**
  * mapping state to props
@@ -41,6 +42,7 @@ const COMPONENT_NAME = 'CVAAOverlay';
 @withLogger(COMPONENT_NAME)
 @withEventDispatcher(COMPONENT_NAME)
 @withKeyboardA11y
+@withText({cvvaDialogText: 'cvaa.title'})
 class CVAAOverlay extends Component {
   /**
    * componentWillUnmount
@@ -132,7 +134,13 @@ class CVAAOverlay extends Component {
   render(props: any): React$Element<any> {
     props.clearAccessibleChildren();
     return (
-      <Overlay open handleKeyDown={this.props.handleKeyDown} addAccessibleChild={this.props.addAccessibleChild} onClose={props.onClose} type="cvaa">
+      <Overlay
+        open
+        handleKeyDown={this.props.handleKeyDown}
+        addAccessibleChild={this.props.addAccessibleChild}
+        onClose={props.onClose}
+        type="cvaa"
+        label={props.cvvaDialogText}>
         {this.state.activeWindow === cvaaOverlayState.Main ? (
           <MainCaptionsWindow
             cvaaOverlayState={cvaaOverlayState}

--- a/src/components/cvaa-overlay/main-captions_window.js
+++ b/src/components/cvaa-overlay/main-captions_window.js
@@ -76,7 +76,7 @@ class MainCaptionsWindow extends Component {
   render(props: any): React$Element<any> {
     return (
       <div className={[style.overlayScreen, style.active].join(' ')}>
-        <div className={style.title} id="modal-title">
+        <div className={style.title}>
           <Text id={'cvaa.title'} />
         </div>
         <div>

--- a/src/components/cvaa-overlay/main-captions_window.js
+++ b/src/components/cvaa-overlay/main-captions_window.js
@@ -76,7 +76,7 @@ class MainCaptionsWindow extends Component {
   render(props: any): React$Element<any> {
     return (
       <div className={[style.overlayScreen, style.active].join(' ')}>
-        <div className={style.title}>
+        <div className={style.title} id="modal-title">
           <Text id={'cvaa.title'} />
         </div>
         <div>

--- a/src/components/overlay/overlay.js
+++ b/src/components/overlay/overlay.js
@@ -139,7 +139,7 @@ class Overlay extends Component {
     }
 
     return (
-      <div tabIndex="-1" className={overlayClass.join(' ')} role="dialog" onKeyDown={this.onKeyDown}>
+      <div tabIndex="0" className={overlayClass.join(' ')} role="dialog" onKeyDown={this.onKeyDown} aria-labelledby="modal-title">
         <div className={style.overlayContents}>{props.children}</div>
         {this.renderCloseButton(props)}
       </div>

--- a/src/components/overlay/overlay.js
+++ b/src/components/overlay/overlay.js
@@ -126,22 +126,22 @@ class Overlay extends Component {
    * @returns {React$Element} - component
    * @memberof Overlay
    */
-  render(props: any): React$Element<any> {
+  render({type, open, label = 'dialog'}: any): React$Element<any> {
     const overlayClass = [style.overlay];
-    if (props.type) {
-      const classType = style[props.type + '-overlay'] ? style[props.type + '-overlay'] : props.type + '-overlay';
+    if (type) {
+      const classType = style[type + '-overlay'] ? style[type + '-overlay'] : type + '-overlay';
       overlayClass.push(classType);
     }
 
-    if (props.open) {
-      this.props.updateOverlay(props.open);
+    if (open) {
+      this.props.updateOverlay(open);
       overlayClass.push(style.active);
     }
 
     return (
-      <div tabIndex="0" className={overlayClass.join(' ')} role="dialog" onKeyDown={this.onKeyDown} aria-labelledby="modal-title">
-        <div className={style.overlayContents}>{props.children}</div>
-        {this.renderCloseButton(props)}
+      <div tabIndex="-1" className={overlayClass.join(' ')} role="dialog" onKeyDown={this.onKeyDown} aria-label={label}>
+        <div className={style.overlayContents}>{this.props.children}</div>
+        {this.renderCloseButton(this.props)}
       </div>
     );
   }

--- a/src/components/smart-container/smart-container.js
+++ b/src/components/smart-container/smart-container.js
@@ -95,7 +95,9 @@ class SmartContainer extends Component {
     return this.isPortal ? (
       createPortal(
         <Overlay open onClose={props.onClose} handleKeyDown={this.props.handleKeyDown} addAccessibleChild={this.props.addAccessibleChild}>
-          <div className={style.title}>{props.title}</div>
+          <div className={style.title} id="modal-title">
+            {props.title}
+          </div>
           {this.renderChildren(props)}
         </Overlay>,
         targetId.querySelector(portalSelector)

--- a/src/components/smart-container/smart-container.js
+++ b/src/components/smart-container/smart-container.js
@@ -7,6 +7,7 @@ import {actions} from '../../reducers/shell';
 import {createPortal} from 'preact/compat';
 import {Overlay} from '../overlay';
 import {withKeyboardA11y} from '../../utils/popup-keyboard-accessibility';
+import {withText} from 'preact-i18n';
 
 /**
  * mapping state to props
@@ -37,6 +38,7 @@ const COMPONENT_NAME = 'SmartContainer';
  */
 @connect(mapStateToProps, bindActions(actions))
 @withKeyboardA11y
+@withText({settingsText: 'settings.title'})
 class SmartContainer extends Component {
   // ie11 fix (FEC-7312) - don't remove
   _portal: any;
@@ -94,10 +96,13 @@ class SmartContainer extends Component {
     props.clearAccessibleChildren();
     return this.isPortal ? (
       createPortal(
-        <Overlay open onClose={props.onClose} handleKeyDown={this.props.handleKeyDown} addAccessibleChild={this.props.addAccessibleChild}>
-          <div className={style.title} id="modal-title">
-            {props.title}
-          </div>
+        <Overlay
+          open
+          onClose={props.onClose}
+          handleKeyDown={this.props.handleKeyDown}
+          addAccessibleChild={this.props.addAccessibleChild}
+          label={props.settingsText}>
+          <div className={style.title}>{props.title}</div>
           {this.renderChildren(props)}
         </Overlay>,
         targetId.querySelector(portalSelector)


### PR DESCRIPTION
### Description of the Changes

**issue:**
in advanced captions modal, when open the modal, screen reader reads only : "dialog".

**solution:**
adding aria-labeledby according to the title of the modal so screen reader announce: "Advanced captions settings dialog" 

solves [ADA-31](https://kaltura.atlassian.net/browse/ADA-31)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[ADA-31]: https://kaltura.atlassian.net/browse/ADA-31?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ