### PR TITLE
fix(FEC-14146): Player v7 | For audio entries there is no option to tab navigate to the "More/Less" buttons under the description. 

### DIFF
--- a/src/components/expandable-text/expandable-text.tsx
+++ b/src/components/expandable-text/expandable-text.tsx
@@ -25,7 +25,7 @@ interface ExpandableTextProps {
 
 const ReadMoreLessButton = ({isTextExpanded, readLessLabel, readMoreLabel, onClick, onKeyDown, ...otherProps}) => {
   return (
-    <div className={styles.moreButtonText} onClick={onClick} onKeyDown={onKeyDown} {...otherProps}>
+    <div tabIndex={0} className={styles.moreButtonText} onClick={onClick} onKeyDown={onKeyDown} {...otherProps}>
       {isTextExpanded ? readLessLabel : readMoreLabel}
     </div>
   );


### PR DESCRIPTION
### Description of the Changes

Add tab index to more/less button which is displayed for audio entries with a long description

Resolves FEC-14146


