### PR TITLE
fix(ADA-98): Moderation - focus should return to plugin button

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,4 +1,5 @@
 export {bindActions} from './bind-actions';
+export {focusElement} from './focus-element';
 export {KeyMap} from './key-map';
 export {default as getLogger} from './logger';
 export {withKeyboardA11y} from './popup-keyboard-accessibility';


### PR DESCRIPTION
### Description of the Changes

export focusElement function. part of - [#71](https://github.com/kaltura/playkit-js-moderation/pull/71) 

solves [ADA-98](https://kaltura.atlassian.net/browse/ADA-98)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
