### PR TITLE
fix(FEC-14177): a11y fixes

### DIFF
--- a/src/components/advanced-audio-desc/advanced-audio-desc.tsx
+++ b/src/components/advanced-audio-desc/advanced-audio-desc.tsx
@@ -97,6 +97,7 @@ class AdvancedAudioDesc extends Component<any, any> implements IconComponent {
    */
   onKeyDown = (e: KeyboardEvent): void => {
     if ([KeyCode.Enter, KeyCode.Space].includes(e.code)) {
+      e.preventDefault();
       this.onClick();
     }
   };

--- a/src/components/picture-in-picture/picture-in-picture.tsx
+++ b/src/components/picture-in-picture/picture-in-picture.tsx
@@ -109,6 +109,7 @@ class PictureInPicture extends Component<any, any> implements IconComponent {
    */
   onKeyDown = (e: KeyboardEvent): void => {
     if ([KeyCode.Enter, KeyCode.Space].includes(e.code)) {
+      e.preventDefault();
       this.togglePip();
       this.props.updatePlayerHoverState(true);
     }

--- a/src/components/vr-stereo/vr-stereo.tsx
+++ b/src/components/vr-stereo/vr-stereo.tsx
@@ -104,6 +104,7 @@ class VrStereo extends Component<any, any> implements IconComponent {
    */
   onKeyDown = (e: KeyboardEvent): void => {
     if ([KeyCode.Enter, KeyCode.Space].includes(e.code)) {
+      e.preventDefault();
       this.onClick();
     }
   };


### PR DESCRIPTION
### Description of the Changes

**Issue:**
using enter and space while PiP, VR and AAD components are in the bottom bar- happens twice. once from onKeyDown and another one from button's onClick.

**Fix:**
use `preventDefault()`.

#### Resolves FEC-14177, FEC-14204


