### PR TITLE
fix(ADA-496): The heading for the modal dialog uses implicit CSS (bold text and margin) to indicate headings

### DIFF
--- a/src/components/cvaa-overlay/main-captions_window.tsx
+++ b/src/components/cvaa-overlay/main-captions_window.tsx
@@ -75,9 +75,9 @@ class MainCaptionsWindow extends Component<any, any> {
   render(props: any): VNode<any> {
     return (
       <div className={[style.overlayScreen, style.active].join(' ')}>
-        <div className={style.title}>
+        <h2 className={style.title}>
           <Text id={'cvaa.title'} />
-        </div>
+        </h2>
         <div role="group">
           <SampleCaptionsStyleButton
             addAccessibleChild={props.addAccessibleChild}

--- a/src/components/overlay/_overlay.scss
+++ b/src/components/overlay/_overlay.scss
@@ -40,6 +40,7 @@
     font-weight: bold;
     line-height: 29px;
     margin-bottom: 60px;
+    margin-top: 0px;
   }
   .close-overlay {
     position: absolute;
@@ -74,6 +75,7 @@
     }
     .title {
       margin-bottom: 24px;
+      margin-top: 0px;
     }
   }
 }
@@ -93,6 +95,7 @@
         font-size: 20px;
         line-height: 19px;
         margin-bottom: 24px;
+        margin-top: 0px;
       }
     }
   }


### PR DESCRIPTION
### Description of the Changes

**Issue:**
The heading for the modal dialog "Advanced captions settings" header is not recognized as header by the screen reader

**Fix:**
Change the the div to h2 element.

#### Resolves [ADA-496](https://kaltura.atlassian.net/browse/ADA-496)




[ADA-496]: https://kaltura.atlassian.net/browse/ADA-496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ