### PR TITLE
fix(ADA-1275): When user focuses the player he will be able to play/pause with "space" key

### DIFF
--- a/src/components/play-pause/play-pause.tsx
+++ b/src/components/play-pause/play-pause.tsx
@@ -63,6 +63,8 @@ class PlayPause extends Component<any, any> {
         this._playPauseButtonRef?.focus();
       });
     });
+    const myPlayerContainer = document.querySelector('.kaltura-player-container');
+    eventManager.listen(myPlayerContainer,'keydown', this.handleSpaceKey);
   }
 
   /**
@@ -76,6 +78,13 @@ class PlayPause extends Component<any, any> {
     this.props.isPlayingAdOrPlayback ? this.props.player.pause() : this.props.player.play();
     this.props.notifyClick();
   };
+
+  handleSpaceKey = (event) => {
+    if (event.code === 'Space') {
+      this.togglePlayPause();
+      event.preventDefault();
+    }
+  }
 
   /**
    * render component

--- a/src/components/play-pause/play-pause.tsx
+++ b/src/components/play-pause/play-pause.tsx
@@ -63,8 +63,9 @@ class PlayPause extends Component<any, any> {
         this._playPauseButtonRef?.focus();
       });
     });
-    const myPlayerContainer = document.querySelector('.kaltura-player-container');
-    eventManager.listen(myPlayerContainer,'keydown', this.handleSpaceKey);
+    const targetId: HTMLDivElement | Document = (document.getElementById(this.props.player.config.targetId) as HTMLDivElement) || document;
+    //const myPlayerContainer = document.querySelector('.kaltura-player-container');
+    eventManager.listen(targetId,'keydown', this.handleSpaceKey);
   }
 
   /**

--- a/src/components/play-pause/play-pause.tsx
+++ b/src/components/play-pause/play-pause.tsx
@@ -64,7 +64,6 @@ class PlayPause extends Component<any, any> {
       });
     });
     const targetId: HTMLDivElement | Document = (document.getElementById(this.props.player.config.targetId) as HTMLDivElement) || document;
-    //const myPlayerContainer = document.querySelector('.kaltura-player-container');
     eventManager.listen(targetId,'keydown', this.handleSpaceKey);
   }
 


### PR DESCRIPTION
**Issue:**
After the pre-playback-overlay is rendered, with the centered big play button shown in the player container, the user can use it to start the playback and make the overlay component disappear. Afterwards he can play/pause the media by pressing "Space" key due to the fact that initially the play/pause button is focused.

The issue appears when the user switches focus from the player and returns to it, because the play button will not be focused anymore.

**Fix:**

Added event listener on the player container for the space key.


