### PR TITLE
fix(ADA-1468): Holding Enter on Player Controls Causes Flashing

### DIFF
--- a/src/components/fullscreen/fullscreen.tsx
+++ b/src/components/fullscreen/fullscreen.tsx
@@ -58,6 +58,14 @@ class Fullscreen extends Component<
   _keyboardEventHandlers: Array<KeyboardEventHandlers> = [
     {
       key: {
+        code: KeyMap.ENTER
+      },
+      action: event => {
+        this.handleKeydown(event);
+      }
+    },
+    {
+      key: {
         code: KeyMap.F
       },
       action: event => {
@@ -92,6 +100,10 @@ class Fullscreen extends Component<
    */
   handleKeydown(event: KeyboardEvent): void {
     switch (event.keyCode) {
+      case KeyMap.ENTER:
+        if (!event.repeat) {
+          this.toggleFullscreen();
+        }
       case KeyMap.F:
         if (!this.props.player!.isFullscreen()) {
           this.toggleFullscreen();


### PR DESCRIPTION
### Description of the Changes

**Issue:**
Holding "enter" on a full screen button will trigger that button repeatedly and causes flashing.

**Fix:**
Check if the event trigger repeatedly by event.repeat and allow enter and exit from full screen only when pressing enter and not when holding the enter.

#### Resolves [ADA-1468](https://kaltura.atlassian.net/browse/ADA-1468)




[ADA-1468]: https://kaltura.atlassian.net/browse/ADA-1468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ