### PR TITLE
fix(FEC-13680): handle logo link with ima

### DIFF
--- a/src/components/logo/logo.tsx
+++ b/src/components/logo/logo.tsx
@@ -40,7 +40,7 @@ class Logo extends Component<any, any> {
    */
   constructor(props: any) {
     super(props);
-    this.setState({isUrlClickable: true, urlLink: props.config.url});
+    this.setState({isUrlClickable: typeof props.config.url === 'string', urlLink: props.config.url});
   }
 
   /**
@@ -64,22 +64,31 @@ class Logo extends Component<any, any> {
     const url = this.props.config.url;
     if (url && url.indexOf(ENTRY_VAR) !== -1) {
       const {player, eventManager} = this.props;
-      const entryId = player.sources.id;
-      if (typeof entryId === 'string') {
-        this.setState({urlLink: url.replace(ENTRY_VAR, entryId)});
-      } else {
-        this.setState({isUrlClickable: false});
+      if (!this._maybeSetLogoUrlWithEntryId(url)) {
         eventManager.listen(player, player.Event.MEDIA_LOADED, () => {
-          const entryId = player.sources.id;
-          if (typeof entryId === 'string') {
-            this.setState({urlLink: url.replace(ENTRY_VAR, entryId), isUrlClickable: true});
-          } else {
-            this.props.logger.debug(`Logo url was not replaced; entry id was not found.`);
-            this.setState({isUrlClickable: false});
-          }
+          this._maybeSetLogoUrlWithEntryId(url);
         });
       }
     }
+  }
+
+  /**
+   * sets the url with the entry id
+   * @param {string} url - the url configured on the logo
+   * @returns {boolean} - whether the url was set with entry id
+   * @memberof Logo
+   */
+  private _maybeSetLogoUrlWithEntryId(url: string): boolean {
+    const {player} = this.props;
+    const entryId = player.sources.id;
+    if (typeof entryId === 'string') {
+      this.setState({urlLink: url.replace(ENTRY_VAR, entryId), isUrlClickable: true});
+      return true;
+    } else {
+      this.props.logger.debug(`Logo url was not replaced; entry id was not found.`);
+      this.setState({isUrlClickable: false});
+    }
+    return false;
   }
 
   /**

--- a/src/components/logo/logo.tsx
+++ b/src/components/logo/logo.tsx
@@ -64,9 +64,9 @@ class Logo extends Component<any, any> {
     const url = this.props.config.url;
     if (url && url.indexOf(ENTRY_VAR) !== -1) {
       const {player, eventManager} = this.props;
-      if (!this._maybeSetLogoUrlWithEntryId(url)) {
+      if (!this._setLogoUrlWithEntryId(url)) {
         eventManager.listen(player, player.Event.MEDIA_LOADED, () => {
-          this._maybeSetLogoUrlWithEntryId(url);
+          this._setLogoUrlWithEntryId(url);
         });
       }
     }
@@ -75,10 +75,10 @@ class Logo extends Component<any, any> {
   /**
    * sets the url with the entry id
    * @param {string} url - the url configured on the logo
-   * @returns {boolean} - whether the url was set with entry id
+   * @returns {boolean} - whether the url was set with entry id or not
    * @memberof Logo
    */
-  private _maybeSetLogoUrlWithEntryId(url: string): boolean {
+  private _setLogoUrlWithEntryId(url: string): boolean {
     const {player} = this.props;
     const entryId = player.sources.id;
     if (typeof entryId === 'string') {
@@ -87,8 +87,8 @@ class Logo extends Component<any, any> {
     } else {
       this.props.logger.debug(`Logo url was not replaced; entry id was not found.`);
       this.setState({isUrlClickable: false});
+      return false;
     }
-    return false;
   }
 
   /**

--- a/src/components/logo/logo.tsx
+++ b/src/components/logo/logo.tsx
@@ -64,15 +64,21 @@ class Logo extends Component<any, any> {
     const url = this.props.config.url;
     if (url && url.indexOf(ENTRY_VAR) !== -1) {
       const {player, eventManager} = this.props;
-      eventManager.listen(player, player.Event.MEDIA_LOADED, () => {
-        const entryId = player.sources.id;
-        if (typeof entryId === 'string') {
-          this.setState({urlLink: url.replace(ENTRY_VAR, entryId)});
-        } else {
-          this.props.logger.debug(`Logo url was not replaced; entry id was not found.`);
-          this.setState({isUrlClickable: false});
-        }
-      });
+      const entryId = player.sources.id;
+      if (typeof entryId === 'string') {
+        this.setState({urlLink: url.replace(ENTRY_VAR, entryId)});
+      } else {
+        this.setState({isUrlClickable: false});
+        eventManager.listen(player, player.Event.MEDIA_LOADED, () => {
+          const entryId = player.sources.id;
+          if (typeof entryId === 'string') {
+            this.setState({urlLink: url.replace(ENTRY_VAR, entryId), isUrlClickable: true});
+          } else {
+            this.props.logger.debug(`Logo url was not replaced; entry id was not found.`);
+            this.setState({isUrlClickable: false});
+          }
+        });
+      }
     }
   }
 


### PR DESCRIPTION
### Description of the Changes

- **bugfix**

**Issue:**
A use-case where the `medialoaded` event has been fired before logo component was mounted.
in case ima is enabled and the media is being preloaded, listening to `medialoaded` event happens too late (after it was already fired). This is causing not replacing the `{entryId}` in the url, which breaks the url href of the logo.

**Fix:**
before listening to `medialoaded` event, first check if the entry id already exists.

#### Resolves [FEC-13680](https://kaltura.atlassian.net/browse/FEC-13680)




[FEC-13680]: https://kaltura.atlassian.net/browse/FEC-13680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ