### PR TITLE
feat(FEC-13945): move core controls to upper bar

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -33,6 +33,10 @@ module.exports = function (config) {
       ChromeHeadlessWithFlags: {
         base: 'ChromeHeadless',
         flags: ['--no-sandbox', '--autoplay-policy=no-user-gesture-required', '--mute-audio', '--max-web-media-player-count=1000']
+      },
+      ChromeWithFlags: {
+        base: 'Chrome',
+        flags: ['--no-sandbox', '--autoplay-policy=no-user-gesture-required', '--mute-audio', '--max-web-media-player-count=1000']
       }
     },
     browsers: ['ChromeHeadlessWithFlags'],

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "prettier": "prettier --write .",
     "test": "karma start karma.conf.js",
     "test:debug": "DEBUG_UNIT_TESTS=1 karma start karma.conf.js --auto-watch --no-single-run --browsers Chrome",
-    "test:watch": "karma start karma.conf.js --auto-watch --no-single-run",
+    "test:watch": "karma start karma.conf.js --auto-watch --no-single-run --browsers ChromeWithFlags",
     "clean": "rimraf ./dist",
     "prebuild": "npm run clean",
     "precommit": "npm run build:prod && npm run type-check && npm run lint:fix",

--- a/src/components/advanced-audio-desc/advanced-audio-desc.tsx
+++ b/src/components/advanced-audio-desc/advanced-audio-desc.tsx
@@ -9,6 +9,9 @@ import {connect} from 'react-redux';
 import {ButtonControl} from '../button-control';
 import {bindActions} from '../../utils';
 import {actions} from '../../reducers/settings';
+import {IconComponent, registerToBottomBar} from '../bottom-bar';
+import {redux} from '../../index';
+import {withPlayer} from '../player';
 
 const COMPONENT_NAME = 'AdvancedAudioDesc';
 
@@ -29,12 +32,38 @@ const mapStateToProps = state => ({
  * @extends {Component}
  */
 @connect(mapStateToProps, bindActions(actions))
+@withPlayer
 @withEventDispatcher(COMPONENT_NAME)
 @withText({AdvancedAudioDescText: 'settings.advancedAudioDescription'})
-class AdvancedAudioDesc extends Component<any, any> {
+class AdvancedAudioDesc extends Component<any, any> implements IconComponent {
   constructor(props: any) {
     super();
     this.state = {toggle: false};
+    registerToBottomBar(COMPONENT_NAME, props.player, () => this.registerComponent());
+  }
+
+  registerComponent(): any {
+    return {
+      ariaLabel: () => this.getComponentText(),
+      displayName: COMPONENT_NAME,
+      order: 5,
+      svgIcon: () => this.getSvgIcon(),
+      onClick: () => this.onClick(),
+      component: () => {
+        return getComp({...this.props, classNames: [style.upperBarIcon]});
+      },
+      selfManagement: true
+    };
+  }
+
+  getComponentText = (): any => {
+    return this.props.AdvancedAudioDescText;
+  }
+
+  getSvgIcon = (): any => {
+    return {
+      type: redux.useStore().getState().settings.advancedAudioDesc ? IconType.AdvancedAudioDescriptionActive : IconType.AdvancedAudioDescription
+    };
   }
 
   /**
@@ -69,7 +98,7 @@ class AdvancedAudioDesc extends Component<any, any> {
    */
   render({AdvancedAudioDescText, innerRef}: any): VNode<any> | undefined {
     return !this._shouldRender() ? undefined : (
-      <ButtonControl name={COMPONENT_NAME} className={style.noIdleControl}>
+      <ButtonControl name={COMPONENT_NAME} className={[style.noIdleControl, this.props.classNames ? this.props.classNames.join(' ') : ''].join(' ')}>
         <Tooltip label={AdvancedAudioDescText}>
           <Button tabIndex="0" aria-label={AdvancedAudioDescText} className={`${style.controlButton}`} ref={innerRef} onClick={this.onClick}>
             <Icon type={this.state.toggle ? IconType.AdvancedAudioDescriptionActive : IconType.AdvancedAudioDescription} />
@@ -78,6 +107,10 @@ class AdvancedAudioDesc extends Component<any, any> {
       </ButtonControl>
     );
   }
+}
+
+const getComp = (props: any): VNode => {
+  return <AdvancedAudioDesc {...props} />;
 }
 
 AdvancedAudioDesc.displayName = COMPONENT_NAME;

--- a/src/components/advanced-audio-desc/advanced-audio-desc.tsx
+++ b/src/components/advanced-audio-desc/advanced-audio-desc.tsx
@@ -50,9 +50,9 @@ class AdvancedAudioDesc extends Component<any, any> implements IconComponent {
       svgIcon: () => this.getSvgIcon(),
       onClick: () => this.onClick(),
       component: () => {
-        return getComp({...this.props, classNames: [style.upperBarIcon]});
+        return getComponent({...this.props, classNames: [style.upperBarIcon]});
       },
-      selfManagement: true
+      shouldHandleOnClick: false
     };
   }
 
@@ -109,7 +109,7 @@ class AdvancedAudioDesc extends Component<any, any> implements IconComponent {
   }
 }
 
-const getComp = (props: any): VNode => {
+const getComponent = (props: any): VNode => {
   return <AdvancedAudioDesc {...props} />;
 }
 

--- a/src/components/bottom-bar/_bottom-bar.scss
+++ b/src/components/bottom-bar/_bottom-bar.scss
@@ -49,6 +49,15 @@
   .bottom-bar-area {
     position: relative;
     pointer-events: none;
+
+    .time-display {
+      padding: 0;
+      position: absolute;
+      bottom: 20px;
+      font-size: 12px;
+      line-height: normal;
+      font-weight: 400;
+    }
   }
 
   .control-button-container {
@@ -66,16 +75,10 @@
       margin: 0;
     }
   }
-  &.size-xs {
-    .left-controls {
-      .control-button-container {
-        display: none;
-      }
-    }
-  }
+
   &.size-xs,
   &.size-sm {
-    .control-button-container {
+    .control-button-container:not(.upper-bar-icon) {
       margin: 0 3px;
     }
   }

--- a/src/components/bottom-bar/bottom-bar-registry-manager.ts
+++ b/src/components/bottom-bar/bottom-bar-registry-manager.ts
@@ -12,7 +12,7 @@ export class BottomBarRegistry {
   }
 
   public register(component: string, componentIcon: any): void {
-    if(!this._registry.get(component)) {
+    if (!this._registry.get(component)) {
       this._registry.set(component, componentIcon);
     }
   }
@@ -35,8 +35,8 @@ export class BottomBarRegistry {
 export const bottomBarRegistryManager: string = 'bottomBarRegistryManager';
 
 export const registerToBottomBar = (compName: string, player: any, getIconDtoCallback: () => any): void => {
-  const bottomBarRegistry = player?.getService(bottomBarRegistryManager) as BottomBarRegistry || undefined;
+  const bottomBarRegistry = (player?.getService(bottomBarRegistryManager) as BottomBarRegistry) || undefined;
   if (bottomBarRegistry && !bottomBarRegistry.registry.get(compName)) {
     bottomBarRegistry.register(compName, getIconDtoCallback());
   }
-}
+};

--- a/src/components/bottom-bar/bottom-bar-registry-manager.ts
+++ b/src/components/bottom-bar/bottom-bar-registry-manager.ts
@@ -1,0 +1,42 @@
+export interface IconComponent {
+  registerComponent(): any;
+  getSvgIcon(): any;
+  getComponentText(): any;
+}
+
+export class BottomBarRegistry {
+  private _registry: Map<string, any>;
+
+  constructor() {
+    this._registry = new Map();
+  }
+
+  public register(component: string, componentIcon: any): void {
+    if(!this._registry.get(component)) {
+      this._registry.set(component, componentIcon);
+    }
+  }
+
+  public unregister(component: string): void {
+    if (this._registry.get(component)) {
+      this._registry.delete(component);
+    }
+  }
+
+  public get registry(): Map<string, any> {
+    return this._registry;
+  }
+
+  public clear(): void {
+    this._registry.clear();
+  }
+}
+
+export const bottomBarRegistryManager: string = 'bottomBarRegistryManager';
+
+export const registerToBottomBar = (compName: string, player: any, getIconDtoCallback: () => any): void => {
+  const bottomBarRegistry = player?.getService(bottomBarRegistryManager) as BottomBarRegistry || undefined;
+  if (bottomBarRegistry && !bottomBarRegistry.registry.get(compName)) {
+    bottomBarRegistry.register(compName, getIconDtoCallback());
+  }
+}

--- a/src/components/bottom-bar/bottom-bar-registry-manager.ts
+++ b/src/components/bottom-bar/bottom-bar-registry-manager.ts
@@ -11,20 +11,20 @@ export class BottomBarRegistryManager {
     this._registry = new Map();
   }
 
-  public register(component: string, componentIcon: any): void {
-    if (!this._registry.get(component)) {
-      this._registry.set(component, componentIcon);
+  public register(componentName: string, componentIcon: any): void {
+    if (!this.getComponentItem(componentName)) {
+      this._registry.set(componentName, componentIcon);
     }
   }
 
-  public unregister(component: string): void {
-    if (this._registry.get(component)) {
-      this._registry.delete(component);
+  public unregister(componentName: string): void {
+    if (this.getComponentItem(componentName)) {
+      this._registry.delete(componentName);
     }
   }
 
-  public get registry(): Map<string, any> {
-    return this._registry;
+  public getComponentItem(componentName: string): any {
+    return this._registry.get(componentName);
   }
 
   public clear(): void {
@@ -34,9 +34,9 @@ export class BottomBarRegistryManager {
 
 export const bottomBarRegistryManager: string = 'bottomBarRegistryManager';
 
-export const registerToBottomBar = (compName: string, player: any, getIconDtoCallback: () => any): void => {
+export const registerToBottomBar = (componentName: string, player: any, getIconDtoCallback: () => any): void => {
   const bottomBarRegistry = (player?.getService(bottomBarRegistryManager) as BottomBarRegistryManager) || undefined;
-  if (bottomBarRegistry && !bottomBarRegistry.registry.get(compName)) {
-    bottomBarRegistry.register(compName, getIconDtoCallback());
+  if (bottomBarRegistry && !bottomBarRegistry.getComponentItem(componentName)) {
+    bottomBarRegistry.register(componentName, getIconDtoCallback());
   }
 };

--- a/src/components/bottom-bar/bottom-bar-registry-manager.ts
+++ b/src/components/bottom-bar/bottom-bar-registry-manager.ts
@@ -4,7 +4,7 @@ export interface IconComponent {
   getComponentText(): any;
 }
 
-export class BottomBarRegistry {
+export class BottomBarRegistryManager {
   private _registry: Map<string, any>;
 
   constructor() {
@@ -35,7 +35,7 @@ export class BottomBarRegistry {
 export const bottomBarRegistryManager: string = 'bottomBarRegistryManager';
 
 export const registerToBottomBar = (compName: string, player: any, getIconDtoCallback: () => any): void => {
-  const bottomBarRegistry = (player?.getService(bottomBarRegistryManager) as BottomBarRegistry) || undefined;
+  const bottomBarRegistry = (player?.getService(bottomBarRegistryManager) as BottomBarRegistryManager) || undefined;
   if (bottomBarRegistry && !bottomBarRegistry.registry.get(compName)) {
     bottomBarRegistry.register(compName, getIconDtoCallback());
   }

--- a/src/components/bottom-bar/bottom-bar.tsx
+++ b/src/components/bottom-bar/bottom-bar.tsx
@@ -9,7 +9,7 @@ import {PLAYER_BREAK_POINTS, TimeDisplayPlaybackContainer} from '../../component
 import {withEventManager} from '../../event';
 import {withPlayer} from '../player';
 import {calculateControlsSize, filterControlsByPriority} from './bettom-bar-utils';
-import {BottomBarRegistry, bottomBarRegistryManager} from './bottom-bar-registry-manager';
+import {BottomBarRegistryManager, bottomBarRegistryManager} from './bottom-bar-registry-manager';
 
 
 const LOWER_PRIORITY_CONTROLS: string[][] = [
@@ -69,7 +69,7 @@ class BottomBar extends Component<any, any> {
       .map(control => control.displayName)
       .forEach(controlName => (this.presetControls[controlName] = true));
     this.state = {fitInControls: this.presetControls, activeControls: this.presetControls};
-    props.player.registerService(bottomBarRegistryManager, new BottomBarRegistry());
+    props.player.registerService(bottomBarRegistryManager, new BottomBarRegistryManager());
   }
 
   /**

--- a/src/components/bottom-bar/bottom-bar.tsx
+++ b/src/components/bottom-bar/bottom-bar.tsx
@@ -2,23 +2,29 @@ import style from '../../styles/style.scss';
 import {h, Component, createRef, RefObject} from 'preact';
 import {bindActions} from '../../utils/bind-actions';
 import {actions} from '../../reducers/shell';
+import {actions as bottomBarActions} from '../../reducers/bottom-bar';
 import {connect} from 'react-redux';
 import {PlayerArea} from '../../components/player-area';
-import {PLAYER_BREAK_POINTS} from '../../components';
+import {PLAYER_BREAK_POINTS, TimeDisplayPlaybackContainer} from '../../components';
 import {withEventManager} from '../../event';
 import {withPlayer} from '../player';
 import {calculateControlsSize, filterControlsByPriority} from './bettom-bar-utils';
+import {BottomBarRegistry, bottomBarRegistryManager} from './bottom-bar-registry-manager';
+
 
 const LOWER_PRIORITY_CONTROLS: string[][] = [
-  ['AdvancedAudioDesc'],
-  ['VrStereo'],
-  ['Rewind', 'Forward'],
-  ['ClosedCaptions'],
   ['PictureInPicture'],
+  ['VrStereo'],
+  ['TimeDisplayPlaybackContainer'],
+  ['AdvancedAudioDesc'],
+  ['ClosedCaptions'],
+  ['CaptionsControl'],
   ['Cast']
 ];
 const CRL_WIDTH = 32;
 const CRL_MARGIN = 12;
+
+const TIME_DISPLAY_COMP: string = 'TimeDisplayPlaybackContainer';
 
 /**
  * mapping state to props
@@ -45,7 +51,7 @@ const COMPONENT_NAME = 'BottomBar';
  */
 @withPlayer
 @withEventManager
-@connect(mapStateToProps, bindActions(actions))
+@connect(mapStateToProps, bindActions({...actions, ...bottomBarActions}))
 class BottomBar extends Component<any, any> {
   bottomBarContainerRef: RefObject<HTMLDivElement> = createRef<HTMLDivElement>();
   presetControls: {[controlName: string]: boolean} = {};
@@ -63,6 +69,7 @@ class BottomBar extends Component<any, any> {
       .map(control => control.displayName)
       .forEach(controlName => (this.presetControls[controlName] = true));
     this.state = {fitInControls: this.presetControls, activeControls: this.presetControls};
+    props.player.registerService(bottomBarRegistryManager, new BottomBarRegistry());
   }
 
   /**
@@ -108,9 +115,11 @@ class BottomBar extends Component<any, any> {
       const controlsToRemove = filterControlsByPriority(currentMinBreakPointWidth, currentBarWidth, currentControlWidth, lowerPriorityControls);
       const removedControls = {};
       controlsToRemove.forEach(control => (removedControls[control] = false));
+      this.props.updateControlsToMove(controlsToRemove);
       this.setState({fitInControls: {...this.presetControls, ...removedControls}});
     } else {
       this.setState({fitInControls: {...this.presetControls}});
+      this.props.updateControlsToMove([]);
     }
   }
 
@@ -127,10 +136,12 @@ class BottomBar extends Component<any, any> {
       styleClass.push(style.hide);
     }
 
+    const shouldRenderTimeDisplay: boolean = this.presetControls[TIME_DISPLAY_COMP] && !this.state.fitInControls[TIME_DISPLAY_COMP];
     return (
       <div className={styleClass.join(' ')}>
         <div className={style.bottomBarArea}>
           <PlayerArea shouldUpdate={true} name={'BottomBar'}>
+            {shouldRenderTimeDisplay && <TimeDisplayPlaybackContainer/>}
             {props.children}
           </PlayerArea>
         </div>

--- a/src/components/bottom-bar/index.ts
+++ b/src/components/bottom-bar/index.ts
@@ -1,1 +1,2 @@
 export {BottomBar} from './bottom-bar';
+export * from './bottom-bar-registry-manager';

--- a/src/components/captions-control/captions-control-mini.tsx
+++ b/src/components/captions-control/captions-control-mini.tsx
@@ -1,4 +1,4 @@
-import {createPortal, useEffect} from 'preact/compat';
+import {createPortal} from 'preact/compat';
 import {registerToBottomBar} from '../bottom-bar';
 import {redux, ReservedPresetNames, style} from '../../index';
 import {Icon, IconType} from '../icon';
@@ -7,7 +7,7 @@ import {ButtonControl} from '../button-control';
 import {Tooltip} from '../tooltip';
 import {Button} from '../button';
 import {CVAAOverlay} from '../cvaa-overlay';
-import {useState} from 'preact/hooks';
+import {useState, useEffect} from 'preact/hooks';
 import {connect} from 'react-redux';
 import {Text} from 'preact-i18n';
 import {CaptionsMenu} from '../captions-menu';

--- a/src/components/captions-control/captions-control-mini.tsx
+++ b/src/components/captions-control/captions-control-mini.tsx
@@ -1,0 +1,112 @@
+import {createPortal, useEffect} from 'preact/compat';
+import {registerToBottomBar} from '../bottom-bar';
+import {redux, ReservedPresetNames, style} from '../../index';
+import {Icon, IconType} from '../icon';
+import {h, VNode} from 'preact';
+import {ButtonControl} from '../button-control';
+import {Tooltip} from '../tooltip';
+import {Button} from '../button';
+import {CVAAOverlay} from '../cvaa-overlay';
+import {useState} from 'preact/hooks';
+import {connect} from 'react-redux';
+import {Text} from 'preact-i18n';
+import {CaptionsMenu} from '../captions-menu';
+import {SmartContainer} from '../smart-container';
+import {CaptionsControl} from './captions-control';
+
+const mapStateToProps = state => ({
+  controlsToMove: state.bottomBar.controlsToMove
+});
+
+const COMPONENT_NAME = 'CaptionsControlMini';
+const CaptionsControlMini = connect(mapStateToProps)((props, context) => {
+  const [shouldRender, setShouldRender] = useState(false);
+
+  const {player} = context;
+  const {controlsToMove} = props;
+  const targetId: HTMLDivElement | Document = (document.getElementById(player.config.targetId) as HTMLDivElement) || document;
+  const portalSelector = `.overlay-portal`;
+  let removeOverlay: any = null;
+
+  useEffect(() => {
+    registerToBottomBar(CaptionsControl.displayName, player, () => registerComponent());
+  }, []);
+
+  const registerComponent = (): any => {
+    return {
+      ariaLabel: props.captionsLabelText,
+      displayName: COMPONENT_NAME,
+      order: 5,
+      svgIcon: {type: IconType.ClosedCaptionsOn},
+      onClick: () => onButtonClick(),
+      component: () => {
+        return getComp(props);
+      },
+      selfManagement: true
+    };
+  };
+
+  useEffect(() => {
+    setShouldRender(controlsToMove.includes(CaptionsControl.displayName));
+  }, [controlsToMove]);
+
+  const getIsTextOnFromStore = (): boolean => {
+    return redux.useStore().getState().settings.isTextOn;
+  };
+
+  const removeCaptionsOverlay = () => {
+    if (removeOverlay) {
+      removeOverlay();
+      removeOverlay = null;
+    }
+  }
+
+  const openCVAAOverlay = () => {
+    removeCaptionsOverlay();
+    removeOverlay = player.ui.addComponent({
+      label: 'cvaa-overlay',
+      area: 'GuiArea',
+      presets: [ReservedPresetNames.Playback, ReservedPresetNames.Live],
+      get: () => {
+        return (
+          createPortal(<CVAAOverlay onClose={() => removeCaptionsOverlay()}/>, targetId.querySelector(portalSelector)!)
+        )}
+    });
+  };
+
+  const onButtonClick = () => {
+    removeOverlay = player.ui.addComponent({
+      label: 'captions-overlay',
+      area: 'GuiArea',
+      presets: [ReservedPresetNames.Playback, ReservedPresetNames.Live],
+      get: () => {
+        return (
+        <SmartContainer targetId={player.config.targetId} onClose={() => removeCaptionsOverlay()} title={<Text id="controls.language" />}>
+          <CaptionsMenu asDropdown={false} onAdvancedCaptionsClick={openCVAAOverlay}/>
+        </SmartContainer>
+        )}
+    });
+  };
+
+  return shouldRender ? (
+    <ButtonControl name={COMPONENT_NAME} className={style.upperBarIcon}>
+      <Tooltip label={props.captionsLabelText}>
+        <Button
+          tabIndex="0"
+          aria-label={props.captionsLabelText}
+          aria-haspopup="true"
+          className={style.controlButton}
+          onClick={onButtonClick}>
+          <Icon type={getIsTextOnFromStore() ? IconType.ClosedCaptionsOn : IconType.ClosedCaptionsOff} />
+        </Button>
+      </Tooltip>
+    </ButtonControl>
+  ) : undefined;
+});
+
+const getComp = (props: any): VNode => {
+  return <CaptionsControlMini {...props} />;
+}
+
+CaptionsControlMini.displayName = COMPONENT_NAME;
+export {CaptionsControlMini};

--- a/src/components/captions-control/captions-control-mini.tsx
+++ b/src/components/captions-control/captions-control-mini.tsx
@@ -24,7 +24,7 @@ const CaptionsControlMini = connect(mapStateToProps)((props, context) => {
 
   const {player} = context;
   const {controlsToMove} = props;
-  const targetId: HTMLDivElement | Document = (document.getElementById(player.config.targetId) as HTMLDivElement) || document;
+  const targetOverlayEl: HTMLDivElement | Document = (document.getElementById(player.config.targetId) as HTMLDivElement) || document;
   const portalSelector = `.overlay-portal`;
   let removeOverlay: any = null;
 
@@ -40,9 +40,9 @@ const CaptionsControlMini = connect(mapStateToProps)((props, context) => {
       svgIcon: {type: IconType.ClosedCaptionsOn},
       onClick: () => onButtonClick(),
       component: () => {
-        return getComp(props);
+        return getComponent(props);
       },
-      selfManagement: true
+      shouldHandleOnClick: false
     };
   };
 
@@ -50,8 +50,8 @@ const CaptionsControlMini = connect(mapStateToProps)((props, context) => {
     setShouldRender(controlsToMove.includes(CaptionsControl.displayName));
   }, [controlsToMove]);
 
-  const getIsTextOnFromStore = (): boolean => {
-    return redux.useStore().getState().settings.isTextOn;
+  const isCaptionsEnabled = (): boolean => {
+    return redux.useStore().getState().settings.isCaptionsEnabled;
   };
 
   const removeCaptionsOverlay = () => {
@@ -69,7 +69,7 @@ const CaptionsControlMini = connect(mapStateToProps)((props, context) => {
       presets: [ReservedPresetNames.Playback, ReservedPresetNames.Live],
       get: () => {
         return (
-          createPortal(<CVAAOverlay onClose={() => removeCaptionsOverlay()}/>, targetId.querySelector(portalSelector)!)
+          createPortal(<CVAAOverlay onClose={() => removeCaptionsOverlay()}/>, targetOverlayEl.querySelector(portalSelector)!)
         )}
     });
   };
@@ -97,14 +97,14 @@ const CaptionsControlMini = connect(mapStateToProps)((props, context) => {
           aria-haspopup="true"
           className={style.controlButton}
           onClick={onButtonClick}>
-          <Icon type={getIsTextOnFromStore() ? IconType.ClosedCaptionsOn : IconType.ClosedCaptionsOff} />
+          <Icon type={isCaptionsEnabled() ? IconType.ClosedCaptionsOn : IconType.ClosedCaptionsOff} />
         </Button>
       </Tooltip>
     </ButtonControl>
   ) : undefined;
 });
 
-const getComp = (props: any): VNode => {
+const getComponent = (props: any): VNode => {
   return <CaptionsControlMini {...props} />;
 }
 

--- a/src/components/closed-captions/closed-captions.tsx
+++ b/src/components/closed-captions/closed-captions.tsx
@@ -60,28 +60,28 @@ const ClosedCaptions = connect(mapStateToProps)(
           svgIcon: () => getSvgIcon(),
           onClick: () => onClick(),
           component: () => {
-            return getComp({...props, classNames: [style.upperBarIcon]});
+            return getComponent({...props, classNames: [style.upperBarIcon]});
           },
-          selfManagement: true
+          shouldHandleOnClick: false
         };
       };
 
-      const getIsTextOnFromStore = (): boolean => {
-        return redux.useStore().getState().settings.isTextOn;
+      const isCaptionsEnabled = (): boolean => {
+        return redux.useStore().getState().settings.isCaptionsEnabled;
       };
 
       const getAriaLabel = (): any => {
-        return getIsTextOnFromStore() ? props.closedCaptionsOnText : props.closedCaptionsOffText;
+        return isCaptionsEnabled() ? props.closedCaptionsOnText : props.closedCaptionsOffText;
       };
 
       const getSvgIcon = (): any => {
         return {
-          type: getIsTextOnFromStore() ? IconType.ClosedCaptionsOn : IconType.ClosedCaptionsOff
+          type: isCaptionsEnabled() ? IconType.ClosedCaptionsOn : IconType.ClosedCaptionsOff
         };
       };
 
       const onClick = () => {
-        const isCCOn = getIsTextOnFromStore();
+        const isCCOn = isCaptionsEnabled();
         props.notifyClick(isCCOn);
         isCCOn ? player.hideTextTrack() : player.showTextTrack();
       };
@@ -128,7 +128,7 @@ const ClosedCaptions = connect(mapStateToProps)(
   )
 );
 
-const getComp = (props: any): VNode => {
+const getComponent = (props: any): VNode => {
   return <ClosedCaptions {...props} />;
 }
 

--- a/src/components/closed-captions/closed-captions.tsx
+++ b/src/components/closed-captions/closed-captions.tsx
@@ -1,5 +1,5 @@
 import style from '../../styles/style.scss';
-import {h} from 'preact';
+import {h, VNode} from 'preact';
 import {useEffect, useState} from 'preact/hooks';
 import {withText} from 'preact-i18n';
 import {Icon, IconType} from '../icon';
@@ -9,6 +9,9 @@ import {withLogger} from '../logger';
 import {Tooltip} from '../tooltip';
 import {Button} from '../button';
 import {ButtonControl} from '../button-control';
+import {registerToBottomBar} from '../bottom-bar';
+import {redux} from '../../index';
+
 /**
  * mapping state to props
  * @param {*} state - redux store state
@@ -16,6 +19,8 @@ import {ButtonControl} from '../button-control';
  */
 const mapStateToProps = state => ({
   textTracks: state.engine.textTracks,
+  showCCButton: state.config.showCCButton,
+  openMenuFromCCButton: state.config.openMenuFromCCButton
 });
 
 const COMPONENT_NAME = 'ClosedCaptions';
@@ -43,8 +48,50 @@ const ClosedCaptions = connect(mapStateToProps)(
           setCCOn(activeTextTrack?.language !== 'off');
         }, [activeTextTrack]);
 
+        useEffect(() => {
+          registerToBottomBar(COMPONENT_NAME, player, () => registerComponent());
+        }, []);
+
+      const registerComponent = (): any => {
+        return {
+          ariaLabel: () => getAriaLabel(),
+          displayName: COMPONENT_NAME,
+          order: 5,
+          svgIcon: () => getSvgIcon(),
+          onClick: () => onClick(),
+          component: () => {
+            return getComp({...props, classNames: [style.upperBarIcon]});
+          },
+          selfManagement: true
+        };
+      };
+
+      const getIsTextOnFromStore = (): boolean => {
+        return redux.useStore().getState().settings.isTextOn;
+      };
+
+      const getAriaLabel = (): any => {
+        return getIsTextOnFromStore() ? props.closedCaptionsOnText : props.closedCaptionsOffText;
+      };
+
+      const getSvgIcon = (): any => {
+        return {
+          type: getIsTextOnFromStore() ? IconType.ClosedCaptionsOn : IconType.ClosedCaptionsOff
+        };
+      };
+
+      const onClick = () => {
+        const isCCOn = getIsTextOnFromStore();
+        props.notifyClick(isCCOn);
+        isCCOn ? player.hideTextTrack() : player.showTextTrack();
+      };
+
+        const shouldRender = !!textTracks?.length && props.showCCButton && !props.openMenuFromCCButton;
+        props.onToggle(COMPONENT_NAME, shouldRender);
+        if (!shouldRender) return undefined;
+
         return (
-          <ButtonControl name={COMPONENT_NAME}>
+          <ButtonControl name={COMPONENT_NAME} className={props.classNames ? props.classNames.join(' ') : ''}>
             {ccOn ? (
               <Tooltip label={props.closedCaptionsOnText}>
                 <Button
@@ -80,6 +127,10 @@ const ClosedCaptions = connect(mapStateToProps)(
     )
   )
 );
+
+const getComp = (props: any): VNode => {
+  return <ClosedCaptions {...props} />;
+}
 
 ClosedCaptions.displayName = COMPONENT_NAME;
 export {ClosedCaptions};

--- a/src/components/engine-connector/engine-connector.tsx
+++ b/src/components/engine-connector/engine-connector.tsx
@@ -5,6 +5,7 @@ import {default as reduce, actions as EngineActions} from '../../reducers/engine
 import {actions as LoadingActions} from '../../reducers/loading';
 import {actions as ShellActions} from '../../reducers/shell';
 import {actions as SeekbarActions} from '../../reducers/seekbar';
+import {actions as SettingsActions} from '../../reducers/settings';
 import {withPlayer} from '../player';
 import {withEventManager} from '../../event';
 import {withLogger} from '../logger';
@@ -18,10 +19,11 @@ type EngineConnectorProps = {
   eventManager: EventManager;
 } & typeof EngineActions &
   typeof LoadingActions &
-  typeof ShellActions & {seekbarUpdateCurrentTime: typeof SeekbarActions.updateCurrentTime};
+  typeof ShellActions & {seekbarUpdateCurrentTime: typeof SeekbarActions.updateCurrentTime} & {updateIsTextOn: typeof SettingsActions.updateIsTextOn};
 
 // Rename so it doesn't clash with the equivalent action in engine state
 const seekbarUpdateCurrentTime = SeekbarActions.updateCurrentTime;
+const updateIsTextOn = SettingsActions.updateIsTextOn;
 
 const COMPONENT_NAME = 'EngineConnector';
 
@@ -32,7 +34,7 @@ const COMPONENT_NAME = 'EngineConnector';
  * @example <EngineConnector />
  * @extends {Component}
  */
-@connect(reduce, bindActions({...EngineActions, ...LoadingActions, ...ShellActions, seekbarUpdateCurrentTime}))
+@connect(reduce, bindActions({...EngineActions, ...LoadingActions, ...ShellActions, seekbarUpdateCurrentTime, updateIsTextOn}))
 @withPlayer
 @withEventManager
 @withLogger(COMPONENT_NAME)
@@ -193,6 +195,7 @@ class EngineConnector extends Component<EngineConnectorProps, any> {
     eventManager.listen(player, player.Event.Core.TEXT_TRACK_CHANGED, () => {
       let tracks = player.getTracks(TrackType.TEXT);
       this.props.updateTextTracks(tracks);
+      this.props.updateIsTextOn(tracks.find(track => track.active)?.language !== 'off');
     });
 
     eventManager.listen(player, player.Event.Core.AUDIO_TRACK_CHANGED, () => {

--- a/src/components/engine-connector/engine-connector.tsx
+++ b/src/components/engine-connector/engine-connector.tsx
@@ -19,11 +19,11 @@ type EngineConnectorProps = {
   eventManager: EventManager;
 } & typeof EngineActions &
   typeof LoadingActions &
-  typeof ShellActions & {seekbarUpdateCurrentTime: typeof SeekbarActions.updateCurrentTime} & {updateIsTextOn: typeof SettingsActions.updateIsTextOn};
+  typeof ShellActions & {seekbarUpdateCurrentTime: typeof SeekbarActions.updateCurrentTime} & {updateIsCaptionsEnabled: typeof SettingsActions.updateIsCaptionsEnabled};
 
 // Rename so it doesn't clash with the equivalent action in engine state
 const seekbarUpdateCurrentTime = SeekbarActions.updateCurrentTime;
-const updateIsTextOn = SettingsActions.updateIsTextOn;
+const updateIsCaptionsEnabled = SettingsActions.updateIsCaptionsEnabled;
 
 const COMPONENT_NAME = 'EngineConnector';
 
@@ -34,7 +34,7 @@ const COMPONENT_NAME = 'EngineConnector';
  * @example <EngineConnector />
  * @extends {Component}
  */
-@connect(reduce, bindActions({...EngineActions, ...LoadingActions, ...ShellActions, seekbarUpdateCurrentTime, updateIsTextOn}))
+@connect(reduce, bindActions({...EngineActions, ...LoadingActions, ...ShellActions, seekbarUpdateCurrentTime, updateIsCaptionsEnabled}))
 @withPlayer
 @withEventManager
 @withLogger(COMPONENT_NAME)
@@ -195,7 +195,7 @@ class EngineConnector extends Component<EngineConnectorProps, any> {
     eventManager.listen(player, player.Event.Core.TEXT_TRACK_CHANGED, () => {
       let tracks = player.getTracks(TrackType.TEXT);
       this.props.updateTextTracks(tracks);
-      this.props.updateIsTextOn(tracks.find(track => track.active)?.language !== 'off');
+      this.props.updateIsCaptionsEnabled(tracks.find(track => track.active)?.language !== 'off');
     });
 
     eventManager.listen(player, player.Event.Core.AUDIO_TRACK_CHANGED, () => {

--- a/src/components/picture-in-picture/picture-in-picture.tsx
+++ b/src/components/picture-in-picture/picture-in-picture.tsx
@@ -74,9 +74,9 @@ class PictureInPicture extends Component<any, any> implements IconComponent {
       svgIcon: () => this.getSvgIcon(),
       onClick: () => this.togglePip(),
       component: () => {
-        return getComp({...this.props, classNames: [style.upperBarIcon]});
+        return getComponent({...this.props, classNames: [style.upperBarIcon]});
       },
-      selfManagement: true
+      shouldHandleOnClick: false
     };
   }
 
@@ -156,7 +156,7 @@ class PictureInPicture extends Component<any, any> implements IconComponent {
   }
 }
 
-const getComp = (props: any): VNode => {
+const getComponent = (props: any): VNode => {
   return <PictureInPicture {...props} />;
 }
 

--- a/src/components/picture-in-picture/picture-in-picture.tsx
+++ b/src/components/picture-in-picture/picture-in-picture.tsx
@@ -14,6 +14,7 @@ import {bindActions} from '../../utils';
 import {actions as shellActions} from '../../reducers/shell';
 import {ButtonControl} from '../button-control';
 import {KeyboardEventHandlers} from '../../types';
+import {registerToBottomBar, IconComponent} from '../bottom-bar';
 
 /**
  * mapping state to props
@@ -43,7 +44,7 @@ const COMPONENT_NAME = 'PictureInPicture';
   pictureInPictureText: 'controls.pictureInPicture',
   pictureInPictureExitText: 'controls.pictureInPictureExit'
 })
-class PictureInPicture extends Component<any, any> {
+class PictureInPicture extends Component<any, any> implements IconComponent {
   _keyboardEventHandlers: Array<KeyboardEventHandlers> = [
     {
       key: {
@@ -55,6 +56,39 @@ class PictureInPicture extends Component<any, any> {
       }
     }
   ];
+
+  /**
+   * Creates an instance of PictureInPicture.
+   * @memberof PictureInPicture
+   */
+  constructor(props: any) {
+    super(props);
+    registerToBottomBar(COMPONENT_NAME, props.player, () => this.registerComponent());
+  }
+
+  registerComponent(): any {
+    return {
+      ariaLabel: () => this.getComponentText(),
+      displayName: COMPONENT_NAME,
+      order: 5,
+      svgIcon: () => this.getSvgIcon(),
+      onClick: () => this.togglePip(),
+      component: () => {
+        return getComp({...this.props, classNames: [style.upperBarIcon]});
+      },
+      selfManagement: true
+    };
+  }
+
+  getSvgIcon = (): any => {
+    return {
+      type: this.props.player.isInPictureInPicture() ? IconType.PictureInPictureStop : IconType.PictureInPictureStart
+    };
+  }
+
+  getComponentText = (): string => {
+    return this.props.player.isInPictureInPicture() ? this.props.pictureInPictureExitText : this.props.pictureInPictureText;
+  }
 
   /**
    * component mounted
@@ -104,7 +138,7 @@ class PictureInPicture extends Component<any, any> {
   render(): VNode<any> | undefined {
     if (this._shouldRender()) {
       return (
-        <ButtonControl name={COMPONENT_NAME}>
+        <ButtonControl name={COMPONENT_NAME} className={this.props.classNames ? this.props.classNames.join(' ') : ''}>
           <Tooltip label={this.props.isInPictureInPicture ? this.props.pictureInPictureExitText : this.props.pictureInPictureText}>
             <Button
               tabIndex="0"
@@ -120,6 +154,10 @@ class PictureInPicture extends Component<any, any> {
       );
     }
   }
+}
+
+const getComp = (props: any): VNode => {
+  return <PictureInPicture {...props} />;
 }
 
 PictureInPicture.displayName = COMPONENT_NAME;

--- a/src/components/scrollable/scrollable.tsx
+++ b/src/components/scrollable/scrollable.tsx
@@ -1,6 +1,6 @@
 import {ComponentChildren, h} from 'preact';
 //@ts-ignore
-import {useState, useRef, useMemo, MutableRef} from 'preact/hooks';
+import {useState, useRef, useMemo, MutableRef, useLayoutEffect} from 'preact/hooks';
 import styles from '../../styles/style.scss';
 
 const SCROLL_BAR_TIMEOUT = 250;
@@ -17,6 +17,7 @@ const Scrollable = ({children, isVertical}: {children: ComponentChildren; isVert
   const ref: MutableRef<HTMLDivElement | null> = useRef<HTMLDivElement | null>(null);
   const [scrolling, setScrolling] = useState<boolean>(false);
   const [scrollTimeoutId, setScrollTimeoutId] = useState<number>(-1);
+  const [scrollableHeight, setScrollableHeight] = useState<string>('');
 
   const handleScroll = (): void => {
     clearTimeout(scrollTimeoutId);
@@ -36,11 +37,24 @@ const Scrollable = ({children, isVertical}: {children: ComponentChildren; isVert
     }
   };
 
+  useLayoutEffect(() => {
+    if (isVertical) {
+      const scrollableEl = document.getElementsByClassName('playkit-scrollable')[0];
+      const parentHeight = scrollableEl && scrollableEl.parentElement?.clientHeight;
+      if (parentHeight) {
+        const cs = getComputedStyle(scrollableEl.parentElement);
+        const verticalPadding = parseFloat(cs.paddingTop) + parseFloat(cs.paddingBottom);
+        setScrollableHeight(`${parentHeight - verticalPadding}px`);
+      }
+    }
+  }, []);
+
   const scrollableParams = useMemo(() => (isVertical ? {onScroll: handleScroll} : {onWheel: handleWheel, ref}), [isVertical]);
 
   return (
     <div
       className={`${styles.scrollable} ${scrolling ? styles.scrolling : ''} ${isVertical ? styles.vertical : styles.horizontal}`}
+      style={`${isVertical && scrollableHeight ? `height: ${scrollableHeight}` : ''}`}
       {...scrollableParams}
     >
       {children}

--- a/src/components/scrollable/scrollable.tsx
+++ b/src/components/scrollable/scrollable.tsx
@@ -40,7 +40,7 @@ const Scrollable = ({children, isVertical}: {children: ComponentChildren; isVert
   useLayoutEffect(() => {
     if (isVertical && ref?.current) {
       const scrollableEl = ref.current;
-      const parentHeight = scrollableEl && scrollableEl.parentElement?.clientHeight;
+      const parentHeight = scrollableEl.parentElement?.clientHeight;
       if (parentHeight) {
         const cs = getComputedStyle(scrollableEl.parentElement);
         const verticalPadding = parseFloat(cs.paddingTop) + parseFloat(cs.paddingBottom);

--- a/src/components/scrollable/scrollable.tsx
+++ b/src/components/scrollable/scrollable.tsx
@@ -38,8 +38,8 @@ const Scrollable = ({children, isVertical}: {children: ComponentChildren; isVert
   };
 
   useLayoutEffect(() => {
-    if (isVertical) {
-      const scrollableEl = document.getElementsByClassName('playkit-scrollable')[0];
+    if (isVertical && ref?.current) {
+      const scrollableEl = ref.current;
       const parentHeight = scrollableEl && scrollableEl.parentElement?.clientHeight;
       if (parentHeight) {
         const cs = getComputedStyle(scrollableEl.parentElement);
@@ -55,6 +55,7 @@ const Scrollable = ({children, isVertical}: {children: ComponentChildren; isVert
     <div
       className={`${styles.scrollable} ${scrolling ? styles.scrolling : ''} ${isVertical ? styles.vertical : styles.horizontal}`}
       style={`${isVertical && scrollableHeight ? `height: ${scrollableHeight}` : ''}`}
+      ref={ref}
       {...scrollableParams}
     >
       {children}

--- a/src/components/tooltip/_tooltip.scss
+++ b/src/components/tooltip/_tooltip.scss
@@ -137,7 +137,6 @@
   &.show {
     visibility: visible;
     opacity: 1;
-    z-index: 1;
   }
 
   &.hide {

--- a/src/components/tooltip/_tooltip.scss
+++ b/src/components/tooltip/_tooltip.scss
@@ -137,6 +137,7 @@
   &.show {
     visibility: visible;
     opacity: 1;
+    z-index: 1;
   }
 
   &.hide {

--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -16,6 +16,7 @@ interface TooltipOwnProps {
   type?: ToolTipPosition;
   maxWidth?: string;
   label: string;
+  className?: string;
 }
 
 type TooltipProps = ReduxStateProps & TooltipOwnProps;
@@ -262,6 +263,9 @@ class Tooltip extends Component<TooltipProps & WithEventManagerProps, any> {
    */
   render(props: any): VNode<any> {
     const className = [style.tooltipLabel, style[`tooltip-${this.state.type}`]];
+    if (props.className) {
+      className.push(props.className);
+    }
     this.state.showTooltip && this.state.valid ? className.push(style.show) : className.push(style.hide);
     if (props.isMobile) {
       return toChildArray(props.children)[0] as VNode<any>;

--- a/src/components/top-bar/_top-bar.scss
+++ b/src/components/top-bar/_top-bar.scss
@@ -14,7 +14,7 @@
   width: 100%;
   top: 0;
   left: 0;
-  z-index: 1;
+  z-index: 2;
   pointer-events: auto;
   .top-bar-area {
     position: absolute;
@@ -56,7 +56,7 @@
       margin: 0;
     }
 
-    .control-button-container {
+    .control-button-container:not(.upper-bar-icon) {
       margin: 0 6px;
 
       &:last-child {

--- a/src/components/vr-stereo/vr-stereo.tsx
+++ b/src/components/vr-stereo/vr-stereo.tsx
@@ -58,9 +58,9 @@ class VrStereo extends Component<any, any> implements IconComponent {
       svgIcon: () => this.getSvgIcon(),
       onClick: () => this.onClick(),
       component: () => {
-        return getComp({...this.props, classNames: [style.upperBarIcon]});
+        return getComponent({...this.props, classNames: [style.upperBarIcon]});
       },
-      selfManagement: true
+      shouldHandleOnClick: false
     };
   }
 
@@ -144,7 +144,7 @@ class VrStereo extends Component<any, any> implements IconComponent {
   }
 }
 
-const getComp = (props: any): VNode => {
+const getComponent = (props: any): VNode => {
   return <VrStereo {...props} />;
 }
 

--- a/src/components/vr-stereo/vr-stereo.tsx
+++ b/src/components/vr-stereo/vr-stereo.tsx
@@ -12,6 +12,8 @@ import {withLogger} from '../logger';
 import {Tooltip} from '../tooltip';
 import {Button} from '../button';
 import {ButtonControl} from '../button-control';
+import {IconComponent, registerToBottomBar} from '../bottom-bar';
+import {redux} from '../../index';
 /**
  * mapping state to props
  * @param {*} state - redux store state
@@ -38,7 +40,40 @@ const COMPONENT_NAME = 'VrStereo';
 @withText({
   vrStereoText: 'controls.vrStereo'
 })
-class VrStereo extends Component<any, any> {
+class VrStereo extends Component<any, any> implements IconComponent {
+  /**
+   * Creates an instance of PictureInPicture.
+   * @memberof VrStereo
+   */
+  constructor(props: any) {
+    super(props);
+    registerToBottomBar(COMPONENT_NAME, props.player, () => this.registerComponent());
+  }
+
+  registerComponent(): any {
+    return {
+      ariaLabel: () => this.getComponentText(),
+      displayName: COMPONENT_NAME,
+      order: 5,
+      svgIcon: () => this.getSvgIcon(),
+      onClick: () => this.onClick(),
+      component: () => {
+        return getComp({...this.props, classNames: [style.upperBarIcon]});
+      },
+      selfManagement: true
+    };
+  }
+
+  getComponentText = (): any => {
+    return this.props.vrStereoText;
+  }
+
+  getSvgIcon(): any {
+    return {
+      type: redux.useStore().getState().engine.vrStereoMode ? IconType.vrStereoFull : IconType.vrStereo
+    };
+  }
+
   /**
    * should render component
    * @returns {boolean} - whether to render the component
@@ -91,7 +126,7 @@ class VrStereo extends Component<any, any> {
    */
   render(): VNode<any> | undefined {
     return !this._shouldRender() ? undefined : (
-      <ButtonControl name={COMPONENT_NAME}>
+      <ButtonControl name={COMPONENT_NAME} className={this.props.classNames ? this.props.classNames.join(' ') : ''}>
         <Tooltip label={this.props.vrStereoText}>
           <Button
             tabIndex="0"
@@ -107,6 +142,10 @@ class VrStereo extends Component<any, any> {
       </ButtonControl>
     );
   }
+}
+
+const getComp = (props: any): VNode => {
+  return <VrStereo {...props} />;
 }
 
 VrStereo.displayName = COMPONENT_NAME;

--- a/src/reducers/bottom-bar.ts
+++ b/src/reducers/bottom-bar.ts
@@ -1,0 +1,27 @@
+/* eslint-disable  @typescript-eslint/explicit-function-return-type */
+import {BottomBarState} from '../types/reducers/bottom-bar';
+
+export const types = {
+  UPDATE_CONTROLS_TO_MOVE: 'bottom-bar/UPDATE_CONTROLS_TO_MOVE'
+};
+
+export const initialState = {
+  controlsToMove: []
+};
+
+export default (state: BottomBarState = initialState, action: any) => {
+  switch (action.type) {
+    case types.UPDATE_CONTROLS_TO_MOVE:
+      return {
+        ...state,
+        controlsToMove: action.controlsToMove
+      };
+
+    default:
+      return state;
+  }
+};
+
+export const actions = {
+  updateControlsToMove: (controlsToMove: string[]) => ({type: types.UPDATE_CONTROLS_TO_MOVE, controlsToMove})
+};

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -10,5 +10,6 @@ import * as setting from './settings';
 import * as shell from './shell';
 import * as volume from './volume';
 import * as overlay from './overlay';
+import * as bottomBar from './bottom-bar';
 
-export {config, cvaa, engine, getters, loading, overlayAction, playlist, seekbar, setting, shell, volume, overlay};
+export {config, cvaa, engine, getters, loading, overlayAction, playlist, seekbar, setting, shell, volume, overlay, bottomBar};

--- a/src/reducers/settings.ts
+++ b/src/reducers/settings.ts
@@ -5,13 +5,15 @@ export const types = {
   UPDATE_QUALITY: 'settings/UPDATE_QUALITY',
   UPDATE_SPEED: 'settings/UPDATE_SPEED',
   UPDATE_AUDIO: 'settings/UPDATE_AUDIO',
-  UPDATE_ADVANCED_AUDIO_DESC: 'settings/UPDATE_ADVANCED_AUDIO_DESC'
+  UPDATE_ADVANCED_AUDIO_DESC: 'settings/UPDATE_ADVANCED_AUDIO_DESC',
+  UPDATE_IS_TEXT_ON: 'settings/UPDATE_IS_TEXT_ON'
 };
 
 export const initialState = {
   quality: 1,
   speed: 2,
-  advancedAudioDesc: false
+  advancedAudioDesc: false,
+  isTextOn: false
 };
 
 export default (state: SettingsState = initialState, action: any) => {
@@ -40,6 +42,12 @@ export default (state: SettingsState = initialState, action: any) => {
         advancedAudioDesc: action.isChecked
       };
 
+    case types.UPDATE_IS_TEXT_ON:
+      return {
+        ...state,
+        isTextOn: action.isTextOn
+      };
+
     default:
       return state;
   }
@@ -49,5 +57,6 @@ export const actions = {
   updateQuality: (quality: string) => ({type: types.UPDATE_QUALITY, quality}),
   updateSpeed: (speed: string) => ({type: types.UPDATE_SPEED, speed}),
   updateAudio: (audio: string) => ({type: types.UPDATE_AUDIO, audio}),
-  updateAdvancedAudioDesc: (isChecked: boolean) => ({type: types.UPDATE_ADVANCED_AUDIO_DESC, isChecked})
+  updateAdvancedAudioDesc: (isChecked: boolean) => ({type: types.UPDATE_ADVANCED_AUDIO_DESC, isChecked}),
+  updateIsTextOn: (isTextOn: boolean) => ({type: types.UPDATE_IS_TEXT_ON, isTextOn})
 };

--- a/src/reducers/settings.ts
+++ b/src/reducers/settings.ts
@@ -6,14 +6,14 @@ export const types = {
   UPDATE_SPEED: 'settings/UPDATE_SPEED',
   UPDATE_AUDIO: 'settings/UPDATE_AUDIO',
   UPDATE_ADVANCED_AUDIO_DESC: 'settings/UPDATE_ADVANCED_AUDIO_DESC',
-  UPDATE_IS_TEXT_ON: 'settings/UPDATE_IS_TEXT_ON'
+  UPDATE_IS_CAPTIONS_ENABLED: 'settings/UPDATE_IS_CAPTIONS_ENABLED'
 };
 
 export const initialState = {
   quality: 1,
   speed: 2,
   advancedAudioDesc: false,
-  isTextOn: false
+  isCaptionsEnabled: false
 };
 
 export default (state: SettingsState = initialState, action: any) => {
@@ -42,10 +42,10 @@ export default (state: SettingsState = initialState, action: any) => {
         advancedAudioDesc: action.isChecked
       };
 
-    case types.UPDATE_IS_TEXT_ON:
+    case types.UPDATE_IS_CAPTIONS_ENABLED:
       return {
         ...state,
-        isTextOn: action.isTextOn
+        isCaptionsEnabled: action.isCaptionsEnabled
       };
 
     default:
@@ -58,5 +58,5 @@ export const actions = {
   updateSpeed: (speed: string) => ({type: types.UPDATE_SPEED, speed}),
   updateAudio: (audio: string) => ({type: types.UPDATE_AUDIO, audio}),
   updateAdvancedAudioDesc: (isChecked: boolean) => ({type: types.UPDATE_ADVANCED_AUDIO_DESC, isChecked}),
-  updateIsTextOn: (isTextOn: boolean) => ({type: types.UPDATE_IS_TEXT_ON, isTextOn})
+  updateIsCaptionsEnabled: (isCaptionsEnabled: boolean) => ({type: types.UPDATE_IS_CAPTIONS_ENABLED, isCaptionsEnabled})
 };

--- a/src/store.ts
+++ b/src/store.ts
@@ -10,6 +10,7 @@ import settings from './reducers/settings';
 import overlayAction from './reducers/overlay-action';
 import playlist from './reducers/playlist';
 import overlay from './reducers/overlay';
+import bottomBar from './reducers/bottom-bar';
 import {RootState} from './types';
 
 const reducer = combineReducers<RootState>({
@@ -23,7 +24,8 @@ const reducer = combineReducers<RootState>({
   settings,
   overlayAction,
   playlist,
-  overlay
+  overlay,
+  bottomBar
 });
 
 export default reducer;

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -71,6 +71,7 @@ $new-live-color: #e12437; // - refs in related-plugin
   progressBarBorderRadius: $progress-bar-border-radius;
   defaultTransitionTime: $default-transition-time;
   bottomBarMaxHeight: $bottom-bar-max-height;
+  topBarMaxHeight: $top-bar-max-height;
   // ***************  Backward Compatibility - Deprecated  **************
   brandColor: $brand-color;
   white: $white;

--- a/src/types/reducers/bottom-bar.ts
+++ b/src/types/reducers/bottom-bar.ts
@@ -1,0 +1,3 @@
+export interface BottomBarState {
+  controlsToMove: string[];
+}

--- a/src/types/reducers/root-state.ts
+++ b/src/types/reducers/root-state.ts
@@ -9,6 +9,7 @@ import {CvaaState} from './cvaa';
 import {EngineState} from './engine';
 import {ConfigState} from './config';
 import {PlaylistState} from './playlist';
+import {BottomBarState} from './bottom-bar';
 
 export interface RootState {
   config: ConfigState;
@@ -22,4 +23,5 @@ export interface RootState {
   overlayAction: OverlayActionsState;
   playlist: PlaylistState;
   overlay: OverlayState;
+  bottomBar: BottomBarState;
 }

--- a/src/ui-presets/live.tsx
+++ b/src/ui-presets/live.tsx
@@ -81,7 +81,7 @@ class LiveUI extends Component<any, any> {
                   </InteractiveArea>
                   <BottomBar
                     leftControls={[PlaybackControls, Rewind, Forward, LiveTag]}
-                    rightControls={[VrStereo, Volume, CaptionsControl, Settings, Cast, PictureInPicture, Fullscreen, Logo]}
+                    rightControls={[VrStereo, Volume, ClosedCaptions, CaptionsControl, Settings, Cast, PictureInPicture, Fullscreen, Logo]}
                   >
                     <SeekBarLivePlaybackContainer showFramePreview showTimeBubble playerContainer={containerRef} />
                   </BottomBar>

--- a/src/ui-presets/playback.tsx
+++ b/src/ui-presets/playback.tsx
@@ -90,7 +90,7 @@ class PlaybackUI extends Component<any, any> {
                   </InteractiveArea>
                   <BottomBar
                     leftControls={[PlaybackControls, Rewind, Forward, TimeDisplayPlaybackContainer]}
-                    rightControls={[VrStereo, Volume, AdvancedAudioDesc, CaptionsControl, Settings, Cast, PictureInPicture, Fullscreen, Logo]}>
+                    rightControls={[VrStereo, Volume, AdvancedAudioDesc, ClosedCaptions, CaptionsControl, Settings, Cast, PictureInPicture, Fullscreen, Logo]}>
                     <SeekBarPlaybackContainer showFramePreview showTimeBubble playerContainer={containerRef} />
                   </BottomBar>
                 </Fragment>

--- a/tests/e2e/bottom-bar-registry-manager.spec.js
+++ b/tests/e2e/bottom-bar-registry-manager.spec.js
@@ -3,7 +3,7 @@ import {BottomBarRegistryManager} from '../../src/components/bottom-bar';
 
 describe('BottomBarRegistryManager', () => {
   const myComponentName = 'MyComponent';
-  const iconDto = {
+  const iconDtoObj = {
     ariaLabel: 'aria label',
     displayName: myComponentName,
     order: 5,
@@ -25,26 +25,33 @@ describe('BottomBarRegistryManager', () => {
 
   describe('register API', () => {
     it('Should register a component to the manager', () => {
-      bottomBarRegistryManager.register(myComponentName, iconDto);
-      bottomBarRegistryManager.registry.size.should.equal(1);
+      bottomBarRegistryManager.register(myComponentName, iconDtoObj);
+      bottomBarRegistryManager._registry.size.should.equal(1);
     });
   });
 
   describe('unregister API', () => {
     it('Should unregister a component from the manager', () => {
-      bottomBarRegistryManager.register(myComponentName, iconDto);
-      bottomBarRegistryManager.registry.size.should.equal(1);
+      bottomBarRegistryManager.register(myComponentName, iconDtoObj);
+      bottomBarRegistryManager._registry.size.should.equal(1);
       bottomBarRegistryManager.unregister(myComponentName);
-      bottomBarRegistryManager.registry.size.should.equal(0);
+      bottomBarRegistryManager._registry.size.should.equal(0);
     });
   });
 
   describe('clear API', () => {
     it('Should clear the registry of the manager', () => {
-      bottomBarRegistryManager.register(myComponentName, iconDto);
-      bottomBarRegistryManager.registry.size.should.equal(1);
+      bottomBarRegistryManager.register(myComponentName, iconDtoObj);
+      bottomBarRegistryManager._registry.size.should.equal(1);
       bottomBarRegistryManager.clear();
-      bottomBarRegistryManager.registry.size.should.equal(0);
+      bottomBarRegistryManager._registry.size.should.equal(0);
+    });
+  });
+
+  describe('getComponentItem API', () => {
+    it('Should get the added component item from the manager', () => {
+      bottomBarRegistryManager.register(myComponentName, iconDtoObj);
+      bottomBarRegistryManager.getComponentItem(myComponentName).should.equal(iconDtoObj);
     });
   });
 });

--- a/tests/e2e/bottom-bar-registry-manager.spec.js
+++ b/tests/e2e/bottom-bar-registry-manager.spec.js
@@ -1,0 +1,53 @@
+import '../../src/index';
+import {BottomBarRegistryManager} from '../../src/components/bottom-bar';
+
+describe('BottomBarRegistryManager', function () {
+  const myComponentName = 'MyComponent';
+  const iconDto = {
+    ariaLabel: 'aria label',
+    displayName: myComponentName,
+    order: 5,
+    svgIcon: 'svg',
+    onClick: () => {},
+    component: () => {},
+    shouldHandleOnClick: false
+  };
+
+  let bottomBarRegistryManager;
+
+  beforeEach(function () {
+    bottomBarRegistryManager = new BottomBarRegistryManager();
+  });
+
+  afterEach(function () {
+    bottomBarRegistryManager = null;
+  });
+
+  describe('register API', function () {
+    it('Should register a component to the manager', function (done) {
+      bottomBarRegistryManager.register(myComponentName, iconDto);
+      bottomBarRegistryManager.registry.size.should.equal(1);
+      done();
+    });
+  });
+
+  describe('unregister API', function () {
+    it('Should unregister a component from the manager', function (done) {
+      bottomBarRegistryManager.register(myComponentName, iconDto);
+      bottomBarRegistryManager.registry.size.should.equal(1);
+      bottomBarRegistryManager.unregister(myComponentName);
+      bottomBarRegistryManager.registry.size.should.equal(0);
+      done();
+    });
+  });
+
+  describe('clear API', function () {
+    it('Should clear the registry of the manager', function (done) {
+      bottomBarRegistryManager.register(myComponentName, iconDto);
+      bottomBarRegistryManager.registry.size.should.equal(1);
+      bottomBarRegistryManager.clear();
+      bottomBarRegistryManager.registry.size.should.equal(0);
+      done();
+    });
+  });
+});

--- a/tests/e2e/bottom-bar-registry-manager.spec.js
+++ b/tests/e2e/bottom-bar-registry-manager.spec.js
@@ -1,7 +1,7 @@
 import '../../src/index';
 import {BottomBarRegistryManager} from '../../src/components/bottom-bar';
 
-describe('BottomBarRegistryManager', function () {
+describe('BottomBarRegistryManager', () => {
   const myComponentName = 'MyComponent';
   const iconDto = {
     ariaLabel: 'aria label',
@@ -15,39 +15,36 @@ describe('BottomBarRegistryManager', function () {
 
   let bottomBarRegistryManager;
 
-  beforeEach(function () {
+  beforeEach(() => {
     bottomBarRegistryManager = new BottomBarRegistryManager();
   });
 
-  afterEach(function () {
+  afterEach(() => {
     bottomBarRegistryManager = null;
   });
 
-  describe('register API', function () {
-    it('Should register a component to the manager', function (done) {
+  describe('register API', () => {
+    it('Should register a component to the manager', () => {
       bottomBarRegistryManager.register(myComponentName, iconDto);
       bottomBarRegistryManager.registry.size.should.equal(1);
-      done();
     });
   });
 
-  describe('unregister API', function () {
-    it('Should unregister a component from the manager', function (done) {
+  describe('unregister API', () => {
+    it('Should unregister a component from the manager', () => {
       bottomBarRegistryManager.register(myComponentName, iconDto);
       bottomBarRegistryManager.registry.size.should.equal(1);
       bottomBarRegistryManager.unregister(myComponentName);
       bottomBarRegistryManager.registry.size.should.equal(0);
-      done();
     });
   });
 
-  describe('clear API', function () {
-    it('Should clear the registry of the manager', function (done) {
+  describe('clear API', () => {
+    it('Should clear the registry of the manager', () => {
       bottomBarRegistryManager.register(myComponentName, iconDto);
       bottomBarRegistryManager.registry.size.should.equal(1);
       bottomBarRegistryManager.clear();
       bottomBarRegistryManager.registry.size.should.equal(0);
-      done();
     });
   });
 });


### PR DESCRIPTION
### Description of the Changes

**New requirement:**
if there is not enough space for controls in bottom bar, instead of removing them- move them to the upper bar.
This was requested for A11y purposes.

- keep 10sec FWD and BWD controls in bottom bar (do not remove them)
- new service to register relevant core components
- new redux state to update the controls that need to be moved from bottom bar to upper bar
- new interface that registers the components to the new service
- a special implementation for `TimeDisplay` component (different behavior)

related PR: https://github.com/kaltura/playkit-js-ui-managers/pull/59

#### Resolves FEC-13945


