### PR TITLE
fix(ADA-43): [V7-Acc] Add "aria-haspopup" attribute to the settings menu button.

### DIFF
--- a/src/components/settings/settings.js
+++ b/src/components/settings/settings.js
@@ -153,6 +153,7 @@ class Settings extends Component {
           <Button
             tabIndex="0"
             aria-label={props.buttonLabel}
+            aria-haspopup="true"
             className={[
               style.controlButton,
               style.buttonBadge,


### PR DESCRIPTION
### Description of the Changes

**issue:**
The settings button doesn't communicate to the user that it opens a popup.

**solution:**
Adding aria-haspopup="true" to settings button.

solves [ADA-43](https://kaltura.atlassian.net/browse/ADA-43)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
