### PR TITLE
feat(FEC-13955): Add finer control over tone colors to support  light…

### DIFF
--- a/src/utils/themes-manager.ts
+++ b/src/utils/themes-manager.ts
@@ -22,7 +22,15 @@ const cssVarNames = {
     tone5: '--playkit-tone-5-color',
     tone6: '--playkit-tone-6-color',
     tone7: '--playkit-tone-7-color',
-    tone8: '--playkit-tone-8-color'
+    tone8: '--playkit-tone-8-color',
+    tone1RGB: '--playkit-tone-1-color-rgb',
+    tone2RGB: '--playkit-tone-2-color-rgb',
+    tone3RGB: '--playkit-tone-3-color-rgb',
+    tone4RGB: '--playkit-tone-4-color-rgb',
+    tone5RGB: '--playkit-tone-5-color-rgb',
+    tone6RGB: '--playkit-tone-6-color-rgb',
+    tone7RGB: '--playkit-tone-7-color-rgb',
+    tone8RGB: '--playkit-tone-8-color-rgb'
   }
 };
 


### PR DESCRIPTION
… theme dynamically

### Description of the Changes

**Issue:**  opacity element of css color of Hex format can not dynamically be changed 

**Fix:** expose the tone ramp global vars as rgb values which can be manipulated dynamically using built-in rgba() css funciton (i.e. :   `background-color: rgba(255 255 255, 0.1);)`


#### Resolves FEC-13955

#### Related PR
https://github.com/kaltura/playkit-js-audio-player/pull/24


