### PR TITLE
fix(FEC-13709): remove player top bar if there is no content in it

### DIFF
--- a/src/components/top-bar/_top-bar.scss
+++ b/src/components/top-bar/_top-bar.scss
@@ -93,6 +93,10 @@
   }
 }
 
+.player .top-bar:has(.left-controls:empty + .right-controls:empty) {
+  visibility: hidden;
+}
+
 .player.size-sm .top-bar {
   .left-controls {
     margin: #{$top-bar-top-bottom-gutter}px 0 #{$top-bar-top-bottom-gutter}px #{$gui-small-gutter}px;


### PR DESCRIPTION
### Description of the Changes

- bugfix.

set `visibility: hidden` to top bar component in case left and right controls do not contain any children (top bar is empty).

related PR: https://github.com/kaltura/playkit-js-ui-managers/pull/53

#### Resolves FEC-13709


