### PR TITLE
fix(ADA-1121): Exit Picture in Picture labeled as Expand

### DIFF
--- a/src/components/picture-in-picture/picture-in-picture.tsx
+++ b/src/components/picture-in-picture/picture-in-picture.tsx
@@ -41,8 +41,7 @@ const COMPONENT_NAME = 'PictureInPicture';
 @withEventDispatcher(COMPONENT_NAME)
 @withText({
   pictureInPictureText: 'controls.pictureInPicture',
-  pictureInPictureExitText: 'controls.pictureInPictureExit',
-  pictureInPictureExpandText: 'controls.pictureInPictureExpand'
+  pictureInPictureExitText: 'controls.pictureInPictureExit'
 })
 class PictureInPicture extends Component<any, any> {
   _keyboardEventHandlers: Array<KeyboardEventHandlers> = [
@@ -106,7 +105,7 @@ class PictureInPicture extends Component<any, any> {
     if (this._shouldRender()) {
       return (
         <ButtonControl name={COMPONENT_NAME}>
-          <Tooltip label={this.props.isInPictureInPicture ? this.props.pictureInPictureExpandText : this.props.pictureInPictureText}>
+          <Tooltip label={this.props.isInPictureInPicture ? this.props.pictureInPictureExitText : this.props.pictureInPictureText}>
             <Button
               tabIndex="0"
               aria-label={this.props.isInPictureInPicture ? this.props.pictureInPictureExitText : this.props.pictureInPictureText}

--- a/translations/ar.i18n.json
+++ b/translations/ar.i18n.json
@@ -19,7 +19,7 @@
       "prev": "السابق",
       "startOver": "البدء من جديد",
       "pictureInPicture": "صورة داخل صورة",
-      "pictureInPictureExit": "خروج من وضع صورة داخل صورة"
+      "pictureInPictureExit": "خروج من وضع صورة داخل صورة" ,
       "logo": "الشعار",
       "seekBarSlider": "شريط تمرير الانتقال"
     },

--- a/translations/ar.i18n.json
+++ b/translations/ar.i18n.json
@@ -19,8 +19,7 @@
       "prev": "السابق",
       "startOver": "البدء من جديد",
       "pictureInPicture": "صورة داخل صورة",
-      "pictureInPictureExit": "خروج من وضع صورة داخل صورة",
-      "pictureInPictureExpand": "توسيع",
+      "pictureInPictureExit": "خروج من وضع صورة داخل صورة"
       "logo": "الشعار",
       "seekBarSlider": "شريط تمرير الانتقال"
     },

--- a/translations/ar.i18n.json
+++ b/translations/ar.i18n.json
@@ -19,7 +19,7 @@
       "prev": "السابق",
       "startOver": "البدء من جديد",
       "pictureInPicture": "صورة داخل صورة",
-      "pictureInPictureExit": "خروج من وضع صورة داخل صورة" ,
+      "pictureInPictureExit": "خروج من وضع صورة داخل صورة",
       "logo": "الشعار",
       "seekBarSlider": "شريط تمرير الانتقال"
     },

--- a/translations/de.i18n.json
+++ b/translations/de.i18n.json
@@ -22,7 +22,6 @@
       "startOver": "Von vorne",
       "pictureInPicture": "Bild im Bild",
       "pictureInPictureExit": "Bild in Bild verlassen",
-      "pictureInPictureExpand": "Erweitern",
       "logo": "Logo",
       "seekBarSlider": "Suchleiste",
       "readLess": "Weniger",

--- a/translations/en.i18n.json
+++ b/translations/en.i18n.json
@@ -22,7 +22,6 @@
       "startOver": "Start over",
       "pictureInPicture": "Picture in picture",
       "pictureInPictureExit": "Exit picture in picture",
-      "pictureInPictureExpand": "Expand",
       "logo": "Logo",
       "seekBarSlider": "Seek bar",
       "readLess": "Less",

--- a/translations/es.i18n.json
+++ b/translations/es.i18n.json
@@ -20,7 +20,6 @@
       "startOver": "Volver a empezar",
       "pictureInPicture": "Imagen dentro de la imagen",
       "pictureInPictureExit": "Salir de imagen en imagen",
-      "pictureInPictureExpand": "Expandir",
       "logo": "Logotipo",
       "seekBarSlider": "Buscar control deslizante",
       "readLess": "Menos",

--- a/translations/fi.i18n.json
+++ b/translations/fi.i18n.json
@@ -20,7 +20,6 @@
       "startOver": "Aloita uudelleen",
       "pictureInPicture": "Kuva kuvassa",
       "pictureInPictureExit": "Poistu kuva-kuvassa-toiminnosta",
-      "pictureInPictureExpand": "Laajenna",
       "logo": "Logo",
       "seekBarSlider": "Hae liukusäädin",
       "readLess": "Vähemmän",

--- a/translations/fr.i18n.json
+++ b/translations/fr.i18n.json
@@ -20,7 +20,6 @@
       "startOver": "Recommencer",
       "pictureInPicture": "Image dans l’image",
       "pictureInPictureExit": "Quitter le mode Image-dans-Image",
-      "pictureInPictureExpand": "Agrandir",
       "logo": "Logo",
       "seekBarSlider": "Diapositive",
       "readLess": "Moins",

--- a/translations/fr_ca.i18n.json
+++ b/translations/fr_ca.i18n.json
@@ -20,7 +20,6 @@
       "startOver": "Recommencer",
       "pictureInPicture": "Picture-in-picture",
       "pictureInPictureExit": "Quitter fenêtre dans fenêtre",
-      "pictureInPictureExpand": "RETOUR (au mode normal)",
       "logo": "Logo",
       "seekBarSlider": "Curseur",
       "readLess": "Moins",

--- a/translations/he.i18n.json
+++ b/translations/he.i18n.json
@@ -20,7 +20,6 @@
       "startOver": "התחל מחדש",
       "pictureInPicture": "תמונה בתוך תמונה",
       "pictureInPictureExit": "צא מתמונה מתוך תמונה",
-      "pictureInPictureExpand": "הרחב",
       "logo": "לוגו",
       "seekBarSlider": "חפש מחוון"
     },

--- a/translations/hi_in.i18n.json
+++ b/translations/hi_in.i18n.json
@@ -20,7 +20,6 @@
       "startOver": "प्रारंभ करें",
       "pictureInPicture": "पिक्चर इन पिक्चर",
       "pictureInPictureExit": "पिक्चर इन पिक्चर से बाहर निकलें",
-      "pictureInPictureExpand": "विस्तृत करें",
       "logo": "लोगो",
       "seekBarSlider": "स्लाइडर के लिए प्रयास करें"
     },

--- a/translations/it.i18n.json
+++ b/translations/it.i18n.json
@@ -20,7 +20,6 @@
       "startOver": "Riavvia",
       "pictureInPicture": "Immagine nell’immagine",
       "pictureInPictureExit": "Esci dalla modalità Picture in Picture",
-      "pictureInPictureExpand": "Ingrandisci",
       "logo": "Logo",
       "seekBarSlider": "Cursore di ricerca",
       "readLess": "Meno",

--- a/translations/ja.i18n.json
+++ b/translations/ja.i18n.json
@@ -20,7 +20,6 @@
       "startOver": "最初から再生する",
       "pictureInPicture": "ピクチャーインピクチャー",
       "pictureInPictureExit": "ピクチャーインピクチャーを終了する",
-      "pictureInPictureExpand": "拡大",
       "logo": "ロゴ",
       "seekBarSlider": "シーク スライダー",
       "readLess": "折りたたみ表示",

--- a/translations/ko.i18n.json
+++ b/translations/ko.i18n.json
@@ -20,7 +20,6 @@
       "startOver": "처음부터 재생",
       "pictureInPicture": "화면 속 화면",
       "pictureInPictureExit": "화면 속 화면 끝내기",
-      "pictureInPictureExpand": "확장",
       "logo": "로고",
       "seekBarSlider": "슬라이더",
       "readLess": "간단히 보기",

--- a/translations/nl.i18n.json
+++ b/translations/nl.i18n.json
@@ -20,7 +20,6 @@
       "startOver": "Opnieuw beginnen",
       "pictureInPicture": "Beeld in beeld",
       "pictureInPictureExit": "Modus Afbeelding in afbeelding verlaten",
-      "pictureInPictureExpand": "Uitbreiden",
       "logo": "Logo",
       "seekBarSlider": "Zoekschuifregelaar",
       "readLess": "Minder",

--- a/translations/pt_br.i18n.json
+++ b/translations/pt_br.i18n.json
@@ -20,7 +20,6 @@
       "startOver": "Começar de novo",
       "pictureInPicture": "Picture in picture",
       "pictureInPictureExit": "Sair do Picture in picture",
-      "pictureInPictureExpand": "Expandir",
       "logo": "Logo",
       "seekBarSlider": "Controle deslizante",
       "readLess": "Menos",

--- a/translations/ru.i18n.json
+++ b/translations/ru.i18n.json
@@ -20,7 +20,6 @@
       "startOver": "Запустить заново",
       "pictureInPicture": "Картинка в картинке",
       "pictureInPictureExit": "Выйти из режима «картинка в картинке»",
-      "pictureInPictureExpand": "Развернуть",
       "logo": "Логотип",
       "seekBarSlider": "Слайдер навигации",
       "readLess": "Меньше",

--- a/translations/zh_cn.i18n.json
+++ b/translations/zh_cn.i18n.json
@@ -20,7 +20,6 @@
       "startOver": "重新开始",
       "pictureInPicture": "画中画",
       "pictureInPictureExit": "退出画中画",
-      "pictureInPictureExpand": "扩展",
       "logo": "标识",
       "seekBarSlider": "搜寻滑块",
       "readLess": "收起",

--- a/translations/zh_tw.i18n.json
+++ b/translations/zh_tw.i18n.json
@@ -20,7 +20,6 @@
       "startOver": "重頭",
       "pictureInPicture": "圖片中的圖片",
       "pictureInPictureExit": "退出畫中畫",
-      "pictureInPictureExpand": "擴展",
       "logo": "圖標",
       "seekBarSlider": "進行輪播",
       "readLess": "更少",


### PR DESCRIPTION
### Description of the Changes

Please add a detailed description of the change, whether it's an enhancement or a bugfix.
If the PR is related to an open issue please link to it.

**Issue:**
Aria-label and tooltip of exit picture in picture button are not the same

**Fix:**
Change the tooltip from "Expand" to "Exit picture in picture"

#### Resolves [ADA-1121](https://kaltura.atlassian.net/browse/ADA-1121)




[ADA-1121]: https://kaltura.atlassian.net/browse/ADA-1121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ