### PR TITLE
fix(ADA-5): Volume control is not accessible from element list

### DIFF
--- a/src/components/volume/volume.js
+++ b/src/components/volume/volume.js
@@ -450,7 +450,6 @@ class Volume extends Component {
 
     return (
       <ButtonControl
-        role="application"
         name={COMPONENT_NAME}
         ref={c => (c ? (this._volumeControlElement = c) : undefined)}
         className={controlButtonClasses}


### PR DESCRIPTION
### Description of the Changes

**issue:**
volume control is not displayed in jaws element list.

**solution:**
remove the role="application" part of [704](https://github.com/kaltura/playkit-js-ui/pull/704) and it's not necessary anymore since we added tabindex on the volume slider.

solves [ADA-5](https://kaltura.atlassian.net/browse/ADA-5)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[ADA-5]: https://kaltura.atlassian.net/browse/ADA-5?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ