### PR TITLE
fix(ADA-1451): Manage focus on closing info modal

### DIFF
--- a/src/utils/popup-keyboard-accessibility.tsx
+++ b/src/utils/popup-keyboard-accessibility.tsx
@@ -1,5 +1,5 @@
-import {h, Component} from 'preact';
-import {KeyMap} from './key-map';
+import { h, Component } from 'preact';
+import { KeyMap } from './key-map';
 
 /**
  * wraps a component and handles all key navigation and focus
@@ -90,7 +90,11 @@ export const withKeyboardA11y = (WrappedComponent): any =>
      */
     componentWillUnmount(): void {
       if (this._previouslyActiveElement) {
-        this._previouslyActiveElement.focus();
+        setTimeout(() => {
+          if (this._previouslyActiveElement && document.contains(this._previouslyActiveElement)) {
+            this._previouslyActiveElement.focus();
+          }
+        }, 100);
       }
     }
 

--- a/src/utils/popup-keyboard-accessibility.tsx
+++ b/src/utils/popup-keyboard-accessibility.tsx
@@ -89,13 +89,11 @@ export const withKeyboardA11y = (WrappedComponent): any =>
      * @memberof HOC
      */
     componentWillUnmount(): void {
-      if (this._previouslyActiveElement) {
         setTimeout(() => {
           if (this._previouslyActiveElement && document.contains(this._previouslyActiveElement)) {
             this._previouslyActiveElement.focus();
           }
         }, 100);
-      }
     }
 
     /**

--- a/src/utils/popup-keyboard-accessibility.tsx
+++ b/src/utils/popup-keyboard-accessibility.tsx
@@ -1,5 +1,6 @@
 import { h, Component } from 'preact';
 import { KeyMap } from './key-map';
+import { focusElement } from './focus-element';
 
 /**
  * wraps a component and handles all key navigation and focus
@@ -89,11 +90,9 @@ export const withKeyboardA11y = (WrappedComponent): any =>
      * @memberof HOC
      */
     componentWillUnmount(): void {
-        setTimeout(() => {
-          if (this._previouslyActiveElement && document.contains(this._previouslyActiveElement)) {
-            this._previouslyActiveElement.focus();
-          }
-        }, 100);
+      if (this._previouslyActiveElement && document.contains(this._previouslyActiveElement)) {
+        focusElement(this._previouslyActiveElement);
+      }
     }
 
     /**


### PR DESCRIPTION
### Description of the Changes
I'm testing if the previouslyActiveElement exists and I've added a slight delay so that it can be focused on closing the modal 

**Issue:**
On closing, the focus was not going to the button that opened the modal

**Fix:**

#### Resolves FEC-[https://kaltura.atlassian.net/browse/ADA-1451]


