### PR TITLE
fix(ADA-28): [V7-Acc] Make sure focus returns to the fuction opening button upon modal closure.

### DIFF
--- a/src/components/cvaa-overlay/cvaa-overlay.js
+++ b/src/components/cvaa-overlay/cvaa-overlay.js
@@ -135,6 +135,7 @@ class CVAAOverlay extends Component {
     return (
       <Overlay
         open
+        focusButton={this.props.focusButton}
         handleKeyDown={this.props.handleKeyDown}
         addAccessibleChild={this.props.addAccessibleChild}
         onClose={props.onClose}

--- a/src/components/overlay/overlay.js
+++ b/src/components/overlay/overlay.js
@@ -69,6 +69,7 @@ class Overlay extends Component {
     if (e.keyCode === KeyMap.ENTER || e.keyCode === KeyMap.SPACE) {
       e.preventDefault();
       this.props.onClose();
+      this.props.focusButton && this.props.focusButton();
     }
   };
 

--- a/src/components/settings/settings.js
+++ b/src/components/settings/settings.js
@@ -51,6 +51,7 @@ const COMPONENT_NAME = 'Settings';
 class Settings extends Component {
   state: Object;
   _controlSettingsElement: HTMLDivElement;
+  _buttonRef: HTMLButtonElement | null = null;
 
   /**
    * before component mounted, set initial state
@@ -105,6 +106,17 @@ class Settings extends Component {
     });
   };
 
+  /**
+   * set button reference
+   *
+   * @param {HTMLButtonElement} ref - button reference
+   * @returns {void}
+   * @memberof Settings
+   */
+  setButtonRef = (ref: HTMLButtonElement) => {
+    this._buttonRef = ref;
+  };
+
   toggleCVAAOverlay = (): void => {
     this.setState(prevState => {
       return {cvaaOverlay: !prevState.cvaaOverlay};
@@ -114,6 +126,12 @@ class Settings extends Component {
   onCVAAOverlayClose = (): void => {
     this.toggleCVAAOverlay();
     this.onControlButtonClick();
+  };
+
+  focusButton = (): void => {
+    setTimeout(() => {
+      this._buttonRef?.focus();
+    }, 100);
   };
 
   /**
@@ -151,6 +169,7 @@ class Settings extends Component {
       <ButtonControl name={COMPONENT_NAME} ref={c => (c ? (this._controlSettingsElement = c) : undefined)}>
         <Tooltip label={props.buttonLabel}>
           <Button
+            ref={this.setButtonRef}
             tabIndex="0"
             aria-label={props.buttonLabel}
             aria-haspopup="true"
@@ -165,7 +184,11 @@ class Settings extends Component {
           </Button>
         </Tooltip>
         {this.state.smartContainerOpen && !this.state.cvaaOverlay && (
-          <SmartContainer targetId={props.player.config.targetId} title={<Text id="settings.title" />} onClose={this.onControlButtonClick}>
+          <SmartContainer
+            targetId={props.player.config.targetId}
+            title={<Text id="settings.title" />}
+            onClose={this.onControlButtonClick}
+            focusButton={this.focusButton}>
             {showAdvancedAudioDescToggle && <AdvancedAudioDescToggle />}
             {showAudioMenu && <AudioMenu />}
             {showCaptionsMenu && <CaptionsMenu onAdvancedCaptionsClick={this.toggleCVAAOverlay} />}
@@ -173,7 +196,11 @@ class Settings extends Component {
             {showSpeedMenu && <SpeedMenu />}
           </SmartContainer>
         )}
-        {this.state.cvaaOverlay ? createPortal(<CVAAOverlay onClose={this.onCVAAOverlayClose} />, targetId.querySelector(portalSelector)) : <div />}
+        {this.state.cvaaOverlay ? (
+          createPortal(<CVAAOverlay onClose={this.onCVAAOverlayClose} focusButton={this.focusButton} />, targetId.querySelector(portalSelector))
+        ) : (
+          <div />
+        )}
       </ButtonControl>
     );
   }

--- a/src/components/smart-container/smart-container.js
+++ b/src/components/smart-container/smart-container.js
@@ -98,6 +98,7 @@ class SmartContainer extends Component {
       createPortal(
         <Overlay
           open
+          focusButton={this.props.focusButton}
           onClose={props.onClose}
           handleKeyDown={this.props.handleKeyDown}
           addAccessibleChild={this.props.addAccessibleChild}


### PR DESCRIPTION
### Description of the Changes

focus should return to settings button after close the modal by keyboard 

solves [ADA-28](https://kaltura.atlassian.net/browse/ADA-28)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
