### PR TITLE
fix(FEC-13880): Add css dynamic vars to support light theme

### DIFF
--- a/src/styles/dynamaic-variables.scss
+++ b/src/styles/dynamaic-variables.scss
@@ -76,6 +76,16 @@
   --playkit-tone-7-color: #212121;
   --playkit-tone-8-color: #000000;
 
+  // Tone Ramp - rgb values
+  --playkit-tone-1-color-rgb: 255, 255, 255;
+  --playkit-tone-2-color-rgb: 204, 204, 204;
+  --playkit-tone-3-color-rgb: 153, 153, 153;
+  --playkit-tone-4-color-rgb: 102, 102, 102;
+  --playkit-tone-5-color-rgb: 82, 82, 82;
+  --playkit-tone-6-color-rgb: 56, 56, 56;
+  --playkit-tone-7-color-rgb: 33, 33, 33;
+  --playkit-tone-8-color-rgb: 0, 0, 0;
+
   --playkit-live-color: #e12437;
   --playkit-player-background-color: #000000;
   --playkit-tab-focus-color: var(--playkit-primary-color);

--- a/src/styles/exported.scss
+++ b/src/styles/exported.scss
@@ -37,6 +37,16 @@ $tone-6-color: var(--playkit-tone-6-color);
 $tone-7-color: var(--playkit-tone-7-color);
 $tone-8-color: var(--playkit-tone-8-color);
 
+// Tone Ramp - rgb values
+$tone-1-color-rgb: var(--playkit-tone-1-color-rgb);
+$tone-2-color-rgb: var(--playkit-tone-2-color-rgb);
+$tone-3-color-rgb: var(--playkit-tone-3-color-rgb);
+$tone-4-color-rgb: var(--playkit-tone-4-color-rgb);
+$tone-5-color-rgb: var(--playkit-tone-5-color-rgb);
+$tone-6-color-rgb: var(--playkit-tone-6-color-rgb);
+$tone-7-color-rgb: var(--playkit-tone-7-color-rgb);
+$tone-8-color-rgb: var(--playkit-tone-8-color-rgb);
+
 $live-color: var(--playkit-live-color);
 $player-background-color: var(--playkit-player-background-color);
 $tab-focus-color: var(--playkit-tab-focus-color);


### PR DESCRIPTION
### Description of the Changes

Please add a detailed description of the change, whether it's an enhancement or a bugfix.
If the PR is related to an open issue please link to it.

**Issue:**  opacity element of css color of Hex format can not dynamically be changed 

**Fix:** expose the tone ramp global vars as rgb values which can be manipulated dynamically using built-in rgba() css funciton (i.e. :   `background-color: rgba(255 255 255, 0.1);)`

#### Resolves FEC-13880

Related Prs:
https://github.com/kaltura/playkit-js-share/pull/44
https://github.com/kaltura/playkit-js-downloads/pull/52


