### PR TITLE
fix(FEC-14169): Player v7 | Two outlines blue and white appears using mouse navigation.

### DIFF
--- a/src/reducers/shell.ts
+++ b/src/reducers/shell.ts
@@ -101,7 +101,7 @@ export const initialState = {
     }
   },
   playerHover: false,
-  playerNav: true,
+  playerNav: false,
   smartContainerOpen: false,
   activePresetName: '',
   sidePanelsModes: {


### PR DESCRIPTION
### Description of the Changes

Revert https://github.com/kaltura/playkit-js-ui/commit/bd09056adb2c3db9f9604c1f07d94ad9b1c04f1d, as it causes issues with button bar focus indication appearing when keyboard navigation is off


