### PR TITLE
fix(ADA-97): The small play button loses the focus after play

### DIFF
--- a/src/components/play-pause/play-pause.tsx
+++ b/src/components/play-pause/play-pause.tsx
@@ -57,8 +57,8 @@ class PlayPause extends Component<any, any> {
   componentDidMount(): void {
     const {eventManager, player} = this.props;
     const playerContainer: HTMLDivElement = document.getElementById(player.config.ui.targetId) as HTMLDivElement;
-    eventManager.listen(player, player.Event.UI.USER_CLICKED_PLAY, () => {
-      eventManager.listen(player, player.Event.Core.FIRST_PLAY, () => {
+    eventManager.listenOnce(player, player.Event.UI.USER_CLICKED_PLAY, () => {
+      eventManager.listenOnce(player, player.Event.Core.FIRST_PLAY, () => {
         playerContainer.focus();
       });
     });

--- a/src/components/play-pause/play-pause.tsx
+++ b/src/components/play-pause/play-pause.tsx
@@ -58,7 +58,9 @@ class PlayPause extends Component<any, any> {
     const {eventManager, player} = this.props;
     const playerContainer: HTMLDivElement = document.getElementById(player.config.ui.targetId) as HTMLDivElement;
     eventManager.listen(player, player.Event.UI.USER_CLICKED_PLAY, () => {
-      playerContainer.focus();
+      eventManager.listen(player, player.Event.Core.FIRST_PLAY, () => {
+        playerContainer.focus();
+      });
     });
     eventManager.listen(document, 'keydown', event => {
       if (event.code === 'Space' || event.code === 'Enter') {


### PR DESCRIPTION
### Description of the Changes

Please add a detailed description of the change, whether it's an enhancement or a bugfix.
If the PR is related to an open issue please link to it.

**Issue:**
When click on the small play button in the control bar via keyboard, the focus move to playerContainer instead of stay of the play button.

**Fix:**
Check only if the play was done from the large player move the focus to playerContainer(if user click and this is the first play)

#### Resolves [ADA-97](https://kaltura.atlassian.net/browse/ADA-97)




[ADA-97]: https://kaltura.atlassian.net/browse/ADA-97?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ