### PR TITLE
fix(ADA-1296): [ACE] V7 Player keyboard accessibility not working properly

### DIFF
--- a/src/components/settings/settings.tsx
+++ b/src/components/settings/settings.tsx
@@ -26,6 +26,7 @@ import {focusElement} from '../../utils';
 import {withKeyboardEvent} from '../../components/keyboard';
 import {KeyboardEventHandlers} from '../../types';
 import {withLogger} from '../logger';
+import {SpeedSelectedEvent} from '../../event/events/speed-selected-event';
 
 /**
  * mapping state to props
@@ -87,6 +88,33 @@ class Settings extends Component<any, any> {
           }
         }
       }
+    },
+    {
+      key: {
+        code: KeyMap.PERIOD,
+        shiftKey: true
+      },
+      action: event => {
+        this.handleKeydown(event);
+      }
+    },
+    {
+      key: {
+        code: KeyMap.SEMI_COLON,
+        shiftKey: true
+      },
+      action: event => {
+        this.handleKeydown(event);
+      }
+    },
+    {
+      key: {
+        code: KeyMap.COMMA,
+        shiftKey: true
+      },
+      action: event => {
+        this.handleKeydown(event);
+      }
     }
   ];
 
@@ -110,6 +138,49 @@ class Settings extends Component<any, any> {
     const {eventManager} = this.props;
     eventManager.listen(document, 'click', e => this.handleClickOutside(e));
     this.props.registerKeyboardEvents(this._keyboardEventHandlers);
+  }
+
+  /**
+   * on settings control key down, update the settings in case of up/down keys
+   *
+   * @method handleKeydown
+   * @param {KeyboardEvent} event - keyboardEvent event
+   * @returns {void}
+   * @memberof SpeedMenu
+   */
+  handleKeydown(event: KeyboardEvent): void {
+    const {player, logger} = this.props;
+    let playbackRate, index;
+    switch (event.code) {
+      case 'Period':
+        playbackRate = player.playbackRate;
+        index = player.playbackRates.indexOf(playbackRate);
+        if (index < player.playbackRates.length - 1) {
+          logger.debug(`Changing playback rate. ${playbackRate} => ${player.playbackRates[index + 1]}`);
+          player.playbackRate = player.playbackRates[index + 1];
+          this.props.updateOverlayActionIcon(IconType.SpeedUp);
+          player.dispatchEvent(new SpeedSelectedEvent(player.playbackRate));
+        }
+        break;
+      case 'Semicolon':
+        if (player.playbackRate !== player.defaultPlaybackRate) {
+          logger.debug(`Changing playback rate. ${player.playbackRate} => ${player.defaultPlaybackRate}`);
+          player.playbackRate = player.defaultPlaybackRate;
+          this.props.updateOverlayActionIcon(IconType.Speed);
+          player.dispatchEvent(new SpeedSelectedEvent(player.playbackRate));
+        }
+        break;
+      case 'Comma':
+        playbackRate = player.playbackRate;
+        index = player.playbackRates.indexOf(playbackRate);
+        if (index > 0) {
+          logger.debug(`Changing playback rate. ${playbackRate} => ${player.playbackRates[index - 1]}`);
+          player.playbackRate = player.playbackRates[index - 1];
+          this.props.updateOverlayActionIcon(IconType.SpeedDown);
+          player.dispatchEvent(new SpeedSelectedEvent(player.playbackRate));
+        }
+        break;
+    }
   }
 
   /**

--- a/src/components/settings/settings.tsx
+++ b/src/components/settings/settings.tsx
@@ -2,7 +2,7 @@ import style from '../../styles/style.scss';
 import {h, Component, VNode} from 'preact';
 import {withText, Text} from 'preact-i18n';
 import {connect} from 'react-redux';
-import {bindActions, KeyMap, KeyCode} from '../../utils';
+import {bindActions, KeyMap} from '../../utils';
 import {actions} from '../../reducers/settings';
 import {
   AdvancedAudioDescToggle,
@@ -151,8 +151,8 @@ class Settings extends Component<any, any> {
   handleKeydown(event: KeyboardEvent): void {
     const {player, logger} = this.props;
     let playbackRate, index;
-    switch (event.code) {
-      case KeyCode.Period:
+    switch (event.keyCode) {
+      case KeyMap.PERIOD:
         playbackRate = player.playbackRate;
         index = player.playbackRates.indexOf(playbackRate);
         if (index < player.playbackRates.length - 1) {
@@ -162,7 +162,7 @@ class Settings extends Component<any, any> {
           player.dispatchEvent(new SpeedSelectedEvent(player.playbackRate));
         }
         break;
-      case KeyCode.Semicolon:
+      case KeyMap.SEMI_COLON:
         if (player.playbackRate !== player.defaultPlaybackRate) {
           logger.debug(`Changing playback rate. ${player.playbackRate} => ${player.defaultPlaybackRate}`);
           player.playbackRate = player.defaultPlaybackRate;
@@ -170,7 +170,7 @@ class Settings extends Component<any, any> {
           player.dispatchEvent(new SpeedSelectedEvent(player.playbackRate));
         }
         break;
-      case KeyCode.Comma:
+      case KeyMap.COMMA:
         playbackRate = player.playbackRate;
         index = player.playbackRates.indexOf(playbackRate);
         if (index > 0) {

--- a/src/components/settings/settings.tsx
+++ b/src/components/settings/settings.tsx
@@ -2,7 +2,7 @@ import style from '../../styles/style.scss';
 import {h, Component, VNode} from 'preact';
 import {withText, Text} from 'preact-i18n';
 import {connect} from 'react-redux';
-import {bindActions, KeyMap} from '../../utils';
+import {bindActions, KeyMap, KeyCode} from '../../utils';
 import {actions} from '../../reducers/settings';
 import {
   AdvancedAudioDescToggle,
@@ -23,7 +23,7 @@ import {Button} from '../button';
 import {ButtonControl} from '../button-control';
 import {createPortal} from 'preact/compat';
 import {focusElement} from '../../utils';
-import {withKeyboardEvent} from '../../components/keyboard';
+import {withKeyboardEvent} from '../keyboard';
 import {KeyboardEventHandlers} from '../../types';
 import {withLogger} from '../logger';
 import {SpeedSelectedEvent} from '../../event/events/speed-selected-event';
@@ -152,7 +152,7 @@ class Settings extends Component<any, any> {
     const {player, logger} = this.props;
     let playbackRate, index;
     switch (event.code) {
-      case 'Period':
+      case KeyCode.Period:
         playbackRate = player.playbackRate;
         index = player.playbackRates.indexOf(playbackRate);
         if (index < player.playbackRates.length - 1) {
@@ -162,7 +162,7 @@ class Settings extends Component<any, any> {
           player.dispatchEvent(new SpeedSelectedEvent(player.playbackRate));
         }
         break;
-      case 'Semicolon':
+      case KeyCode.Semicolon:
         if (player.playbackRate !== player.defaultPlaybackRate) {
           logger.debug(`Changing playback rate. ${player.playbackRate} => ${player.defaultPlaybackRate}`);
           player.playbackRate = player.defaultPlaybackRate;
@@ -170,7 +170,7 @@ class Settings extends Component<any, any> {
           player.dispatchEvent(new SpeedSelectedEvent(player.playbackRate));
         }
         break;
-      case 'Comma':
+      case KeyCode.Comma:
         playbackRate = player.playbackRate;
         index = player.playbackRates.indexOf(playbackRate);
         if (index > 0) {

--- a/src/components/speed-menu/speed-menu.tsx
+++ b/src/components/speed-menu/speed-menu.tsx
@@ -1,16 +1,13 @@
 import {h, Component, VNode} from 'preact';
 import {withText} from 'preact-i18n';
 import {connect} from 'react-redux';
-import {bindActions, KeyMap} from '../../utils';
+import {bindActions} from '../../utils';
 import {actions} from '../../reducers/settings';
 import {SmartContainerItem} from '../../components';
 import {IconType} from '../icon';
 import {withPlayer} from '../player';
 import {withLogger} from '../logger';
 import {withEventDispatcher} from '../event-dispatcher';
-import {withKeyboardEvent} from '../keyboard';
-import {SpeedSelectedEvent} from '../../event/events/speed-selected-event';
-import {KeyboardEventHandlers} from '../../types';
 
 const COMPONENT_NAME = 'SpeedMenu';
 
@@ -23,7 +20,6 @@ const COMPONENT_NAME = 'SpeedMenu';
  */
 @connect(null, bindActions(actions))
 @withPlayer
-@withKeyboardEvent(COMPONENT_NAME)
 @withLogger(COMPONENT_NAME)
 @withEventDispatcher(COMPONENT_NAME)
 @withText({
@@ -31,89 +27,6 @@ const COMPONENT_NAME = 'SpeedMenu';
   speedNormalLabelText: 'settings.speedNormal'
 })
 class SpeedMenu extends Component<any, any> {
-  _keyboardEventHandlers: Array<KeyboardEventHandlers> = [
-    {
-      key: {
-        code: KeyMap.PERIOD,
-        shiftKey: true
-      },
-      action: event => {
-        this.handleKeydown(event);
-      }
-    },
-    {
-      key: {
-        code: KeyMap.SEMI_COLON,
-        shiftKey: true
-      },
-      action: event => {
-        this.handleKeydown(event);
-      }
-    },
-    {
-      key: {
-        code: KeyMap.COMMA,
-        shiftKey: true
-      },
-      action: event => {
-        this.handleKeydown(event);
-      }
-    }
-  ];
-
-  /**
-   * after component mounted, set event listener to click outside of the component
-   *
-   * @returns {void}
-   * @memberof SpeedMenu
-   */
-  componentDidMount() {
-    this.props.registerKeyboardEvents(this._keyboardEventHandlers);
-  }
-
-  /**
-   * on settings control key down, update the settings in case of up/down keys
-   *
-   * @method handleKeydown
-   * @param {KeyboardEvent} event - keyboardEvent event
-   * @returns {void}
-   * @memberof SpeedMenu
-   */
-  handleKeydown(event: KeyboardEvent): void {
-    const {player, logger} = this.props;
-    let playbackRate, index;
-    switch (event.keyCode) {
-      case KeyMap.PERIOD:
-        playbackRate = player.playbackRate;
-        index = player.playbackRates.indexOf(playbackRate);
-        if (index < player.playbackRates.length - 1) {
-          logger.debug(`Changing playback rate. ${playbackRate} => ${player.playbackRates[index + 1]}`);
-          player.playbackRate = player.playbackRates[index + 1];
-          this.props.updateOverlayActionIcon(IconType.SpeedUp);
-          player.dispatchEvent(new SpeedSelectedEvent(player.playbackRate));
-        }
-        break;
-      case KeyMap.SEMI_COLON:
-        if (player.playbackRate !== player.defaultPlaybackRate) {
-          logger.debug(`Changing playback rate. ${player.playbackRate} => ${player.defaultPlaybackRate}`);
-          player.playbackRate = player.defaultPlaybackRate;
-          this.props.updateOverlayActionIcon(IconType.Speed);
-          player.dispatchEvent(new SpeedSelectedEvent(player.playbackRate));
-        }
-        break;
-      case KeyMap.COMMA:
-        playbackRate = player.playbackRate;
-        index = player.playbackRates.indexOf(playbackRate);
-        if (index > 0) {
-          logger.debug(`Changing playback rate. ${playbackRate} => ${player.playbackRates[index - 1]}`);
-          player.playbackRate = player.playbackRates[index - 1];
-          this.props.updateOverlayActionIcon(IconType.SpeedDown);
-          player.dispatchEvent(new SpeedSelectedEvent(player.playbackRate));
-        }
-        break;
-    }
-  }
-
   /**
    * change player playback rate and update it in the store state
    *

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,6 +1,6 @@
 export {bindActions} from './bind-actions';
 export {focusElement} from './focus-element';
-export {KeyMap} from './key-map';
+export {KeyMap, KeyCode} from './key-map';
 export {default as getLogger} from './logger';
 export {withKeyboardA11y} from './popup-keyboard-accessibility';
 export * from './time-format';

--- a/src/utils/key-map.ts
+++ b/src/utils/key-map.ts
@@ -1,4 +1,9 @@
-/* eslint-disable   @typescript-eslint/no-use-before-define */
+/**
+ * @deprecated Use the `KeyCode` object instead.
+ * see here: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode
+ * For more information on keyboard event codes, refer to the MDN documentation:
+ * https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code/code_values
+ */
 export const KeyMap: {[key: string]: number} = {
   TAB: 9,
   ENTER: 13,
@@ -17,6 +22,43 @@ export const KeyMap: {[key: string]: number} = {
   SEMI_COLON: 186,
   COMMA: 188,
   PERIOD: 190
+};
+
+export const KeyCode = {
+  Backspace: 'Backspace',
+  Tab: 'Tab',
+  Enter: 'Enter',
+  ShiftLeft: 'ShiftLeft',
+  ShiftRight: 'ShiftRight',
+  ControlLeft: 'ControlLeft',
+  ControlRight: 'ControlRight',
+  AltLeft: 'AltLeft',
+  AltRight: 'AltRight',
+  Pause: 'Pause',
+  CapsLock: 'CapsLock',
+  Escape: 'Escape',
+  Space: 'Space',
+  PageUp: 'PageUp',
+  PageDown: 'PageDown',
+  End: 'End',
+  Home: 'Home',
+  ArrowLeft: 'ArrowLeft',
+  ArrowUp: 'ArrowUp',
+  ArrowRight: 'ArrowRight',
+  ArrowDown: 'ArrowDown',
+  Insert: 'Insert',
+  Delete: 'Delete',
+  KeyP: 'KeyP',
+  KeyC: 'KeyC',
+  KeyF: 'KeyF',
+  KeyM: 'KeyM',
+  Numpad0: 'Numpad0',
+  Semicolon: 'Semicolon',
+  Equal: 'Equal',
+  Comma: 'Comma',
+  Minus: 'Minus',
+  Period: 'Period',
+  Slash: 'Slash'
 };
 
 /**


### PR DESCRIPTION
### Description of the Changes

Please add a detailed description of the change, whether it's an enhancement or a bug fix.
If the PR is related to an open issue please link to it.

**Issue:** Shift+</>  was not working since the events registrations were done inside the speed-menu comp which does not exist until the menu and the submenu are pressed/navigated 

**Fix:** Move the event listener to the parent (settings ) comp which is always existing on the UI

#### Resolves ADA-1296


