### PR TITLE
fix(FEC-13573): align acknowledgement colors with design

### DIFF
--- a/src/styles/dynamaic-variables.scss
+++ b/src/styles/dynamaic-variables.scss
@@ -1,7 +1,7 @@
 .player {
   // HSL args
   //--playkit-primary-hsl-hue: #{hue($brand-color)};
-  --playkit-primary-hsl-hue: 215deg;
+  --playkit-primary-hsl-hue: 214deg;
   --playkit-secondary-hsl-hue: 40deg;
   --playkit-success-hsl-hue: 135deg;
   --playkit-danger-hsl-hue: 354deg;
@@ -13,7 +13,7 @@
   --playkit-danger-hsl-saturation: 76%;
   --playkit-warning-hsl-saturation: 81%;
 
-  --playkit-primary-hsl-lightness: 50%;
+  --playkit-primary-hsl-lightness: 49%;
   --playkit-secondary-hsl-lightness: 50%;
   --playkit-success-hsl-lightness: 30%;
   --playkit-danger-hsl-lightness: 51%;

--- a/src/styles/dynamaic-variables.scss
+++ b/src/styles/dynamaic-variables.scss
@@ -3,21 +3,21 @@
   //--playkit-primary-hsl-hue: #{hue($brand-color)};
   --playkit-primary-hsl-hue: 215deg;
   --playkit-secondary-hsl-hue: 40deg;
-  --playkit-success-hsl-hue: 136deg;
-  --playkit-danger-hsl-hue: 355deg;
+  --playkit-success-hsl-hue: 135deg;
+  --playkit-danger-hsl-hue: 354deg;
   --playkit-warning-hsl-hue: 21deg;
 
   --playkit-primary-hsl-saturation: 100%;
   --playkit-secondary-hsl-saturation: 100%;
-  --playkit-success-hsl-saturation: 100%;
-  --playkit-danger-hsl-saturation: 100%;
-  --playkit-warning-hsl-saturation: 100%;
+  --playkit-success-hsl-saturation: 57%;
+  --playkit-danger-hsl-saturation: 76%;
+  --playkit-warning-hsl-saturation: 81%;
 
   --playkit-primary-hsl-lightness: 50%;
   --playkit-secondary-hsl-lightness: 50%;
-  --playkit-success-hsl-lightness: 50%;
-  --playkit-danger-hsl-lightness: 50%;
-  --playkit-warning-hsl-lightness: 50%;
+  --playkit-success-hsl-lightness: 30%;
+  --playkit-danger-hsl-lightness: 51%;
+  --playkit-warning-hsl-lightness: 53%;
 
   // Accent Colors
   --playkit-primary-color: hsl(var(--playkit-primary-hsl-hue) var(--playkit-primary-hsl-saturation) var(--playkit-primary-hsl-lightness));


### PR DESCRIPTION
### Description of the Changes

align acknowledgement colors (success, error, warning) with [design](https://www.figma.com/file/8yTuCnuVHLYTFp89w7z05J/%F0%9F%93%BA-Player-v7?type=design&node-id=10596-25297&mode=design&t=PgzlXVLHFVknWO5g-0).

Solves FEC-13573

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
