### PR TITLE
fix(ADA-111): Seek backwards’ and ‘Seek forward’ labels

### DIFF
--- a/src/components/forward/forward.js
+++ b/src/components/forward/forward.js
@@ -37,7 +37,11 @@ const mapStateToProps = state => ({
  * @returns {Object} - The object translations
  */
 const translates = (props: any) => ({
-  forwardText: !props.step ? <Text id={'controls.forward'}></Text> : <Text id={'controls.secondsForward'} fields={{seconds: props.step}}></Text>
+  forwardText: !props.step ? (
+    <Text id={'controls.secondsForward'} fields={{seconds: FORWARD_DEFAULT_STEP}}></Text>
+  ) : (
+    <Text id={'controls.secondsForward'} fields={{seconds: props.step}}></Text>
+  )
 });
 /**
  * Forward component

--- a/src/components/forward/forward.js
+++ b/src/components/forward/forward.js
@@ -37,11 +37,7 @@ const mapStateToProps = state => ({
  * @returns {Object} - The object translations
  */
 const translates = (props: any) => ({
-  forwardText: !props.step ? (
-    <Text id={'controls.secondsForward'} fields={{seconds: FORWARD_DEFAULT_STEP}}></Text>
-  ) : (
-    <Text id={'controls.secondsForward'} fields={{seconds: props.step}}></Text>
-  )
+  forwardText: <Text id={'controls.secondsForward'} fields={{seconds: props.step || FORWARD_DEFAULT_STEP}}></Text>
 });
 /**
  * Forward component

--- a/src/components/rewind/rewind.js
+++ b/src/components/rewind/rewind.js
@@ -37,7 +37,11 @@ const mapStateToProps = state => ({
  * @returns {Object} - The object translations
  */
 const translates = (props: any) => ({
-  rewindText: !props.step ? <Text id={'controls.rewind'}></Text> : <Text id={'controls.secondsRewind'} fields={{seconds: props.step}}></Text>
+  rewindText: !props.step ? (
+    <Text id={'controls.secondsRewind'} fields={{seconds: REWIND_DEFAULT_STEP}}></Text>
+  ) : (
+    <Text id={'controls.secondsRewind'} fields={{seconds: props.step}}></Text>
+  )
 });
 /**
  * Rewind component

--- a/src/components/rewind/rewind.js
+++ b/src/components/rewind/rewind.js
@@ -37,11 +37,7 @@ const mapStateToProps = state => ({
  * @returns {Object} - The object translations
  */
 const translates = (props: any) => ({
-  rewindText: !props.step ? (
-    <Text id={'controls.secondsRewind'} fields={{seconds: REWIND_DEFAULT_STEP}}></Text>
-  ) : (
-    <Text id={'controls.secondsRewind'} fields={{seconds: props.step}}></Text>
-  )
+  rewindText: <Text id={'controls.secondsRewind'} fields={{seconds: props.step || REWIND_DEFAULT_STEP}}></Text>
 });
 /**
  * Rewind component


### PR DESCRIPTION
### Description of the Changes

**issue:**
in case props.step is null the label of seek button is "seek backwards/forwards" and not with specific time

**solution:**
use the default step in case of props.step is null 

solves [ADA-111](https://kaltura.atlassian.net/browse/ADA-111)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[ADA-111]: https://kaltura.atlassian.net/browse/ADA-111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ