### PR TITLE
fix(ADA-1633): The tooltips for a player controls are not dismissible using the Esc key

### DIFF
--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -50,7 +50,6 @@ const ToolTipType: {[type: string]: ToolTipPosition} = {
   Right: 'right'
 };
 
-
 /**
  * Tooltip component
  *

--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -232,7 +232,7 @@ class Tooltip extends Component<TooltipProps & WithEventManagerProps, any> {
     const {eventManager} = this.props;
     eventManager!.listen(document, 'click', e => this.handleClickOutside(e));
     if (this._buttonRef?.addEventListener) {
-      this._buttonRef.addEventListener('keydown', this.handleKeyDown);
+      eventManager!.listen(this._buttonRef, 'keydown', this.handleKeyDown);
     }
   }
 
@@ -281,9 +281,10 @@ class Tooltip extends Component<TooltipProps & WithEventManagerProps, any> {
    * @memberof Tooltip
    */
   componentWillUnmount(): void {
+    const {eventManager} = this.props;
     this._clearHoverTimeout();
     if (this._buttonRef?.removeEventListener) {
-      this._buttonRef.removeEventListener('keydown', this.handleKeyDown);
+      eventManager!.unlisten(this._buttonRef, 'keydown', this.handleKeyDown);
     }
   }
 

--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -4,9 +4,6 @@ import {connect} from 'react-redux';
 import {withEventManager} from '../../event';
 import {WithEventManagerProps} from '../../event/with-event-manager';
 import {KeyMap} from '../../utils/key-map';
-import {withKeyboardEvent} from '../../components/keyboard';
-import {KeyboardEventHandlers} from '../../types';
-import {WithKeyboardEventProps} from '../keyboard/with-keyboard-event';
 
 interface ReduxStateProps {
   playerClientRect?: DOMRect;
@@ -53,7 +50,6 @@ const ToolTipType: {[type: string]: ToolTipPosition} = {
   Right: 'right'
 };
 
-const COMPONENT_NAME = 'Tooltip';
 
 /**
  * Tooltip component
@@ -64,8 +60,7 @@ const COMPONENT_NAME = 'Tooltip';
  */
 @connect(mapStateToProps)
 @withEventManager
-@withKeyboardEvent(COMPONENT_NAME)
-class Tooltip extends Component<TooltipProps & WithEventManagerProps & WithKeyboardEventProps, any> {
+class Tooltip extends Component<TooltipProps & WithEventManagerProps, any> {
   _hoverTimeout: number | null = null;
   textElement!: HTMLSpanElement;
   tooltipElement!: HTMLDivElement;
@@ -319,8 +314,7 @@ class Tooltip extends Component<TooltipProps & WithEventManagerProps & WithKeybo
         className={style.tooltip}
         onMouseOver={this.onMouseOver}
         onMouseLeave={this.onMouseLeave}
-        ref={el => (el ? (this.tooltipElement = el) : undefined)}
-      >
+        ref={el => (el ? (this.tooltipElement = el) : undefined)}>
         {children}
         <span style={{maxWidth: props.maxWidth}} ref={el => (el ? (this.textElement = el) : undefined)} className={className.join(' ')}>
           {props.label}

--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -281,11 +281,7 @@ class Tooltip extends Component<TooltipProps & WithEventManagerProps, any> {
    * @memberof Tooltip
    */
   componentWillUnmount(): void {
-    const {eventManager} = this.props;
     this._clearHoverTimeout();
-    if (this._buttonRef?.removeEventListener) {
-      eventManager!.unlisten(this._buttonRef, 'keydown', this.handleKeyDown);
-    }
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

**Issue:**
When focusing on control the tooltip is shown and is not gone until you move to another element.

**Fix:**
When click on Escape key the tooltip will disappear.

#### Resolves [ADA-1633](https://kaltura.atlassian.net/browse/ADA-1633)




[ADA-1633]: https://kaltura.atlassian.net/browse/ADA-1633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ