### PR TITLE
fix(ADA-42): i18n Add "Volume Control" Aria Label to the volume slider

### DIFF
--- a/translations/de.i18n.json
+++ b/translations/de.i18n.json
@@ -103,7 +103,8 @@
       "seventy_percent": "siebzig Prozent",
       "eighty_percent": "achtzig Prozent",
       "ninety_percent": "neunzig Prozent",
-      "one_hundred_percent": "hundert Prozent"
+      "one_hundred_percent": "hundert Prozent",
+      "volume_slider_aria_label": "Lautstärkeregler, verwenden Sie die Pfeile, um die Lautstärke zu regulieren"
     }
   }
 }

--- a/translations/es.i18n.json
+++ b/translations/es.i18n.json
@@ -103,7 +103,8 @@
       "seventy_percent": "setenta por ciento",
       "eighty_percent": "ochenta por ciento",
       "ninety_percent": "noventa por ciento",
-      "one_hundred_percent": "cien por cien"
+      "one_hundred_percent": "cien por cien",
+      "volume_slider_aria_label": "Control de volumen: usa las flechas para controlar el volumen\n"
     }
   }
 }

--- a/translations/fi.i18n.json
+++ b/translations/fi.i18n.json
@@ -103,7 +103,8 @@
       "seventy_percent": "seitsemänkymmentä prosenttia",
       "eighty_percent": "kahdeksankymmentä prosenttia",
       "ninety_percent": "yhdeksänkymmentä prosenttia",
-      "one_hundred_percent": "sata prosenttia"
+      "one_hundred_percent": "sata prosenttia",
+      "volume_slider_aria_label": "Äänenvoimakkuuden säätö; säädä nuolilla äänenvoimakkuutta"
     }
   }
 }

--- a/translations/fr.i18n.json
+++ b/translations/fr.i18n.json
@@ -103,7 +103,8 @@
       "seventy_percent": "soixante-dix pour cent",
       "eighty_percent": "quatre-vingt pour cent",
       "ninety_percent": "quatre-vingt-dix pour cent",
-      "one_hundred_percent": "cent pour cent"
+      "one_hundred_percent": "cent pour cent",
+      "volume_slider_aria_label": "Contrôle du volume, utiliser les flèches pour contrôler le volume"
     }
   }
 }

--- a/translations/fr_ca.i18n.json
+++ b/translations/fr_ca.i18n.json
@@ -103,7 +103,8 @@
       "seventy_percent": "soixante-dix pour cent",
       "eighty_percent": "quatre-vingt pour cent",
       "ninety_percent": "quatre-vingt-dix pour cent",
-      "one_hundred_percent": "cent pour cent"
+      "one_hundred_percent": "cent pour cent",
+      "volume_slider_aria_label": "Contrôle du volume, utiliser les flèches pour contrôler le volume"
     }
   }
 }

--- a/translations/it.i18n.json
+++ b/translations/it.i18n.json
@@ -103,7 +103,8 @@
       "seventy_percent": "70%",
       "eighty_percent": "80%",
       "ninety_percent": "90%",
-      "one_hundred_percent": "100%"
+      "one_hundred_percent": "100%",
+      "volume_slider_aria_label": "Regolazione del volume, utilizzare le frecce per regolare il volume"
     }
   }
 }

--- a/translations/ja.i18n.json
+++ b/translations/ja.i18n.json
@@ -103,7 +103,8 @@
       "seventy_percent": "70パーセント",
       "eighty_percent": "80パーセント",
       "ninety_percent": "90パーセント",
-      "one_hundred_percent": "100パーセント"
+      "one_hundred_percent": "100パーセント",
+      "volume_slider_aria_label": "音量：矢印を使用して音量を制御する"
     }
   }
 }

--- a/translations/ko.i18n.json
+++ b/translations/ko.i18n.json
@@ -103,7 +103,8 @@
       "seventy_percent": "70%",
       "eighty_percent": "80%",
       "ninety_percent": "90%",
-      "one_hundred_percent": "100%"
+      "one_hundred_percent": "100%",
+      "volume_slider_aria_label": "볼륨 조절, 화살표를 사용해서 볼륨을 조절하세요."
     }
   }
 }

--- a/translations/nl.i18n.json
+++ b/translations/nl.i18n.json
@@ -103,7 +103,8 @@
       "seventy_percent": "zeventig procent",
       "eighty_percent": "tachtig procent",
       "ninety_percent": "negentig procent",
-      "one_hundred_percent": "honderd procent"
+      "one_hundred_percent": "honderd procent",
+      "volume_slider_aria_label": "Volumeregeling, gebruik de pijlen om het volume te regelen"
     }
   }
 }

--- a/translations/pt_br.i18n.json
+++ b/translations/pt_br.i18n.json
@@ -103,7 +103,8 @@
       "seventy_percent": "setenta por cento",
       "eighty_percent": "oitenta por cento",
       "ninety_percent": "noventa por cento",
-      "one_hundred_percent": "cem por cento"
+      "one_hundred_percent": "cem por cento",
+      "volume_slider_aria_label": "Controle de volume, use as setas para controlar o volume"
     }
   }
 }

--- a/translations/ru.i18n.json
+++ b/translations/ru.i18n.json
@@ -103,7 +103,8 @@
       "seventy_percent": "семьдесят процентов",
       "eighty_percent": "восемьдесят процентов",
       "ninety_percent": "девяносто процентов",
-      "one_hundred_percent": "сто процентов"
+      "one_hundred_percent": "сто процентов",
+      "volume_slider_aria_label": "Регулирование громкости; для управления громкостью используйте стрелки"
     }
   }
 }

--- a/translations/zh_cn.i18n.json
+++ b/translations/zh_cn.i18n.json
@@ -90,6 +90,9 @@
     },
     "pictureInPicture": {
       "overlay_text": "以画中画模式播放"
+    },
+    "volume": {
+      "volume_slider_aria_label": "音量控制，使用箭头调整音量"
     }
   }
 }

--- a/translations/zh_tw.i18n.json
+++ b/translations/zh_tw.i18n.json
@@ -103,7 +103,8 @@
       "seventy_percent": "百分之七十",
       "eighty_percent": "百分之八十",
       "ninety_percent": "百分之九十",
-      "one_hundred_percent": "百分之一百"
+      "one_hundred_percent": "百分之一百",
+      "volume_slider_aria_label": "音量控制，使用箭頭調整音量"
     }
   }
 }


### PR DESCRIPTION
### Description of the Changes

Adding translation to: “Volume control, use the arrows to control the volume”

solves [ADA-42](https://kaltura.atlassian.net/browse/ADA-42)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[ADA-42]: https://kaltura.atlassian.net/browse/ADA-42?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ