### PR TITLE
fix(ADA-101): There is no indication to the focused element when modal is opened

### DIFF
--- a/src/components/shell/shell.tsx
+++ b/src/components/shell/shell.tsx
@@ -81,22 +81,6 @@ class Shell extends Component<any, any> {
   _playerRef: HTMLDivElement | null = null;
 
   /**
-   * on mouse over, add hover class (shows the player ui) and timeout of 3 seconds bt default or what pass as prop configuration to component
-   *
-   * @returns {void}
-   * @memberof Shell
-   */
-  onMouseOver = (): void => {
-    if (this.props.isMobile) {
-      return;
-    }
-    if (this.state.nav) {
-      this.setState({nav: false});
-      this.props.updatePlayerNavState(false);
-    }
-  };
-
-  /**
    * on mouse leave, remove the hover class (hide the player gui)
    * @param {Event} event - the mouse leave event
    * @returns {void}

--- a/src/components/shell/shell.tsx
+++ b/src/components/shell/shell.tsx
@@ -128,6 +128,10 @@ class Shell extends Component<any, any> {
     if (this.props.isMobile) {
       return;
     }
+    if (this.state.nav) {
+      this.setState({nav: false});
+      this.props.updatePlayerNavState(false);
+    }
     this._updatePlayerHoverState();
   };
 
@@ -429,7 +433,6 @@ class Shell extends Component<any, any> {
         className={joinedPlayerClasses}
         onTouchEnd={this.onTouchEnd}
         onMouseUp={this.onMouseUp}
-        onMouseOver={this.onMouseOver}
         onMouseMove={this.onMouseMove}
         onMouseLeave={this.onMouseLeave}
         onKeyDown={this.onKeyDown}


### PR DESCRIPTION
### Description of the Changes

**Issue:**
When user open modal with keyboard, focus is moving to the first element but there is no blue border around the element.

**Root cause:**
The playkit-nav class (that have the css with the border) is removed from the player on mouseOver event.
mouseOver event is triggered also when the mouse enter to the element bounding without move the mouse so when the overlay div is created the mousseOver is triggered.

**Fix:**
Move the functionality to mouseMove event.

#### Resolves [ADA-101](https://kaltura.atlassian.net/browse/ADA-101)


[ADA-101]: https://kaltura.atlassian.net/browse/ADA-101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ