### PR TITLE
fix: export video-filter sass variable

### DIFF
--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -27,7 +27,6 @@ $bottom-bar-bottom-gutter: 4;
 $gui-gutter: 16;
 $gui-small-gutter: 8;
 $blur: 16px;
-$video-filter: playkit-video-filter;
 // ***************  Backward Compatibility - Deprecated  **************
 $brand-color: #006bff; // - refs in playkit-ui and related-plugin
 $white: #ffffff; // - refs in playkit-ui and related-plugin

--- a/src/styles/exported.scss
+++ b/src/styles/exported.scss
@@ -57,3 +57,4 @@ $playkit-background-color: var(--playkit-background-color);
 $elevated-color: var(--playkit-elevated-color);
 $paper-color: var(--playkit-paper-color);
 $protection-color: var(--playkit-protection-color);
+$video-filter: playkit-video-filter;


### PR DESCRIPTION
### Description of the Changes

Move $video-filter to exported.scss, so it would be exported and will be able to be used in dualscreen scss files
Having it in variables only means that it's available in the js style object, not as a scss variable


