### PR TITLE
fix(FEC-13393): Player v7| audio player| entry info seem broken in KMC share&embed page

### DIFF
--- a/src/components/audio-entry-details/_audio-entry-details.scss
+++ b/src/components/audio-entry-details/_audio-entry-details.scss
@@ -1,7 +1,8 @@
 .player { 
     .audio-entry-backdrop {
         background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.7) 100%);
-        bottom: 0; 
+        bottom: 0;
+        left: 0;
         position: absolute; 
         width: 100%;
         pointer-events: none;


### PR DESCRIPTION
### Description of the Changes

In KMC preview the position of the backdrop breaks. Added left position to resolve it. 

Resolves FEC-13393

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
