### PR TITLE
fix(ADA-41): [V7-Acc] remove the tabindex="0" attribute from the vide…

### DIFF
--- a/src/components/shell/shell.js
+++ b/src/components/shell/shell.js
@@ -426,9 +426,8 @@ class Shell extends Component {
 
     return (
       <div
-        tabIndex="0"
+        tabIndex="-1"
         ref={node => (this._playerRef = node)}
-        aria-label="Video Player"
         className={playerClasses}
         onTouchEnd={this.onTouchEnd}
         onMouseUp={this.onMouseUp}


### PR DESCRIPTION
…o player container being a non actionable element.

### Description of the Changes

**issue:**
after hitting play, tab should be pressed twice to focused on seek bar. first one as a result of https://github.com/kaltura/playkit-js-ui/pull/775 and second on the internal div. 

**solution:**
remove the tabIndex=0 from the internal div

solves [ADA-41](https://kaltura.atlassian.net/browse/ADA-41)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[ADA-41]: https://kaltura.atlassian.net/browse/ADA-41?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ