### PR TITLE
fix(FEC-13377): Player v7| audio player entry info| Entry info does not change when changing audio entries

### DIFF
--- a/src/components/audio-entry-details/audio-entry-details.js
+++ b/src/components/audio-entry-details/audio-entry-details.js
@@ -75,14 +75,16 @@ const AudioEntryDetails = connect(mapStateToProps)(
         if (!forceShowMore) {
           setForceShowMore(textRef?.current?.getBoundingClientRect().height > comparisonTextRef?.current?.getBoundingClientRect().height);
         }
+      });
 
-        props.eventManager.listenOnce(props.player, props.player.Event.CHANGE_SOURCE_STARTED, () => {
+      useLayoutEffect(() => {
+        props.eventManager.listen(props.player, props.player.Event.CHANGE_SOURCE_STARTED, () => {
           setIsReady(false);
         });
-        props.eventManager.listenOnce(props.player, props.player.Event.CHANGE_SOURCE_ENDED, () => {
+        props.eventManager.listen(props.player, props.player.Event.CHANGE_SOURCE_ENDED, () => {
           setIsReady(true);
         });
-      });
+      }, []);
 
       if (!isReady || !props.isAudio || !(props.player.sources?.metadata?.name || props.player.sources?.metadata.description)) {
         return undefined;


### PR DESCRIPTION
### Description of the Changes

Audio player details component does not re-render on entry change, probably due to its location in the component hierarchy. 
To force the component to re-render - added a listener to source change events.

Resolves FEC-13377

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
