### PR TITLE
fix(ADA-14):Unable to adjust volume in video player using VoiceOver

### DIFF
--- a/src/components/volume/volume.js
+++ b/src/components/volume/volume.js
@@ -473,6 +473,7 @@ class Volume extends Component {
         </Tooltip>
         <div
           tabIndex="0"
+          aria-orientation="vertical"
           aria-label={this.props.sliderAriaLabel}
           onKeyDown={this.onProgressBarKeyDown}
           className={style.volumeControlBar}


### PR DESCRIPTION
issue:
when use voiceOver quick navigation can't adjust volume

solution:
add aria-orientation="vertical" to the volume slider
