### PR TITLE
fix(SUP-43895): New AAD Player layout of V7 Player not working

### DIFF
--- a/src/components/event-dispatcher/event-dispatcher-provider.tsx
+++ b/src/components/event-dispatcher/event-dispatcher-provider.tsx
@@ -182,6 +182,7 @@ function onClickableComponentsHandler(store: any, action: any, player: KalturaPl
       break;
 
     case 'AdvancedAudioDescToggle':
+    case 'AdvancedAudioDesc':
       onAdvancedAudioDescriptionClicked(store, action, player);
       break;
 


### PR DESCRIPTION
### Description of the Changes

**Issue:**
AD button is not working from button-bar, the advanced audio description only can be enabled from settings button.

**Root cause:**
The advanced-audio-description event is not triggered when activating the AD button since there is reference only to the old toggle component.

**Fix:**
Add the name of new component to the switch case in the event-dispatcher.

#### Resolves [SUP-43895](https://kaltura.atlassian.net/browse/SUP-43895)


