### PR TITLE
fix(FEC-13373): Player v7| audio player entry info| Entry title seem truncated

### DIFF
--- a/src/components/audio-entry-details/_audio-entry-details.scss
+++ b/src/components/audio-entry-details/_audio-entry-details.scss
@@ -35,6 +35,7 @@
             
             .audio-entry-title {
                 font-size: 32px; 
+                line-height: 38px;
                 
                 &.audio-entry-title-trimmed {
                     -webkit-box-orient: vertical;
@@ -46,7 +47,8 @@
             }
             
             .audio-entry-description { 
-                font-size: 14px; 
+                font-size: 14px;
+                line-height: 18px;
             }
         }
 


### PR DESCRIPTION
### Description of the Changes

Add explicit line-height to audio entry title and description to prevent external css from overriding these values

Resolves FEC-13373, FEC-13374

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
