### PR TITLE
fix(FEC-14076): Player v7 | Download | Download notification popup is being display behind download overlay.

### DIFF
--- a/src/components/interactive-area/_interactive-area.scss
+++ b/src/components/interactive-area/_interactive-area.scss
@@ -1,5 +1,9 @@
-.player.overlay-active .interactive-area {
-  filter: blur($blur);
+.player.overlay-active .interactive-area {  
+  .filter {
+    filter: blur($blur);
+    height: 100%;
+    width: 100%;
+  }
 }
 .interactive-area {
   pointer-events: none;

--- a/src/components/interactive-area/interactive-area.tsx
+++ b/src/components/interactive-area/interactive-area.tsx
@@ -26,6 +26,7 @@ class InteractiveArea extends Component<any, any> {
     const {children} = this.props;
     return (
       <div className={style.interactiveArea}>
+        <div className={style.filter}></div>
         <div style={{pointerEvents: 'auto'}}>
           <PlayerArea name={'InteractiveArea'}>{children}</PlayerArea>
         </div>


### PR DESCRIPTION
### Description of the Changes

Move interactive area filter to a separate element
If interactive area itself has a filter, it affects every component within the interactive area, including popups, which should not be affected by it

Related PR: https://github.com/kaltura/playkit-js-ui-managers/pull/61

Resolves FEC-14076

**Issue:**

**Fix:**

#### Resolves FEC-[Please add the ticket reference here]


