### PR TITLE
fix(ADA-126): Certain ARIA roles must be contained by particular parents

### DIFF
--- a/src/components/smart-container/smart-container.tsx
+++ b/src/components/smart-container/smart-container.tsx
@@ -105,7 +105,7 @@ class SmartContainer extends Component<any, any> {
         targetId.querySelector(portalSelector)!
       )
     ) : (
-      <div onKeyDown={props.handleKeyDown} tabIndex={-1} className={[style.smartContainer, style.top, style.left].join(' ')}>
+      <div onKeyDown={props.handleKeyDown} tabIndex={-1} role="menu" className={[style.smartContainer, style.top, style.left].join(' ')}>
         {this.renderChildren(props)}
       </div>
     );


### PR DESCRIPTION
### Description of the Changes

**Issue:**
The elements in the drop-down menu inside the settings button (such as quality, captions, etc) have a "menuitem" role but are not wrapped in a menu role.

**Fix:**
Adding "menu" role on div inside the settings button.

#### Resolves [ADA-126](https://kaltura.atlassian.net/browse/ADA-126)




[ADA-126]: https://kaltura.atlassian.net/browse/ADA-126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ