### PR TITLE
fix(SUP-38805): Hero unit causes the page to jump to the top

### DIFF
--- a/src/components/play-pause/play-pause.js
+++ b/src/components/play-pause/play-pause.js
@@ -59,7 +59,7 @@ class PlayPause extends Component {
     const {eventManager, player} = this.props;
     // $FlowFixMe.
     const playerContainer: HTMLDivElement = document.getElementById(player.config.ui.targetId);
-    eventManager.listen(player, player.Event.Core.PLAY, () => {
+    eventManager.listen(player, player.Event.UI.USER_CLICKED_PLAY, () => {
       playerContainer.focus();
     });
     eventManager.listen(document, 'keydown', event => {


### PR DESCRIPTION
**issue:**
focus is moved to the player always when starting play even if the click was not from the user and we was focused on different element.

**solution:**
change the listener from "play to "user click play"

solves [SUP-38805](https://kaltura.atlassian.net/browse/SUP-38805)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[SUP-38805]: https://kaltura.atlassian.net/browse/SUP-38805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ