### PR TITLE
fix(ADA-95): Purpose of logo link on player is not clear in context

### DIFF
--- a/src/components/logo/logo.js
+++ b/src/components/logo/logo.js
@@ -53,11 +53,8 @@ class Logo extends Component {
       return undefined;
     }
     return (
-      <div
-        className={[style.controlButtonContainer, !props.config.url ? style.emptyUrl : ''].join(' ')}
-        aria-label={props.logoText}
-        title={props.config.text}>
-        <a className={style.controlButton} href={props.config.url} target="_blank" rel="noopener noreferrer">
+      <div className={[style.controlButtonContainer, !props.config.url ? style.emptyUrl : ''].join(' ')} title={props.config.text}>
+        <a className={style.controlButton} href={props.config.url} aria-label={props.logoText} target="_blank" rel="noopener noreferrer">
           <img className={style.icon} src={props.config.img} />
         </a>
       </div>


### PR DESCRIPTION
### Description of the Changes

logo button: move aria-label into a element instead of the div

solves [ADA-95](https://kaltura.atlassian.net/browse/ADA-95)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[ADA-95]: https://kaltura.atlassian.net/browse/ADA-95?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ