### PR TITLE
fix(ADA-1789): [ORS] - Firefox playerkit - "Read more" button in the navigation overlay is not read by screen reader (NVDA)

### DIFF
--- a/src/components/expandable-text/expandable-text.tsx
+++ b/src/components/expandable-text/expandable-text.tsx
@@ -25,7 +25,7 @@ interface ExpandableTextProps {
 
 const ReadMoreLessButton = ({isTextExpanded, readLessLabel, readMoreLabel, onClick, onKeyDown, ...otherProps}) => {
   return (
-    <div tabIndex={0} className={styles.moreButtonText} onClick={onClick} onKeyDown={onKeyDown} {...otherProps}>
+    <div role="button" tabIndex={0} className={styles.moreButtonText} onClick={onClick} onKeyDown={onKeyDown} {...otherProps}>
       {isTextExpanded ? readLessLabel : readMoreLabel}
     </div>
   );


### PR DESCRIPTION
### Description of the Changes

**Issue:**
screen reader doesn't announce the "Read more" button in Firefox browser

**Fix:**
Adding role button to div element.

#### Resolves [ADA-1789](https://kaltura.atlassian.net/browse/ADA-1789)




[ADA-1789]: https://kaltura.atlassian.net/browse/ADA-1789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ