### PR TITLE
fix(ADA-190): Focus back on the player from other elements

### DIFF
--- a/src/components/logo/logo.tsx
+++ b/src/components/logo/logo.tsx
@@ -128,7 +128,9 @@ class Logo extends Component<any, any> {
           href={this.state.urlLink}
           aria-label={props.logoText}
           target="_blank"
-          rel="noopener noreferrer">
+          rel="noopener noreferrer"
+          tabIndex={0}
+          >
           <img className={style.icon} src={props.config.img} />
         </a>
       </div>

--- a/src/components/play-pause/play-pause.tsx
+++ b/src/components/play-pause/play-pause.tsx
@@ -60,6 +60,7 @@ class PlayPause extends Component<any, any> {
     eventManager.listenOnce(player, player.Event.UI.USER_CLICKED_PLAY, () => {
       eventManager.listenOnce(player, player.Event.Core.FIRST_PLAY, () => {
         playerContainer.focus();
+        playerContainer.setAttribute('role', 'application'); // Set JAWS screen reader into 'forms' mode, where keys are passed through to the web-page.
       });
     });
     eventManager.listen(document, 'keydown', event => {


### PR DESCRIPTION
### Description of the Changes

use role 'application' to set JAWS screen reader into 'forms' mode, where keys are passed through to the web-page.

**Issue:**

**Fix:**

#### Resolves https://kaltura.atlassian.net/browse/ADA-190


