### PR TITLE
fix(FEC-13949): a11y labels on volume control

### DIFF
--- a/src/components/volume/volume.tsx
+++ b/src/components/volume/volume.tsx
@@ -453,7 +453,7 @@ class Volume extends Component<any, any> {
           <Button
             tabIndex="0"
             aria-live="polite"
-            aria-label={this.props.volumeLabel}
+            aria-label={`${this.props.volumeLabel}. ${this.props.sliderAriaLabel}`}
             className={style.controlButton}
             onMouseUp={this.toggleMute}
             onTouchEnd={this.onTouchEnd}


### PR DESCRIPTION
### Description of the Changes

<img width="913" alt="image" src="https://github.com/kaltura/playkit-js-ui/assets/51074448/dbc2701c-398b-4a2d-914f-680f52031e8e">


**Issue:**

**Fix:**

Resolves: https://kaltura.atlassian.net/browse/FEC-13949


