### PR TITLE
fix(ADA-32): [V7-Acc] Add menu on top of menuitems for the advanced captions menu

### DIFF
--- a/src/components/cvaa-overlay/custom-captions-window.js
+++ b/src/components/cvaa-overlay/custom-captions-window.js
@@ -36,6 +36,16 @@ class CustomCaptionsWindow extends Component {
   };
 
   /**
+   * transition to state handler
+   *
+   * @returns {void}
+   * @memberof MainWindow
+   */
+  transitionToState = (): void => {
+    this.props.transitionToState(this.props.cvaaOverlayState.Main);
+  };
+
+  /**
    * on key down handler
    *
    * @param {KeyboardEvent} e - keyboard event
@@ -157,7 +167,10 @@ class CustomCaptionsWindow extends Component {
               ref={el => {
                 props.addAccessibleChild(el);
               }}
-              onClick={this.changeCaptionsStyle}
+              onClick={() => {
+                this.changeCaptionsStyle();
+                this.transitionToState();
+              }}
               onKeyDown={this.onKeyDown}
               className={[style.btn, style.btnBranded, style.btnBlock].join(' ')}>
               <Text id={'cvaa.apply'} />

--- a/src/components/cvaa-overlay/cvaa-overlay.js
+++ b/src/components/cvaa-overlay/cvaa-overlay.js
@@ -91,7 +91,6 @@ class CVAAOverlay extends Component {
   changeCaptionsStyle = (textStyle: Object): void => {
     this.props.updateCaptionsStyle(textStyle);
     this.props.player.textStyle = textStyle;
-    this.props.onClose();
     this.props.notifyClick({
       textStyle: textStyle
     });
@@ -152,6 +151,8 @@ class CVAAOverlay extends Component {
             changeCustomStyle={this.changeCustomStyle}
             getPreviewStyle={this.getPreviewStyle}
             customTextStyle={this.state.customTextStyle}
+            transitionToState={this.transitionToState}
+            cvaaOverlayState={cvaaOverlayState}
           />
         )}
       </Overlay>

--- a/src/components/cvaa-overlay/main-captions_window.js
+++ b/src/components/cvaa-overlay/main-captions_window.js
@@ -79,7 +79,7 @@ class MainCaptionsWindow extends Component {
         <div className={style.title}>
           <Text id={'cvaa.title'} />
         </div>
-        <div>
+        <div role="group">
           <SampleCaptionsStyleButton
             addAccessibleChild={props.addAccessibleChild}
             classNames={[style.sample]}


### PR DESCRIPTION
### Description of the Changes

- Adding role="group" to to div that wraps the samples buttons (and not "menu" since it not working on NVDA).
- Keep the "Advanced captions settings" modal opened also after choosing sample/custom caption. 

solves [ADA-32](https://kaltura.atlassian.net/browse/ADA-32)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[ADA-32]: https://kaltura.atlassian.net/browse/ADA-32?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ