### PR TITLE
fix(FEC-14034): Player v7 | Safari | Opening the CC menu cause size a…

### DIFF
--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -279,7 +279,7 @@ class MenuItem extends Component<any, any> {
         ref={element => {
           this.props.addAccessibleChild(element);
           if (props.isSelected(props.data)) {
-            props.setDefaultFocusedElement(element);
+            setTimeout(() => props.setDefaultFocusedElement(element))
           }
         }}
         className={props.isSelected(props.data) ? [style.dropdownMenuItem, style.active].join(' ') : style.dropdownMenuItem}


### PR DESCRIPTION
### Description of the Changes

founding: 

- it is not a reggaeton  - it is reproduced on [0.79.2](https://github.com/kaltura/playkit-js-ui/commit/7c7d4db698e2f2baa38c3829c4a5da476bf9f1cf) as well (prior to [#871)](https://github.com/kaltura/playkit-js-ui/pull/871) PR ) on any dropdown menu click

- ti is happen only when the menu items on  menu component are of a huge number that overflowing  that player size

- it is caused by the focus element that triggers on Menu Component mount from the Al11y wrapper that wraps the Menu component

#### Resolves FEC-14034


