### PR TITLE
fix(ADA-1468): Holding Enter on Player Controls Causes Flashing

### DIFF
--- a/src/components/fullscreen/fullscreen.tsx
+++ b/src/components/fullscreen/fullscreen.tsx
@@ -98,9 +98,10 @@ class Fullscreen extends Component<
    * @returns {void}
    * @memberof Fullscreen
    */
-  handleKeydown(event: KeyboardEvent): void {
+  handleKeydown = (event: KeyboardEvent): void => {
     switch (event.keyCode) {
       case KeyMap.ENTER:
+        event.preventDefault();
         if (!event.repeat) {
           this.toggleFullscreen();
         }
@@ -117,7 +118,7 @@ class Fullscreen extends Component<
       default:
         break;
     }
-  }
+  };
   /**
    * toggle fullscreen based on current fullscreen state in store
    *
@@ -145,6 +146,7 @@ class Fullscreen extends Component<
             tabIndex="0"
             aria-label={this.props.isInFullscreen ? this.props.fullscreenExitText : this.props.fullscreenText}
             className={this.props.isInFullscreen ? [style.controlButton, style.isFullscreen].join(' ') : style.controlButton}
+            onKeyDown={this.handleKeydown}
             onClick={this.toggleFullscreen}
           >
             <Icon type={IconType.Maximize} />


### PR DESCRIPTION
### Description of the Changes

**Issue:**
Pressing enter on full screen button go to onClick instead of using handleKeydown

**Fix:**
Adding onKeyDown on the button

#### Resolves [ADA-1468](https://kaltura.atlassian.net/browse/ADA-1468)




[ADA-1468]: https://kaltura.atlassian.net/browse/ADA-1468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ