### PR TITLE
fix(ADA-1621): bring captions in front of entry title/description

### DIFF
--- a/src/components/audio-entry-details/_audio-entry-details.scss
+++ b/src/components/audio-entry-details/_audio-entry-details.scss
@@ -64,4 +64,7 @@
       }
     }
   }
+  :global(.playkit-subtitles) {
+    z-index: 1;
+  }
 }


### PR DESCRIPTION
### Description of the Changes

Used z-index to bring captions in front of Title and Description for audio entries.

**Issue:**

**Fix:**

#### Resolves https://kaltura.atlassian.net/browse/ADA-1621


