### PR TITLE
fix(FEC-14172): overlay-active is not removed from player

### DIFF
--- a/src/components/overlay/overlay.tsx
+++ b/src/components/overlay/overlay.tsx
@@ -58,10 +58,14 @@ class Overlay extends Component<any, any> {
       clearTimeout(this._timeoutId);
       this._timeoutId = null;
     }
-    // Remove the overlay-active class only when there is a single child
-    const overlayPortalEl = getOverlayPortalElement(this.props.player);
-    if (overlayPortalEl?.childElementCount === 1) {
+    if (this.props.dontCheckOverlayPortal) {
       this.props.removePlayerClass(style.overlayActive);
+    } else {
+      // Remove the overlay-active class only when overlay portal has a single child
+      const overlayPortalEl = getOverlayPortalElement(this.props.player);
+      if (overlayPortalEl!.childElementCount <= 1) {
+        this.props.removePlayerClass(style.overlayActive);
+      }
     }
   }
 


### PR DESCRIPTION
### Description of the Changes

bugfix

**Issue:**
`overlay-active` class is not being removed from the player, which prevents any user interaction with the player.
in this specific case, `welcomeScreen` of quiz is an `Overlay` component but is not rendered under `OverlayPortal` - which breaks the current condition to remove the `overlay-active` class.

**Fix:**
add a new prop - `dontCheckOverlayPortal`, which indicates whether `Overlay` should go through the `OverlayPortal` condition, or simply remove `overlay-active` class unconditionally.

#### Resolves FEC-14172
**related pr:** https://github.com/kaltura/playkit-js-ivq/pull/136


