### PR TITLE
fix(FEC-13897):  Close captions order alphabetically works only for labels that starts with capital letter.

### DIFF
--- a/src/components/captions-menu/captions-menu.tsx
+++ b/src/components/captions-menu/captions-menu.tsx
@@ -118,7 +118,11 @@ class CaptionsMenu extends Component<any, any> {
         active: t.active,
         value: t
       }))
-      .sort((a, b) => a.label > b.label || a.label === 'Off' ? 1 : -1);
+      .map(t => ({
+        ...t,
+        label: t.label.charAt(0).toUpperCase() + t.label.slice(1)
+      }))
+      .sort((a, b) => (a.label > b.label || a.label === 'Off' ? 1 : -1));
 
     if (props.showAdvancedCaptionsMenu) {
       textOptions.push({label: props.advancedCaptionsSettingsText, value: props.advancedCaptionsSettingsText, active: false});


### PR DESCRIPTION
### Description of the Changes

Close captions order alphabetically works only for labels that starts with capital letter.


#### Resolves FEC-13897


