### PR TITLE
fix(SUP-41568): Thumbnail dimmed for audio track in V7

### DIFF
--- a/src/components/audio-entry-details/_audio-entry-details.scss
+++ b/src/components/audio-entry-details/_audio-entry-details.scss
@@ -55,8 +55,8 @@
 
     &.audio-entry-expanded {
       overflow: auto;
-      background: rgba(0, 0, 0, 0.7);
-      height: 100%;
+      background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.7) 100%);
+      height: auto;
 
       .audio-entry-details {
         overflow: auto;


### PR DESCRIPTION
### Description of the Changes

issue:
on audio track when title is not trimmed there is black cover on all screen

fix:
change css in case audio-entry-expanded so the black cover will be only on the title

#### Resolves SUP-41568


