### PR TITLE
fix(ADA-190): Focus back on the player from other elements

### DIFF
--- a/src/components/logo/logo.tsx
+++ b/src/components/logo/logo.tsx
@@ -53,7 +53,7 @@ class Logo extends Component<any, any> {
     }
     return (
       <div className={[style.controlButtonContainer, !props.config.url ? style.emptyUrl : ''].join(' ')} title={props.config.text}>
-        <a className={style.controlButton} href={props.config.url} aria-label={props.logoText} target="_blank" rel="noopener noreferrer">
+        <a className={style.controlButton} href={props.config.url} tabIndex={0} aria-label={props.logoText} target="_blank" rel="noopener noreferrer">
           <img className={style.icon} src={props.config.img} />
         </a>
       </div>

--- a/src/components/shell/shell.tsx
+++ b/src/components/shell/shell.tsx
@@ -11,6 +11,7 @@ import {withEventDispatcher} from '../event-dispatcher';
 import {withLogger} from '../logger';
 import {ResizeWatcher} from '../../utils/resize-watcher';
 import {debounce} from '../../utils/debounce';
+import {focusElement} from '../../utils';
 
 /**
  * mapping state to props
@@ -344,6 +345,29 @@ class Shell extends Component<any, any> {
     }
   }
 
+  _setFocusOnPlayer(): void {
+    const {eventManager, player} = this.props;
+    eventManager.listen(player, player.Event.FIRST_PLAY, () => {
+      const playerContainer: HTMLDivElement = document.getElementById(this.props.targetId) as HTMLDivElement;
+      playerContainer.setAttribute('tabindex', '0');
+      playerContainer.setAttribute('aria-label', 'Player container');
+    });
+    eventManager.listen(document, 'keyup', event => {
+      if (event.code === 'Tab') {
+        this.props.updatePlayerHoverState(true);
+        if (this.state.hover && this.props.playerHover) {
+          if (document.activeElement?.firstElementChild === this._playerRef) {
+            if (event.shiftKey) {
+              const lastElementChild = this._playerRef?.getElementsByClassName('playkit-right-controls')[1].lastElementChild;
+              const elementToFocus = lastElementChild?.querySelectorAll('[tabIndex="0"]')[0] as HTMLElement;
+              focusElement(elementToFocus);
+            }
+          }
+        }
+      }
+    });
+  }
+
   /**
    * when component did update and change its props from prePlayback to !prePlayback
    * update the hover state
@@ -371,6 +395,7 @@ class Shell extends Component<any, any> {
       }
       this._updatePlayerHoverState();
     }
+    this._setFocusOnPlayer();
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

**Issue:**
There is no option to focus on the player via keyboard when the control bar is hidden

**Fix:**
Listen to tab press on the page, display the control bar and move the focus to the playerContainer or to the last element on the player (according to the user press: tab or shift tab)

#### Resolves [ADA-190](https://kaltura.atlassian.net/browse/ADA-190)




[ADA-190]: https://kaltura.atlassian.net/browse/ADA-190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ