### PR TITLE
fix(ADA-17): Playback button labels are generic and not video specific

### DIFF
--- a/src/components/play-pause/play-pause.tsx
+++ b/src/components/play-pause/play-pause.tsx
@@ -94,14 +94,14 @@ class PlayPause extends Component<any, any> {
     const controlButtonClass = this.props.isPlayingAdOrPlayback ? [style.controlButton, style.isPlaying].join(' ') : style.controlButton;
     const isStartOver = props.isPlaybackEnded && !this.props.adBreak;
     const entryName = `, ${this.props.title}: ${this.props.player.sources.metadata?.name}`;
-    const playbackStateText = `${this.props.isPlayingAdOrPlayback ? this.props.pauseText : this.props.playText}${entryName}`;
+    const playbackStateText = this.props.isPlayingAdOrPlayback ? this.props.pauseText : this.props.playText;
     const labelText = isStartOver ? this.props.startOverText : playbackStateText;
     return (
       <ButtonControl name={COMPONENT_NAME}>
         <Tooltip label={labelText}>
           <Button
             tabIndex="0"
-            aria-label={labelText}
+            aria-label={labelText+ entryName}
             className={controlButtonClass}
             onClick={this.togglePlayPause}
             ref={node => {

--- a/src/components/play-pause/play-pause.tsx
+++ b/src/components/play-pause/play-pause.tsx
@@ -47,7 +47,8 @@ const COMPONENT_NAME = 'PlayPause';
 @withText({
   startOverText: 'controls.startOver',
   pauseText: 'controls.pause',
-  playText: 'controls.play'
+  playText: 'controls.play',
+  title: 'controls.title'
 })
 class PlayPause extends Component<any, any> {
   private _playPauseButtonRef?: HTMLButtonElement;
@@ -92,7 +93,8 @@ class PlayPause extends Component<any, any> {
   render(props: any): VNode<any> | undefined {
     const controlButtonClass = this.props.isPlayingAdOrPlayback ? [style.controlButton, style.isPlaying].join(' ') : style.controlButton;
     const isStartOver = props.isPlaybackEnded && !this.props.adBreak;
-    const playbackStateText = this.props.isPlayingAdOrPlayback ? this.props.pauseText : this.props.playText;
+    const entryName = `, ${this.props.title}: ${this.props.player.sources.metadata?.name}`;
+    const playbackStateText = `${this.props.isPlayingAdOrPlayback ? this.props.pauseText : this.props.playText}${entryName}`;
     const labelText = isStartOver ? this.props.startOverText : playbackStateText;
     return (
       <ButtonControl name={COMPONENT_NAME}>

--- a/src/components/play-pause/play-pause.tsx
+++ b/src/components/play-pause/play-pause.tsx
@@ -93,7 +93,7 @@ class PlayPause extends Component<any, any> {
   render(props: any): VNode<any> | undefined {
     const controlButtonClass = this.props.isPlayingAdOrPlayback ? [style.controlButton, style.isPlaying].join(' ') : style.controlButton;
     const isStartOver = props.isPlaybackEnded && !this.props.adBreak;
-    const entryName = `, ${this.props.title}: ${this.props.player.sources.metadata?.name}`;
+    const entryName = `${this.props.title}: ${this.props.player.sources.metadata?.name}`;
     const playbackStateText = this.props.isPlayingAdOrPlayback ? this.props.pauseText : this.props.playText;
     const labelText = isStartOver ? this.props.startOverText : playbackStateText;
     return (
@@ -101,7 +101,7 @@ class PlayPause extends Component<any, any> {
         <Tooltip label={labelText}>
           <Button
             tabIndex="0"
-            aria-label={labelText+ entryName}
+            aria-label={`${labelText}, ${entryName}`}
             className={controlButtonClass}
             onClick={this.togglePlayPause}
             ref={node => {

--- a/src/components/pre-playback-play-overlay/pre-playback-play-overlay.tsx
+++ b/src/components/pre-playback-play-overlay/pre-playback-play-overlay.tsx
@@ -91,10 +91,10 @@ class PrePlaybackPlayOverlay extends Component<any, any> {
       return undefined;
     }
     const entryName = `, ${this.props.title}: ${this.props.player.sources.metadata?.name}`;
-    const labelText = `${props.isPlaybackEnded ? props.startOverText : props.playText} ${entryName}`;
+    const labelText = props.isPlaybackEnded ? props.startOverText : props.playText;
     return (
       <div className={style.prePlaybackPlayOverlay} onMouseOver={this.onMouseOver} onClick={this.handleClick}>
-        <Button className={style.prePlaybackPlayButton} tabIndex="0" aria-label={labelText} onKeyDown={this.onKeyDown}>
+        <Button className={style.prePlaybackPlayButton} tabIndex="0" aria-label={labelText + entryName} onKeyDown={this.onKeyDown}>
           <Tooltip label={labelText}>{props.isPlaybackEnded ? <Icon type={IconType.StartOver} /> : <Icon type={IconType.Play} />}</Tooltip>
         </Button>
       </div>

--- a/src/components/pre-playback-play-overlay/pre-playback-play-overlay.tsx
+++ b/src/components/pre-playback-play-overlay/pre-playback-play-overlay.tsx
@@ -39,7 +39,8 @@ const COMPONENT_NAME = 'PrePlaybackPlayOverlay';
 @withEventDispatcher(COMPONENT_NAME)
 @withText({
   startOverText: 'controls.startOver',
-  playText: 'controls.play'
+  playText: 'controls.play',
+  title: 'controls.title'
 })
 class PrePlaybackPlayOverlay extends Component<any, any> {
   /**
@@ -89,7 +90,8 @@ class PrePlaybackPlayOverlay extends Component<any, any> {
     if (!(props.prePlayback || isStartOver) || props.loading) {
       return undefined;
     }
-    const labelText = props.isPlaybackEnded ? props.startOverText : props.playText;
+    const entryName = `, ${this.props.title}: ${this.props.player.sources.metadata?.name}`;
+    const labelText = `${props.isPlaybackEnded ? props.startOverText : props.playText} ${entryName}`;
     return (
       <div className={style.prePlaybackPlayOverlay} onMouseOver={this.onMouseOver} onClick={this.handleClick}>
         <Button className={style.prePlaybackPlayButton} tabIndex="0" aria-label={labelText} onKeyDown={this.onKeyDown}>

--- a/src/components/pre-playback-play-overlay/pre-playback-play-overlay.tsx
+++ b/src/components/pre-playback-play-overlay/pre-playback-play-overlay.tsx
@@ -90,11 +90,11 @@ class PrePlaybackPlayOverlay extends Component<any, any> {
     if (!(props.prePlayback || isStartOver) || props.loading) {
       return undefined;
     }
-    const entryName = `, ${this.props.title}: ${this.props.player.sources.metadata?.name}`;
+    const entryName = `${this.props.title}: ${this.props.player.sources.metadata?.name}`;
     const labelText = props.isPlaybackEnded ? props.startOverText : props.playText;
     return (
       <div className={style.prePlaybackPlayOverlay} onMouseOver={this.onMouseOver} onClick={this.handleClick}>
-        <Button className={style.prePlaybackPlayButton} tabIndex="0" aria-label={labelText + entryName} onKeyDown={this.onKeyDown}>
+        <Button className={style.prePlaybackPlayButton} tabIndex="0" aria-label={`${labelText}, ${entryName}`} onKeyDown={this.onKeyDown}>
           <Tooltip label={labelText}>{props.isPlaybackEnded ? <Icon type={IconType.StartOver} /> : <Icon type={IconType.Play} />}</Tooltip>
         </Button>
       </div>

--- a/translations/en.i18n.json
+++ b/translations/en.i18n.json
@@ -3,6 +3,7 @@
     "controls": {
       "play": "Play",
       "pause": "Pause",
+      "title": "title",
       "language": "Language",
       "settings": "Settings",
       "fullscreen": "Fullscreen",


### PR DESCRIPTION
### Description of the Changes

**Issue:**
When multiple players are embedded in single page, the screen reader's element list does not identify which button related to which player.

**Fix:**
Adding the entry name to the aria-label of play, pause, start over buttons

#### Resolves [ADA-17](https://kaltura.atlassian.net/browse/ADA-17)




[ADA-17]: https://kaltura.atlassian.net/browse/ADA-17?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ