### PR TITLE
ADA-1499 - Make aria label equal to logo title

### DIFF
--- a/src/components/logo/logo.tsx
+++ b/src/components/logo/logo.tsx
@@ -126,7 +126,7 @@ class Logo extends Component<any, any> {
           onClick={this._handleOnClick}
           className={style.controlButton}
           href={this.state.urlLink}
-          aria-label={props.logoText}
+          aria-label={props.config.text ? props.config.text : "Logo"}
           target="_blank"
           rel="noopener noreferrer"
           tabIndex={0}

--- a/src/components/logo/logo.tsx
+++ b/src/components/logo/logo.tsx
@@ -126,7 +126,7 @@ class Logo extends Component<any, any> {
           onClick={this._handleOnClick}
           className={style.controlButton}
           href={this.state.urlLink}
-          aria-label={props.config.text ? props.config.text : "Logo"}
+          aria-label={props.config.text || props.logoText}
           target="_blank"
           rel="noopener noreferrer"
           tabIndex={0}


### PR DESCRIPTION

### Description of the Changes

For the Logo link the SR was not announcing a meaningful description. The code was modified so that the message announced can now be customized by the client by modifying the Logo Title.

**Issue:**
Logo link aria-label is not meaningful
**Fix:**
Logo link aria-label is equal to the logo title or absence with a default title
#### Resolves https://kaltura.atlassian.net/browse/ADA-1499


