### PR TITLE
fix(ADA-1404): Focus handling on pre-playback

### DIFF
--- a/src/styles/_buttons.scss
+++ b/src/styles/_buttons.scss
@@ -44,6 +44,10 @@
   padding: 2px;
 }
 
+.pre-playback-play-overlay button.pre-playback-play-button:focus{
+  outline: 1px solid $tab-focus-color;
+}
+
 .player {
   button {
     &:focus {


### PR DESCRIPTION
Issue:
On a first render in case a user is navigating with Tab key, the element that receives the first focus is the pre-playback-play-button that has a default styling of "outline: none ". 

Fix:
Adding existing outline styling for this particular case of focus as well.



