### PR TITLE
fix(ADA-1404): Add focus indicator to the first focusable element

### DIFF
--- a/src/reducers/shell.ts
+++ b/src/reducers/shell.ts
@@ -101,7 +101,7 @@ export const initialState = {
     }
   },
   playerHover: false,
-  playerNav: false,
+  playerNav: true,
   smartContainerOpen: false,
   activePresetName: '',
   sidePanelsModes: {


### PR DESCRIPTION
### Description of the Changes

I made playerNav default true, so that the keyboard navigation is activated from the first tab;

**Issue:**

**Fix:**

#### Resolves [ADA-1404](https://kaltura.atlassian.net/browse/ADA-1404)




[ADA-1404]: https://kaltura.atlassian.net/browse/ADA-1404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ