### PR TITLE
fix(FEC-13174): fix z-index and overflow of side panels

### DIFF
--- a/src/components/side-panel/_side-panel.scss
+++ b/src/components/side-panel/_side-panel.scss
@@ -1,9 +1,12 @@
 .side-panel {
   position: absolute;
-  overflow: hidden;
   transition: all #{$default-transition-time}ms;
   transition-property: left, right, bottom, top, opacity;
-  z-index: 1;
+  z-index: 0;
+  &.small-size {
+    // for small sizes the side panel should be over player controls
+    z-index: 1;
+  }
 }
 
 .vertical-side-panel {
@@ -19,4 +22,5 @@
 .side-panel-content {
   width: 100%;
   height: 100%;
+  overflow: hidden;
 }

--- a/src/components/side-panel/side-panel.tsx
+++ b/src/components/side-panel/side-panel.tsx
@@ -11,7 +11,8 @@ import {connect} from 'react-redux';
  */
 const mapStateToProps = state => ({
   sidePanelsStyles: state.shell.layoutStyles.sidePanels,
-  playerClientRect: state.shell.playerClientRect
+  playerClientRect: state.shell.playerClientRect,
+  isSmallSize: state.shell.isSmallSize
 });
 
 /**
@@ -51,6 +52,9 @@ class SidePanel extends Component<any, any> {
     const isVertical = [SidePanelPositions.RIGHT, SidePanelPositions.LEFT].indexOf(position) !== -1;
     const stylePrefix = isVertical ? 'verticalSidePanel' : 'horizontalSidePanel';
     const styleClass = [style.sidePanel, style[stylePrefix]];
+    if (props.isSmallSize) {
+      styleClass.push(style.smallSize);
+    }
 
     const areaName = `SidePanel${position.charAt(0).toUpperCase() + position.slice(1).toLowerCase()}`;
 


### PR DESCRIPTION
### Description of the Changes

**Issue:**
If for element uses `position: absolute` and `overflow: hidden` - all child content with absolute position will limited by the element sizes. That causes issue for tooltips and popups that should overlap parent elements (regardless of size).

**Fix:**
1. use `overflow: hidden` for child of element that uses `position: absolute`, so all relative children nodes will be limited by parent size and absolute children will not.
2. use z-index only for small player size (when side panels should take all player area and overlap the player controls).


#### Resolves https://kaltura.atlassian.net/browse/FEC-13174


