### PR TITLE
fix(FEC-13407): Slim Audio Player - Allow colors configuration

### DIFF
--- a/src/styles/dynamaic-variables.scss
+++ b/src/styles/dynamaic-variables.scss
@@ -62,4 +62,9 @@
   --playkit-tooltip-background-color: var(--playkit-tone-1-color);
   --playkit-tooltip-color: var(--playkit-tone-7-color);
   --playkit-ads-color: var(--playkit-secondary-color);
+
+  --playkit-background-color: #111111;
+  --playkit-elevated-color: #333333;
+  --playkit-paper-color: #222222;
+  --playkit-protection-color: #222222;
 }

--- a/src/ui-manager.js
+++ b/src/ui-manager.js
@@ -256,6 +256,25 @@ class UIManager {
   get Event(): {[event: string]: string} {
     return EventType;
   }
+
+  /**
+   * Return a css variable value
+   * @param {string} variableName - CSS variable name
+   * @returns {string} CSS variable value
+   */
+  getCSSVariable(variableName: string): string {
+    return this._themesManager.getCSSVariable(variableName);
+  }
+
+  /**
+   * Return a css variable name
+   * @param {string} variableName - CSS variable name
+   * @param {string} value - CSS variable value
+   * @returns {void}
+   */
+  setCSSVariable(variableName: string, value: string) {
+    this._themesManager.setCSSVariable(variableName, value);
+  }
 }
 
 export {UIManager};

--- a/src/utils/themes-manager.js
+++ b/src/utils/themes-manager.js
@@ -12,7 +12,9 @@ const HSL_LIGHTNESS_CSS_VAR = `--${PREFIX}-{name}-hsl-lightness`;
 const cssVarNames = {
   colors: {
     live: '--playkit-live-color',
-    playerBackground: '--playkit-player-background-color'
+    playerBackground: '--playkit-player-background-color',
+    paper: '--playkit-paper-color',
+    tone1: '--playkit-tone-1-color'
   }
 };
 
@@ -108,16 +110,10 @@ export class ThemesManager {
    */
   setAccentOrAcknowledgementColor(colorTitle: string, color: string): void {
     const [hue, saturation, lightness] = hexToHsl(color);
-    this.playerContainerElement?.querySelector(`.${style.player}`)?.style.setProperty(ACTUAL_USED_CSS_VAR.replace('{name}', colorTitle), color);
-    this.playerContainerElement
-      ?.querySelector(`.${style.player}`)
-      ?.style.setProperty(HSL_HUE_CSS_VAR.replace('{name}', colorTitle), `${Math.round(hue)}deg`);
-    this.playerContainerElement
-      ?.querySelector(`.${style.player}`)
-      ?.style.setProperty(HSL_SATURATION_CSS_VAR.replace('{name}', colorTitle), `${Math.round(saturation)}%`);
-    this.playerContainerElement
-      ?.querySelector(`.${style.player}`)
-      ?.style.setProperty(HSL_LIGHTNESS_CSS_VAR.replace('{name}', colorTitle), `${Math.round(lightness)}%`);
+    this.setCSSVariable(ACTUAL_USED_CSS_VAR.replace('{name}', colorTitle), color);
+    this.setCSSVariable(HSL_HUE_CSS_VAR.replace('{name}', colorTitle), `${Math.round(hue)}deg`);
+    this.setCSSVariable(HSL_SATURATION_CSS_VAR.replace('{name}', colorTitle), `${Math.round(saturation)}%`);
+    this.setCSSVariable(HSL_LIGHTNESS_CSS_VAR.replace('{name}', colorTitle), `${Math.round(lightness)}%`);
   }
 
   /**
@@ -127,29 +123,7 @@ export class ThemesManager {
    * @returns {void}
    */
   setColor(cssVarName: string, color: string): void {
-    this.playerContainerElement?.querySelector(`.${style.player}`)?.style.setProperty(cssVarName, color);
-
-    if (color.startsWith('#') && (color.length === 4 || color.length === 7)) {
-      const colorRGBValues = this._getColorAsRGB(color);
-      if (colorRGBValues) {
-        this.playerContainerElement?.querySelector(`.${style.player}`)?.style.setProperty(`${cssVarName}-rgb`, colorRGBValues.join(','));
-      }
-    }
-  }
-
-  /**
-   * Return a hex color as an array of Red, Green and Blue values
-   * @param {string} color  - 3 or 6 digit hex color value
-   * @returns {number[]} array of RGB numeric values
-   */
-  _getColorAsRGB(color: string) {
-    let fullHexColor = color;
-    if (color.length === 4) {
-      fullHexColor = `#${color[1]}${color[1]}${color[2]}${color[2]}${color[3]}${color[3]}`;
-    }
-
-    const colorArr = fullHexColor.match(/^#?([\da-f]{2})([\da-f]{2})([\da-f]{2})$/i);
-    return colorArr ? [parseInt(colorArr[1], 16), parseInt(colorArr[2], 16), parseInt(colorArr[3], 16)] : null;
+    this.setCSSVariable(cssVarName, color);
   }
 
   /**
@@ -160,11 +134,33 @@ export class ThemesManager {
   setSvgFillColor(color: string): void {
     for (const varName of dynamicColoredIconsSvgUrlVars) {
       // $FlowFixMe
-      const svgUrl = getComputedStyle(this.playerContainerElement?.querySelector(`.${style.player}`)).getPropertyValue(varName);
+      const svgUrl = this.getCSSVariable(varName);
       const newColor = color.replace('#', '%23');
-      this.playerContainerElement
-        ?.querySelector(`.${style.player}`)
-        ?.style.setProperty(varName, svgUrl.replace(/fill='%23([a-f0-9]{3}){1,2}\b'/, `fill='${newColor}'`));
+      this.setCSSVariable(varName, svgUrl.replace(/fill='%23([a-f0-9]{3}){1,2}\b'/, `fill='${newColor}'`));
     }
+  }
+
+  /**
+   * Return a css variable value
+   * @param {string} variableName - CSS variable name
+   * @returns {string} CSS variable value
+   */
+  getCSSVariable(variableName: string) {
+    // $FlowFixMe
+    return getComputedStyle(this.playerContainerElement?.querySelector(`.${style.player}`)).getPropertyValue(variableName) || '';
+  }
+
+  /**
+   * Return a css variable name
+   * @param {string} variableName - CSS variable name
+   * @param {string} value - CSS variable value
+   * @returns {void}
+   */
+  setCSSVariable(variableName: string, value: string) {
+    const playkitPlayerElement = this.playerContainerElement?.querySelector(`.${style.player}`);
+    // $FlowFixMe
+    const playkitPlayerElementStyle = playkitPlayerElement.style;
+
+    playkitPlayerElementStyle.setProperty(variableName, value);
   }
 }

--- a/src/utils/themes-manager.js
+++ b/src/utils/themes-manager.js
@@ -128,6 +128,28 @@ export class ThemesManager {
    */
   setColor(cssVarName: string, color: string): void {
     this.playerContainerElement?.querySelector(`.${style.player}`)?.style.setProperty(cssVarName, color);
+
+    if (color.startsWith('#') && (color.length === 4 || color.length === 7)) {
+      const colorRGBValues = this._getColorAsRGB(color);
+      if (colorRGBValues) {
+        this.playerContainerElement?.querySelector(`.${style.player}`)?.style.setProperty(`${cssVarName}-rgb`, colorRGBValues.join(','));
+      }
+    }
+  }
+
+  /**
+   * Return a hex color as an array of Red, Green and Blue values
+   * @param {string} color  - 3 or 6 digit hex color value
+   * @returns {number[]} array of RGB numeric values
+   */
+  _getColorAsRGB(color: string) {
+    let fullHexColor = color;
+    if (color.length === 4) {
+      fullHexColor = `#${color[1]}${color[1]}${color[2]}${color[2]}${color[3]}${color[3]}`;
+    }
+
+    const colorArr = fullHexColor.match(/^#?([\da-f]{2})([\da-f]{2})([\da-f]{2})$/i);
+    return colorArr ? [parseInt(colorArr[1], 16), parseInt(colorArr[2], 16), parseInt(colorArr[3], 16)] : null;
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

Changes to support audio player colors customization: 
- Add and expose API for working with player CSS variables
- Add new player colors
- Allow configuration of tone 1 and paper colors

Related PR: https://github.com/kaltura/playkit-js-audio-player/pull/10

Resolves FEC-13407

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
