### PR TITLE
fix(FEC-14156): quiz overlay behind cvaa freezes

### DIFF
--- a/src/components/captions-control/captions-control-mini.tsx
+++ b/src/components/captions-control/captions-control-mini.tsx
@@ -13,6 +13,7 @@ import {Text} from 'preact-i18n';
 import {CaptionsMenu} from '../captions-menu';
 import {SmartContainer} from '../smart-container';
 import {CaptionsControl} from './captions-control';
+import {getOverlayPortalElement} from '../overlay-portal';
 
 const mapStateToProps = state => ({
   controlsToMove: state.bottomBar.controlsToMove
@@ -24,8 +25,6 @@ const CaptionsControlMini = connect(mapStateToProps)((props, context) => {
 
   const {player} = context;
   const {controlsToMove} = props;
-  const targetOverlayEl: HTMLDivElement | Document = (document.getElementById(player.config.targetId) as HTMLDivElement) || document;
-  const portalSelector = `.overlay-portal`;
   let removeOverlay: any = null;
 
   useEffect(() => {
@@ -69,7 +68,7 @@ const CaptionsControlMini = connect(mapStateToProps)((props, context) => {
       presets: [ReservedPresetNames.Playback, ReservedPresetNames.Live],
       get: () => {
         return (
-          createPortal(<CVAAOverlay onClose={() => removeCaptionsOverlay()}/>, targetOverlayEl.querySelector(portalSelector)!)
+          createPortal(<CVAAOverlay onClose={() => removeCaptionsOverlay()}/>, getOverlayPortalElement(player)!)
         )}
     });
   };

--- a/src/components/captions-control/captions-control.tsx
+++ b/src/components/captions-control/captions-control.tsx
@@ -13,6 +13,7 @@ import {focusElement} from '../../utils';
 import {createPortal} from 'preact/compat';
 import {CVAAOverlay} from '../cvaa-overlay';
 import {CaptionsControlMini} from './captions-control-mini';
+import {getOverlayPortalElement} from '../overlay-portal';
 
 /**
  * mapping state to props
@@ -86,9 +87,6 @@ const CaptionsControl = connect(mapStateToProps)(
     props.onToggle(COMPONENT_NAME, shouldRender);
     if (!shouldRender) return undefined;
 
-    const targetId: HTMLDivElement | Document = (document.getElementById(player.config.targetId) as HTMLDivElement) || document;
-    const portalSelector = `.overlay-portal`;
-
     return (
       <>
         <ButtonControl name={COMPONENT_NAME} ref={controlCaptionsElement}>
@@ -108,7 +106,7 @@ const CaptionsControl = connect(mapStateToProps)(
               <CaptionsMenu asDropdown={false} onAdvancedCaptionsClick={toggleCVAAOverlay} />
             </SmartContainer>
           )}
-          {cvaaOverlay ? createPortal(<CVAAOverlay onClose={onCVAAOverlayClose} />, targetId.querySelector(portalSelector)!) : <div />}
+          {cvaaOverlay ? createPortal(<CVAAOverlay onClose={onCVAAOverlayClose} />, getOverlayPortalElement(player)!) : <div />}
         </ButtonControl>
         <CaptionsControlMini {...props}/>
       </>

--- a/src/components/overlay-portal/index.ts
+++ b/src/components/overlay-portal/index.ts
@@ -1,1 +1,2 @@
 export {OverlayPortal} from './overlay-portal';
+export * from './overlay-portal-utils';

--- a/src/components/overlay-portal/overlay-portal-utils.ts
+++ b/src/components/overlay-portal/overlay-portal-utils.ts
@@ -1,0 +1,8 @@
+import {KalturaPlayer} from '@playkit-js/kaltura-player-js';
+
+const OVERLAY_PORTAL_SELECTOR = '.overlay-portal';
+
+export const getOverlayPortalElement = (player: KalturaPlayer): Element | null => {
+  const targetOverlayEl: HTMLDivElement | Document = (document.getElementById(player.config.targetId) as HTMLDivElement) || document;
+  return targetOverlayEl.querySelector(OVERLAY_PORTAL_SELECTOR);
+}

--- a/src/components/overlay-portal/overlay-portal-utils.ts
+++ b/src/components/overlay-portal/overlay-portal-utils.ts
@@ -5,4 +5,4 @@ const OVERLAY_PORTAL_SELECTOR = '.overlay-portal';
 export const getOverlayPortalElement = (player: KalturaPlayer): Element | null => {
   const targetOverlayEl: HTMLDivElement | Document = (document.getElementById(player.config.targetId) as HTMLDivElement) || document;
   return targetOverlayEl.querySelector(OVERLAY_PORTAL_SELECTOR);
-}
+};

--- a/src/components/overlay/overlay.tsx
+++ b/src/components/overlay/overlay.tsx
@@ -7,6 +7,8 @@ import {actions as overlayActions} from '../../reducers/overlay';
 import {actions as shellActions} from '../../reducers/shell';
 import {default as Icon, IconType} from '../icon';
 import {KeyMap} from '../../utils';
+import {withPlayer} from '../player';
+import {getOverlayPortalElement} from '../overlay-portal';
 
 const COMPONENT_NAME = 'Overlay';
 
@@ -31,6 +33,7 @@ const mapStateToProps = state => ({
  * @extends {Component}
  */
 @connect(mapStateToProps, bindActions({...shellActions, ...overlayActions}))
+@withPlayer
 class Overlay extends Component<any, any> {
   _timeoutId: number | null = null;
   overlayRef: RefObject<HTMLDivElement> = createRef<HTMLDivElement>();
@@ -57,7 +60,8 @@ class Overlay extends Component<any, any> {
       this._timeoutId = null;
     }
     // Remove the overlay-active class only when there is a single child
-    if (this.overlayRef.current?.childElementCount === 1) {
+    const overlayPortalEl = getOverlayPortalElement(this.props.player);
+    if (overlayPortalEl?.childElementCount === 1) {
       this.props.removePlayerClass(style.overlayActive);
     }
   }

--- a/src/components/overlay/overlay.tsx
+++ b/src/components/overlay/overlay.tsx
@@ -1,5 +1,5 @@
 import style from '../../styles/style.scss';
-import {h, Component, VNode} from 'preact';
+import {h, Component, VNode, RefObject, createRef} from 'preact';
 import {Localizer, Text} from 'preact-i18n';
 import {connect} from 'react-redux';
 import {bindActions} from '../../utils';
@@ -33,6 +33,7 @@ const mapStateToProps = state => ({
 @connect(mapStateToProps, bindActions({...shellActions, ...overlayActions}))
 class Overlay extends Component<any, any> {
   _timeoutId: number | null = null;
+  overlayRef: RefObject<HTMLDivElement> = createRef<HTMLDivElement>();
   /**
    * componentWillMount
    *
@@ -55,7 +56,10 @@ class Overlay extends Component<any, any> {
       clearTimeout(this._timeoutId);
       this._timeoutId = null;
     }
-    this.props.removePlayerClass(style.overlayActive);
+    // Remove the overlay-active class only when there is a single child
+    if (this.overlayRef.current?.childElementCount === 1) {
+      this.props.removePlayerClass(style.overlayActive);
+    }
   }
 
   /**
@@ -141,7 +145,7 @@ class Overlay extends Component<any, any> {
     }
 
     return (
-      <div tabIndex={-1} className={overlayClass.join(' ')} role="dialog" onKeyDown={this.onKeyDown} {...ariaProps}>
+      <div tabIndex={-1} className={overlayClass.join(' ')} role="dialog" onKeyDown={this.onKeyDown} {...ariaProps} ref={this.overlayRef}>
         <div className={style.overlayContents}>{this.props.children}</div>
         {this.renderCloseButton(this.props)}
       </div>

--- a/src/components/overlay/overlay.tsx
+++ b/src/components/overlay/overlay.tsx
@@ -1,5 +1,5 @@
 import style from '../../styles/style.scss';
-import {h, Component, VNode, RefObject, createRef} from 'preact';
+import {h, Component, VNode} from 'preact';
 import {Localizer, Text} from 'preact-i18n';
 import {connect} from 'react-redux';
 import {bindActions} from '../../utils';
@@ -36,7 +36,6 @@ const mapStateToProps = state => ({
 @withPlayer
 class Overlay extends Component<any, any> {
   _timeoutId: number | null = null;
-  overlayRef: RefObject<HTMLDivElement> = createRef<HTMLDivElement>();
   /**
    * componentWillMount
    *
@@ -149,7 +148,7 @@ class Overlay extends Component<any, any> {
     }
 
     return (
-      <div tabIndex={-1} className={overlayClass.join(' ')} role="dialog" onKeyDown={this.onKeyDown} {...ariaProps} ref={this.overlayRef}>
+      <div tabIndex={-1} className={overlayClass.join(' ')} role="dialog" onKeyDown={this.onKeyDown} {...ariaProps}>
         <div className={style.overlayContents}>{this.props.children}</div>
         {this.renderCloseButton(this.props)}
       </div>

--- a/src/components/settings/settings.tsx
+++ b/src/components/settings/settings.tsx
@@ -27,6 +27,7 @@ import {withKeyboardEvent} from '../keyboard';
 import {KeyboardEventHandlers} from '../../types';
 import {withLogger} from '../logger';
 import {SpeedSelectedEvent} from '../../event/events/speed-selected-event';
+import {getOverlayPortalElement} from '../overlay-portal';
 
 /**
  * mapping state to props
@@ -312,8 +313,6 @@ class Settings extends Component<any, any> {
     if (props.isLive && props.videoTracks.length <= 1 && !showAudioMenu && !showCaptionsMenu) return undefined;
     const buttonBadgeType: string = this.getButtonBadgeType() || '';
 
-    const targetId: HTMLDivElement | Document = (document.getElementById(this.props.player.config.targetId) as HTMLDivElement) || document;
-    const portalSelector = `.overlay-portal`;
     const buttonAriaLabel = props.buttonLabel + ' ' + this.getQualityLabel(buttonBadgeType);
     return (
       <ButtonControl name={COMPONENT_NAME} ref={c => (c ? (this._controlSettingsElement = c) : undefined)}>
@@ -334,7 +333,7 @@ class Settings extends Component<any, any> {
           </Button>
         </Tooltip>
         {this.state.smartContainerOpen && !this.state.cvaaOverlay && (
-          <SmartContainer targetId={props.player.config.targetId} title={<Text id="settings.title" />} onClose={this.onControlButtonClick}>
+          <SmartContainer title={<Text id="settings.title" />} onClose={this.onControlButtonClick}>
             {showAdvancedAudioDescToggle && <AdvancedAudioDescToggle />}
             {showAudioMenu && <AudioMenu />}
             {showCaptionsMenu && <CaptionsMenu asDropdown={true} onAdvancedCaptionsClick={this.toggleCVAAOverlay} />}
@@ -342,7 +341,7 @@ class Settings extends Component<any, any> {
             {showSpeedMenu && <SpeedMenu />}
           </SmartContainer>
         )}
-        {this.state.cvaaOverlay ? createPortal(<CVAAOverlay onClose={this.onCVAAOverlayClose} />, targetId.querySelector(portalSelector)!) : <div />}
+        {this.state.cvaaOverlay ? createPortal(<CVAAOverlay onClose={this.onCVAAOverlayClose} />, getOverlayPortalElement(props.player)!) : <div />}
       </ButtonControl>
     );
   }

--- a/src/components/smart-container/smart-container.tsx
+++ b/src/components/smart-container/smart-container.tsx
@@ -7,6 +7,8 @@ import {createPortal} from 'preact/compat';
 import {Overlay} from '../overlay';
 import {withKeyboardA11y} from '../../utils';
 import {withText} from 'preact-i18n';
+import {withPlayer} from '../player';
+import {getOverlayPortalElement} from '../overlay-portal';
 
 /**
  * mapping state to props
@@ -37,6 +39,7 @@ const COMPONENT_NAME = 'SmartContainer';
  */
 @connect(mapStateToProps, bindActions(actions))
 @withKeyboardA11y
+@withPlayer
 @withText({settingsText: 'settings.title'})
 class SmartContainer extends Component<any, any> {
   /**
@@ -87,8 +90,6 @@ class SmartContainer extends Component<any, any> {
    * @memberof SmartContainer
    */
   render(props: any): VNode<any> {
-    const targetId = document.getElementById(this.props.targetId) || document;
-    const portalSelector = `.overlay-portal`;
     props.clearAccessibleChildren();
     return this.isPortal ? (
       createPortal(
@@ -102,7 +103,7 @@ class SmartContainer extends Component<any, any> {
           <div className={style.title}>{props.title}</div>
           {this.renderChildren(props)}
         </Overlay>,
-        targetId.querySelector(portalSelector)!
+        getOverlayPortalElement(props.player)!
       )
     ) : (
       <div onKeyDown={props.handleKeyDown} tabIndex={-1} role="menu" className={[style.smartContainer, style.top, style.left].join(' ')}>

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,8 +16,12 @@ import style from './styles/style.scss';
 import {SidePanelPositions, SidePanelModes, ReservedPresetNames, ReservedPresetAreas} from './reducers/shell';
 // Event
 import * as Event from './event';
-export {Event};
+// Overlay portal utils
+import {getOverlayPortalElement} from './components/overlay-portal';
+
 export {EventType, EventType as UIEventType} from './event/event-type';
+export {Event};
+export {getOverlayPortalElement};
 
 declare const __VERSION__: string;
 declare const __NAME__: string;


### PR DESCRIPTION
### Description of the Changes

bugfix

**Issue:**
when opening the cvaa (advanced captions settings) while the video is playing and the video reaches a quiz question cue point, then closing the cvaa overlay- the quiz question overlay stays on the player and there is no way to close it.
the root cause is that closing the cvaa causes the removal of overlay-active class, which causes the odd behavior of the quiz question overlay.

**Fix:**
- do not remove the `overlay-active` class if `overlayPortal` component has multiple children- remove it only if there's a single child
- create a reusable `getOverlayPortalElement` function which returns the `overlayPortal` element
- use `getOverlayPortalElement` function in other components
- expose `getOverlayPortalElement` function for a future use outside of core scope

#### Resolves FEC-14156


