### PR TITLE
fix(ADA-95): Purpose of logo link on player is not clear in context

### DIFF
--- a/src/components/logo/logo.js
+++ b/src/components/logo/logo.js
@@ -2,7 +2,7 @@
 import style from '../../styles/style.scss';
 import {h, Component} from 'preact';
 import {connect} from 'react-redux';
-import {Text} from 'preact-i18n';
+import {withText} from 'preact-i18n';
 import {withPlayer} from '../player';
 import {withLogger} from 'components/logger';
 
@@ -29,6 +29,7 @@ const mapStateToProps = state => ({
 @connect(mapStateToProps)
 @withPlayer
 @withLogger(COMPONENT_NAME)
+@withText({logoText: 'controls.logo'})
 class Logo extends Component {
   /**
    * should render component
@@ -54,7 +55,7 @@ class Logo extends Component {
     return (
       <div
         className={[style.controlButtonContainer, !props.config.url ? style.emptyUrl : ''].join(' ')}
-        aria-label={<Text id="controls.logo" />}
+        aria-label={props.logoText}
         title={props.config.text}>
         <a className={style.controlButton} href={props.config.url} target="_blank" rel="noopener noreferrer">
           <img className={style.icon} src={props.config.img} />


### PR DESCRIPTION
### Description of the Changes

aria-label was [object object] instead of the strings from the translation object. 

solves [ADA-95](https://kaltura.atlassian.net/browse/ADA-95)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[ADA-95]: https://kaltura.atlassian.net/browse/ADA-95?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ