### PR TITLE
feat(FEC-13567): add dynamic links to logo

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -5,3 +5,4 @@
 - [Seekbar](./components/seekbar/README.md)
 - [Time Display](./components/time-display/README.md)
 - [Error Overlay](./components/error-overlay/README.md)
+- [Logo](./components/logo/README.md)

--- a/docs/components/logo/README.md
+++ b/docs/components/logo/README.md
@@ -1,0 +1,65 @@
+# Logo
+
+Component that renders a logo image in the bottom bar area
+
+## Props
+
+| Prop | Description       |
+|------|-------------------|
+| img  | The image url     |
+| text | Text for tooltip  |
+| link | The logo url link |
+
+## Configuration
+
+> > ### img
+> >
+> > ##### Type: `string | undefined`
+> >
+> > ##### Default: `-`
+> >
+> > ##### Description: Defines logo image url.
+>
+> > ### text
+> >
+> > ##### Type: `string | undefined`
+> >
+> > ##### Default: `-`
+> >
+> > ##### Description: Defines logo tooltip text.
+>
+> > ### link
+> >
+> > ##### Type: `string | undefined`
+> >
+> > ##### Default: `-`
+> >
+> > ##### Description: Defines logo image link url.
+>
+
+
+## Player configuration
+
+> This guide assumes you are using the [Kaltura Player]
+
+[kaltura player]: https://github.com/kaltura/kaltura-player-js/
+
+In order to override error-overlay background add `backgroundUrl` link to player config
+
+```js
+const config = {
+    ...
+    ui: {
+        components: {
+            logo: {
+                img: "https://custom-logo-image-url",
+                url: "https://custom-logo-link-url",
+                text: 'Logo text'
+            }
+        }
+    }
+    ...
+}
+
+const player = KalturaPlayer.setup(config);
+```

--- a/docs/components/logo/README.md
+++ b/docs/components/logo/README.md
@@ -44,8 +44,6 @@ Component that renders a logo image in the bottom bar area
 
 [kaltura player]: https://github.com/kaltura/kaltura-player-js/
 
-In order to override error-overlay background add `backgroundUrl` link to player config
-
 ```js
 const config = {
     ...

--- a/docs/components/logo/README.md
+++ b/docs/components/logo/README.md
@@ -16,7 +16,7 @@ Component that renders a logo image in the bottom bar area
 > >
 > > ##### Type: `string | undefined`
 > >
-> > ##### Default: `-`
+> > ##### Default: `undefined`
 > >
 > > ##### Description: Defines logo image url.
 >
@@ -24,7 +24,7 @@ Component that renders a logo image in the bottom bar area
 > >
 > > ##### Type: `string | undefined`
 > >
-> > ##### Default: `-`
+> > ##### Default: `undefined`
 > >
 > > ##### Description: Defines logo tooltip text.
 >
@@ -32,7 +32,7 @@ Component that renders a logo image in the bottom bar area
 > >
 > > ##### Type: `string | undefined`
 > >
-> > ##### Default: `-`
+> > ##### Default: `undefined`
 > >
 > > ##### Description: Defines logo image link url.
 >

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -156,7 +156,7 @@ var uiManager = new playkit.ui.UIManager(player, config);
 >
 > ##### Description: Defines the ui components configuration.
 >
-> Optional components to configure: `watermark`,`seekbar`, `fullscreen`
+> Optional components to configure: `watermark`,`seekbar`, `fullscreen`, `logo`
 
 ##
 

--- a/src/components/logo/logo.tsx
+++ b/src/components/logo/logo.tsx
@@ -57,7 +57,7 @@ class Logo extends Component<any, any> {
     const url = this.props.config.url;
     if (url.indexOf(ENTRY_VAR) !== -1) {
       const {player, eventManager} = this.props;
-      eventManager.listen(player, player.Event.CHANGE_SOURCE_ENDED, () => {
+      eventManager.listen(player, player.Event.MEDIA_LOADED, () => {
         if (this._logoRef?.current) {
           this._logoRef.current.href = url.replace(ENTRY_VAR, player.sources.id);
         } else {

--- a/src/components/logo/logo.tsx
+++ b/src/components/logo/logo.tsx
@@ -4,6 +4,7 @@ import {connect} from 'react-redux';
 import {withText} from 'preact-i18n';
 import {withPlayer} from '../player';
 import {withLogger} from '../logger';
+import {withEventManager} from '../../event';
 
 const COMPONENT_NAME = 'Logo';
 
@@ -29,6 +30,7 @@ const ENTRY_VAR = '${entryId}';
  */
 @connect(mapStateToProps)
 @withPlayer
+@withEventManager
 @withLogger(COMPONENT_NAME)
 @withText({logoText: 'controls.logo'})
 class Logo extends Component<any, any> {
@@ -54,8 +56,8 @@ class Logo extends Component<any, any> {
   private _handleLogoUrl(): void {
     const url = this.props.config.url;
     if (url.indexOf(ENTRY_VAR) !== -1) {
-      const {player} = this.props;
-      player.addEventListener(player.Event.CHANGE_SOURCE_ENDED, () => {
+      const {player, eventManager} = this.props;
+      eventManager.listen(player, player.Event.CHANGE_SOURCE_ENDED, () => {
         if (this._logoRef?.current) {
           this._logoRef.current.href = url.replace(ENTRY_VAR, player.sources.id);
         } else {

--- a/src/components/logo/logo.tsx
+++ b/src/components/logo/logo.tsx
@@ -56,7 +56,11 @@ class Logo extends Component<any, any> {
     if (url.indexOf(ENTRY_VAR) !== -1) {
       const {player} = this.props;
       player.addEventListener(player.Event.CHANGE_SOURCE_ENDED, () => {
-        this._logoRef!.current!.href = url.replace('${entryId}', player.sources.id);
+        if (this._logoRef?.current) {
+          this._logoRef.current.href = url.replace(ENTRY_VAR, player.sources.id);
+        } else {
+          this.props.logger.debug(`Logo url was not replaced, because ref is null. The url: '${url}'`);
+        }
       });
     }
   }

--- a/src/components/logo/logo.tsx
+++ b/src/components/logo/logo.tsx
@@ -58,7 +58,7 @@ class Logo extends Component<any, any> {
     if (url.indexOf(ENTRY_VAR) !== -1) {
       const {player, eventManager} = this.props;
       eventManager.listen(player, player.Event.MEDIA_LOADED, () => {
-        if (this._logoRef?.current) {
+        if (this._logoRef.current) {
           this._logoRef.current.href = url.replace(ENTRY_VAR, player.sources.id);
         } else {
           this.props.logger.debug(`Logo url was not replaced, because ref is null. The url: '${url}'`);

--- a/src/components/logo/logo.tsx
+++ b/src/components/logo/logo.tsx
@@ -1,5 +1,5 @@
 import style from '../../styles/style.scss';
-import {h, Component, VNode, RefObject, createRef} from 'preact';
+import {h, Component, VNode} from 'preact';
 import {connect} from 'react-redux';
 import {withText} from 'preact-i18n';
 import {withPlayer} from '../player';
@@ -34,16 +34,13 @@ const ENTRY_VAR = '{entryId}';
 @withLogger(COMPONENT_NAME)
 @withText({logoText: 'controls.logo'})
 class Logo extends Component<any, any> {
-  private _logoRef: RefObject<HTMLAnchorElement> = createRef<HTMLAnchorElement>();
-
   /**
-   * before component mounted, set initial state of the logo
-   *
-   * @returns {void}
-   * @memberof Logo
+   * @constructor
+   * @param {*} props props
    */
-  public componentWillMount(): void {
-    this.setState({isUrlClickable: true});
+  constructor(props: any) {
+    super(props);
+    this.setState({isUrlClickable: true, urlLink: props.config.url});
   }
 
   /**
@@ -69,10 +66,10 @@ class Logo extends Component<any, any> {
       const {player, eventManager} = this.props;
       eventManager.listen(player, player.Event.MEDIA_LOADED, () => {
         const entryId = player.sources.id;
-        if (this._logoRef.current && typeof entryId === 'string') {
-          this._logoRef.current.href = url.replace(ENTRY_VAR, entryId);
+        if (typeof entryId === 'string') {
+          this.setState({urlLink: url.replace(ENTRY_VAR, entryId)});
         } else {
-          this.props.logger.debug(`Logo url was not replaced; the logo ref is null, or entry id was not found.`);
+          this.props.logger.debug(`Logo url was not replaced; entry id was not found.`);
           this.setState({isUrlClickable: false});
         }
       });
@@ -104,13 +101,7 @@ class Logo extends Component<any, any> {
       <div
         className={[style.controlButtonContainer, !props.config.url || !this.state.isUrlClickable ? style.emptyUrl : ''].join(' ')}
         title={props.config.text}>
-        <a
-          className={style.controlButton}
-          href={props.config.url}
-          aria-label={props.logoText}
-          target="_blank"
-          rel="noopener noreferrer"
-          ref={this._logoRef}>
+        <a className={style.controlButton} href={this.state.urlLink} aria-label={props.logoText} target="_blank" rel="noopener noreferrer">
           <img className={style.icon} src={props.config.img} />
         </a>
       </div>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -89,12 +89,12 @@ module.exports = (env, {mode}) => {
     },
     externals: {
       '@playkit-js/kaltura-player-js': {root: 'KalturaPlayer'},
-      // '@playkit-js/playkit-js': {
-      //   commonjs: '@playkit-js/playkit-js',
-      //   commonjs2: '@playkit-js/playkit-js',
-      //   amd: 'playkit-js',
-      //   root: ['playkit', 'core']
-      // }
+      '@playkit-js/playkit-js': {
+        commonjs: '@playkit-js/playkit-js',
+        commonjs2: '@playkit-js/playkit-js',
+        amd: 'playkit-js',
+        root: ['playkit', 'core']
+      }
     }
   };
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -89,12 +89,12 @@ module.exports = (env, {mode}) => {
     },
     externals: {
       '@playkit-js/kaltura-player-js': {root: 'KalturaPlayer'},
-      '@playkit-js/playkit-js': {
-        commonjs: '@playkit-js/playkit-js',
-        commonjs2: '@playkit-js/playkit-js',
-        amd: 'playkit-js',
-        root: ['playkit', 'core']
-      }
+      // '@playkit-js/playkit-js': {
+      //   commonjs: '@playkit-js/playkit-js',
+      //   commonjs2: '@playkit-js/playkit-js',
+      //   amd: 'playkit-js',
+      //   root: ['playkit', 'core']
+      // }
     }
   };
 };


### PR DESCRIPTION
### Description of the Changes

- **enhancement**

allow configuring the `url` configuration with dynamic `entryId` value (for kms).
**for example,** configuring the following url: `https://kms-hostname.com/media/{entryId}`
the entry id will be replaced with the current played entry id (taken from `player.sources.id`), and when clicking on the logo link, it will open the media page in kms.

**Note-** if there is no entry id (for example when using `setMedia` API and not passing the entry id), then the logo will be unclickable.

#### Resolves [FEC-13567](https://kaltura.atlassian.net/browse/FEC-13567)




[FEC-13567]: https://kaltura.atlassian.net/browse/FEC-13567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ