### PR TITLE
ADA(ADA-1451): Close Video Info modal dialog focus management

### DIFF
--- a/src/utils/popup-keyboard-accessibility.tsx
+++ b/src/utils/popup-keyboard-accessibility.tsx
@@ -1,6 +1,6 @@
-import { h, Component } from 'preact';
-import { KeyMap } from './key-map';
-import { focusElement } from './focus-element';
+import {h, Component} from 'preact';
+import {KeyMap} from './key-map';
+import {focusElement} from './focus-element';
 
 /**
  * wraps a component and handles all key navigation and focus
@@ -13,6 +13,7 @@ export const withKeyboardA11y = (WrappedComponent): any =>
     _accessibleChildren: Array<HTMLElement> = [];
     _previouslyActiveElement?: HTMLElement | null;
     _isModal: boolean = false;
+    _morePluginButton: HTMLButtonElement | null;
 
     /**
      * after component mounted, focus on relevant element
@@ -31,6 +32,15 @@ export const withKeyboardA11y = (WrappedComponent): any =>
      */
     set isModal(value: boolean) {
       this._isModal = value;
+    }
+
+    /**
+     * setter to change to more button state
+     * @param {boolean} value - the modal state
+     * @memberOf HOC
+     */
+    set morePluginButton(button: HTMLButtonElement | null) {
+      this._morePluginButton = button;
     }
 
     /**
@@ -92,6 +102,8 @@ export const withKeyboardA11y = (WrappedComponent): any =>
     componentWillUnmount(): void {
       if (this._previouslyActiveElement && document.contains(this._previouslyActiveElement)) {
         focusElement(this._previouslyActiveElement);
+      } else if (this._previouslyActiveElement?.classList.contains('playkit-dropdown-item_kw')) {
+        focusElement(this._morePluginButton);
       }
     }
 
@@ -112,6 +124,7 @@ export const withKeyboardA11y = (WrappedComponent): any =>
           clearAccessibleChildren={this.clearAccessibleChildren}
           handleKeyDown={this.onKeyDown}
           setIsModal={this.setIsModel}
+          setMoreButton={this.setMoreButton}
         />
       );
     }
@@ -171,5 +184,9 @@ export const withKeyboardA11y = (WrappedComponent): any =>
      */
     setIsModel = (isModel: boolean): void => {
       this.isModal = isModel;
+    };
+
+    setMoreButton = (moreButton: HTMLButtonElement | null): void => {
+      this.morePluginButton = moreButton;
     };
   };

--- a/src/utils/popup-keyboard-accessibility.tsx
+++ b/src/utils/popup-keyboard-accessibility.tsx
@@ -13,7 +13,7 @@ export const withKeyboardA11y = (WrappedComponent): any =>
     _accessibleChildren: Array<HTMLElement> = [];
     _previouslyActiveElement?: HTMLElement | null;
     _isModal: boolean = false;
-    _morePluginButton: HTMLButtonElement | null;
+    _morePluginButton: HTMLButtonElement | null = null;
 
     /**
      * after component mounted, focus on relevant element


### PR DESCRIPTION
### Description of the Changes

**Issue:** 
if user open the info plugin from more plugin, when press enter on x the focus is lost and doesn't move to the more plugin

**Root cause:**
The previous element is the dropdown info div from the more dropdown and not the the more button

**Fix:**
Create a reference of more plugin (we set it from the info plugin) and in case the previous element is dropdown item (of the more), move the focus to more plugin.

part of:
https://github.com/kaltura/playkit-js-ui-managers/pull/67
https://github.com/kaltura/playkit-js-info/pull/106

#### Resolves [ADA-1451](https://kaltura.atlassian.net/browse/ADA-1451)




[ADA-1451]: https://kaltura.atlassian.net/browse/ADA-1451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ