### PR TITLE
fix(ADA-1084): Color contrast of v7 player icons

### DIFF
--- a/src/components/bottom-bar/_bottom-bar.scss
+++ b/src/components/bottom-bar/_bottom-bar.scss
@@ -1,5 +1,5 @@
 .player .bottom-bar {
-  background: linear-gradient(180deg, rgba(0, 0, 0, 0.0) 0%, rgba(0, 0, 0, 0.8) 100%);
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.8) 100%);
   color: #fff;
   height: auto;
   width: 100%;

--- a/src/components/bottom-bar/_bottom-bar.scss
+++ b/src/components/bottom-bar/_bottom-bar.scss
@@ -1,5 +1,5 @@
 .player .bottom-bar {
-  background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.6) 100%);
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0.00) 0%, rgba(0, 0, 0, 0.80) 100%);
   color: #fff;
   height: auto;
   width: 100%;

--- a/src/components/bottom-bar/_bottom-bar.scss
+++ b/src/components/bottom-bar/_bottom-bar.scss
@@ -1,5 +1,5 @@
 .player .bottom-bar {
-  background: linear-gradient(180deg, rgba(0, 0, 0, 0.00) 0%, rgba(0, 0, 0, 0.80) 100%);
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0.0) 0%, rgba(0, 0, 0, 0.8) 100%);
   color: #fff;
   height: auto;
   width: 100%;

--- a/src/components/icon/icon.scss
+++ b/src/components/icon/icon.scss
@@ -136,6 +136,7 @@
   background-size: cover;
   background-repeat: no-repeat;
   background-position: 50% 50%;
+  filter: drop-shadow(0px 0px 2px rgba(0, 0, 0, 0.70));
 }
 
 .badge-icon:after {

--- a/src/components/time-display/_time-display.scss
+++ b/src/components/time-display/_time-display.scss
@@ -5,6 +5,7 @@
   font-size: 14px;
   padding: 0 23px;
   font-weight: bold;
+  filter: drop-shadow(0px 0px 2px rgba(0, 0, 0, 0.70));
 }
 
 .touch .time-display {

--- a/src/components/top-bar/_top-bar.scss
+++ b/src/components/top-bar/_top-bar.scss
@@ -1,5 +1,5 @@
 .player .top-bar {
-  background: linear-gradient(0deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.6) 100%);
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0.80) 0%, rgba(0, 0, 0, 0.00) 100%);
   color: #fff;
   visibility: hidden;
   position: relative;

--- a/src/components/top-bar/_top-bar.scss
+++ b/src/components/top-bar/_top-bar.scss
@@ -1,5 +1,5 @@
 .player .top-bar {
-  background: linear-gradient(180deg, rgba(0, 0, 0, 0.8) 0%, rgba(0, 0, 0, 0.0) 100%);
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0.8) 0%, rgba(0, 0, 0, 0) 100%);
   color: #fff;
   visibility: hidden;
   position: relative;

--- a/src/components/top-bar/_top-bar.scss
+++ b/src/components/top-bar/_top-bar.scss
@@ -1,5 +1,5 @@
 .player .top-bar {
-  background: linear-gradient(180deg, rgba(0, 0, 0, 0.80) 0%, rgba(0, 0, 0, 0.00) 100%);
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0.8) 0%, rgba(0, 0, 0, 0.0) 100%);
   color: #fff;
   visibility: hidden;
   position: relative;


### PR DESCRIPTION
### Description of the Changes

**Issue:**
menu controls can have very low contrast ratios

**Fix:**
make the gradient stronger and add a shadow to the icons and the text

#### Resolves [ADA-1084](https://kaltura.atlassian.net/browse/ADA-1084)




[ADA-1084]: https://kaltura.atlassian.net/browse/ADA-1084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ