### PR TITLE
fix(FEC-13518): timeline blue bar is on top of button tooltips

### DIFF
--- a/src/components/bottom-bar/_bottom-bar.scss
+++ b/src/components/bottom-bar/_bottom-bar.scss
@@ -21,6 +21,8 @@
 
   .controls-container {
     width: 100%;
+    position: relative;
+    z-index: 1;
 
     .left-controls {
       float: left;

--- a/src/components/tooltip/_tooltip.scss
+++ b/src/components/tooltip/_tooltip.scss
@@ -9,7 +9,6 @@
   display: inline-block;
   height: 100%;
   width: 100%;
-  z-index: 1;
   .tooltip-label {
     visibility: hidden;
     background-color: $tooltip-background-color;

--- a/src/components/tooltip/_tooltip.scss
+++ b/src/components/tooltip/_tooltip.scss
@@ -9,6 +9,7 @@
   display: inline-block;
   height: 100%;
   width: 100%;
+  z-index: 1;
   .tooltip-label {
     visibility: hidden;
     background-color: $tooltip-background-color;


### PR DESCRIPTION
### Description of the Changes

- bug fix.

This issue is a regression from this [PR](https://github.com/kaltura/playkit-js-ui/pull/782/files).

**the issue:**
Since the z-index of the seekbar area was increased, it is now overlaying the tooltip of the control buttons which is inside a sibling container of the bottom bar. it also overlays for example the hover container of playlist (next and prev items).

**solution:**
matching the z-index of controls-container to the seekbar.

Solves FEC-13518

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
