### PR TITLE
fix(ADA-1062): Change role on Advanced captions settings

### DIFF
--- a/src/components/captions-menu/captions-menu.tsx
+++ b/src/components/captions-menu/captions-menu.tsx
@@ -85,7 +85,7 @@ class CaptionsMenu extends Component<any, any> {
       .sort((a, b) => (a.label > b.label || a.label === 'Off' ? 1 : -1));
 
     if (props.showAdvancedCaptionsMenu) {
-      textOptions.push({label: props.advancedCaptionsSettingsText, value: props.advancedCaptionsSettingsText, active: false, key: 'adv_captions'});
+      textOptions.push({label: props.advancedCaptionsSettingsText, value: props.advancedCaptionsSettingsText, active: false, isAdvanced: true});
     }
 
     if (this.props.asDropdown) {

--- a/src/components/captions-menu/captions-menu.tsx
+++ b/src/components/captions-menu/captions-menu.tsx
@@ -85,7 +85,7 @@ class CaptionsMenu extends Component<any, any> {
       .sort((a, b) => (a.label > b.label || a.label === 'Off' ? 1 : -1));
 
     if (props.showAdvancedCaptionsMenu) {
-      textOptions.push({label: props.advancedCaptionsSettingsText, value: props.advancedCaptionsSettingsText, active: false});
+      textOptions.push({label: props.advancedCaptionsSettingsText, value: props.advancedCaptionsSettingsText, active: false, key: 'adv_captions'});
     }
 
     if (this.props.asDropdown) {

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -271,9 +271,10 @@ class MenuItem extends Component<any, any> {
   render(props: any): VNode<any> {
     const badgeType: string | null =
       props.data.badgeType && !props.isSelected(props.data) ? BadgeType[props.data.badgeType] : BadgeType[props.data.badgeType + 'Active'];
+      const isAdvanced = props.data.value == "Advanced captions settings" ? true : false;
     return (
       <div
-        role="menuitemradio"
+        role={isAdvanced ? "menuitem" : "menuitemradio"}
         tabIndex={-1}
         aria-checked={props.isSelected(props.data) ? 'true' : 'false'}
         ref={element => {

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -271,10 +271,11 @@ class MenuItem extends Component<any, any> {
   render(props: any): VNode<any> {
     const badgeType: string | null =
       props.data.badgeType && !props.isSelected(props.data) ? BadgeType[props.data.badgeType] : BadgeType[props.data.badgeType + 'Active'];
-      const isAdvanced = props?.data?.key == "adv_captions" ? true : false;
+      const menuItemRole = "menuitem";
+      const menuItemRadioRole = "menuitemradio";
     return (
       <div
-        role={isAdvanced ? "menuitem" : "menuitemradio"}
+        role={props?.data?.isAdvanced ? menuItemRole : menuItemRadioRole}
         tabIndex={-1}
         aria-checked={props.isSelected(props.data) ? 'true' : 'false'}
         ref={element => {

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -198,6 +198,8 @@ class Menu extends Component<MenuProps & WithEventManagerProps, any> {
    */
   render(props: any): VNode<any> {
     props.clearAccessibleChildren();
+    const menuItemRole = "menuitem";
+    const menuItemRadioRole = "menuitemradio";
     return props.isMobile || props.isSmallSize ? (
       this.renderNativeSelect(props.labelledby)
     ) : (
@@ -217,6 +219,7 @@ class Menu extends Component<MenuProps & WithEventManagerProps, any> {
             }}
             key={index}
             data={o}
+            role={o?.isAdvanced ? menuItemRole : menuItemRadioRole}
           />
         ))}
       </div>
@@ -271,11 +274,9 @@ class MenuItem extends Component<any, any> {
   render(props: any): VNode<any> {
     const badgeType: string | null =
       props.data.badgeType && !props.isSelected(props.data) ? BadgeType[props.data.badgeType] : BadgeType[props.data.badgeType + 'Active'];
-      const menuItemRole = "menuitem";
-      const menuItemRadioRole = "menuitemradio";
     return (
       <div
-        role={props?.data?.isAdvanced ? menuItemRole : menuItemRadioRole}
+        role={props?.role}
         tabIndex={-1}
         aria-checked={props.isSelected(props.data) ? 'true' : 'false'}
         ref={element => {

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -271,7 +271,7 @@ class MenuItem extends Component<any, any> {
   render(props: any): VNode<any> {
     const badgeType: string | null =
       props.data.badgeType && !props.isSelected(props.data) ? BadgeType[props.data.badgeType] : BadgeType[props.data.badgeType + 'Active'];
-      const isAdvanced = props.data.value == "Advanced captions settings" ? true : false;
+      const isAdvanced = props?.data?.key == "adv_captions" ? true : false;
     return (
       <div
         role={isAdvanced ? "menuitem" : "menuitemradio"}


### PR DESCRIPTION
### Description of the Changes

**Issue:**
The "Advanced captions settings on captions menu has role="menuitemradio" but the option cannot be checked.

**Fix:**
Change role to "menuitem" so that the SR will not announce the option as a checked/not checked option.

#### Resolves [ADA-1062](https://kaltura.atlassian.net/browse/ADA-1062)




[ADA-1062]: https://kaltura.atlassian.net/browse/ADA-1062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ