### PR TITLE
fix(ADA-1593): instead of forwardRef , manually set the button reference in the button component

### DIFF
--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -20,7 +20,7 @@ const Button = (props) => {
     if (ref && 'current' in ref && buttonRef.current) {
       ref.current = buttonRef.current;
     }
-  }, [setRef, ref]);
+  },[buttonRef]);
 
   return <button type="button" ref={buttonRef} {...otherProps}/>;
 };

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -1,6 +1,5 @@
 import {h} from 'preact';
-import {forwardRef} from 'preact/compat';
-
+import {useEffect, useRef} from 'preact/hooks';
 const COMPONENT_NAME = 'Button';
 /**
  * Button component
@@ -8,7 +7,24 @@ const COMPONENT_NAME = 'Button';
  * @const Button
  * @example <Button/>
  */
-const Button = forwardRef<HTMLButtonElement, any>((props, ref) => <button type="button" ref={ref} {...props} />);
+const Button = (props) => {
+  const { setRef, ref,...otherProps } = props;
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    // if setRef is a function
+    if (typeof setRef === 'function' && buttonRef.current) {
+      setRef(buttonRef.current);
+    }
+    // if ref is a ref object
+    if (ref && 'current' in ref && buttonRef.current) {
+      ref.current = buttonRef.current;
+    }
+  }, [setRef, ref]);
+
+  return <button type="button" ref={buttonRef} {...otherProps}/>;
+};
+
 
 Button.displayName = COMPONENT_NAME;
 export {Button};

--- a/src/components/copy-button/copy-button.tsx
+++ b/src/components/copy-button/copy-button.tsx
@@ -107,7 +107,7 @@ class CopyButton extends Component<any, any> {
             <Button
               tabIndex="0"
               aria-label={this.props.copyButtonLabel}
-              ref={el => {
+              setRef={el => {
                 if (props.addAccessibleChild) {
                   props.addAccessibleChild(el);
                 }

--- a/src/components/play-pause/play-pause.tsx
+++ b/src/components/play-pause/play-pause.tsx
@@ -51,11 +51,7 @@ const COMPONENT_NAME = 'PlayPause';
   title: 'controls.title'
 })
 class PlayPause extends Component<any, any> {
-  private _playPauseButtonRef?: HTMLButtonElement | null;
-
-  setButtonRef = (node: HTMLButtonElement | null) => {
-    this._playPauseButtonRef = node;
-  };
+  private _playPauseButtonRef?: HTMLButtonElement;
 
   /**
    * component mounted
@@ -108,7 +104,9 @@ class PlayPause extends Component<any, any> {
             aria-label={`${labelText}, ${entryName}`}
             className={controlButtonClass}
             onClick={this.togglePlayPause}
-            setRef={this.setButtonRef}
+            setRef={node => {
+              this._playPauseButtonRef = node;
+            }}
           >
             {isStartOver ? (
               <Icon type={IconType.StartOver} />

--- a/src/components/play-pause/play-pause.tsx
+++ b/src/components/play-pause/play-pause.tsx
@@ -51,7 +51,11 @@ const COMPONENT_NAME = 'PlayPause';
   title: 'controls.title'
 })
 class PlayPause extends Component<any, any> {
-  private _playPauseButtonRef?: HTMLButtonElement;
+  private _playPauseButtonRef?: HTMLButtonElement | null;
+
+  setButtonRef = (node: HTMLButtonElement | null) => {
+    this._playPauseButtonRef = node;
+  };
 
   /**
    * component mounted
@@ -104,9 +108,8 @@ class PlayPause extends Component<any, any> {
             aria-label={`${labelText}, ${entryName}`}
             className={controlButtonClass}
             onClick={this.togglePlayPause}
-            ref={node => {
-              this._playPauseButtonRef = node;
-            }}>
+            setRef={this.setButtonRef}
+          >
             {isStartOver ? (
               <Icon type={IconType.StartOver} />
             ) : (

--- a/src/components/seekbar/seekbar.tsx
+++ b/src/components/seekbar/seekbar.tsx
@@ -100,7 +100,7 @@ class SeekBar extends Component<any, any> {
    * @memberof SeekBar
    */
   componentDidMount(): void {
-    const {player, eventManager, playerSize} = this.props;
+    const {player, eventManager} = this.props;
     const clientRect = this._seekBarElement.getBoundingClientRect();
     this.props.updateSeekbarClientRect(clientRect);
     eventManager.listen(player, EventType.GUI_RESIZE, () => {

--- a/src/components/settings/settings.tsx
+++ b/src/components/settings/settings.tsx
@@ -318,7 +318,7 @@ class Settings extends Component<any, any> {
       <ButtonControl name={COMPONENT_NAME} ref={c => (c ? (this._controlSettingsElement = c) : undefined)}>
         <Tooltip label={props.buttonLabel}>
           <Button
-            ref={this.setButtonRef}
+            setRef={this.setButtonRef}
             tabIndex="0"
             aria-label={buttonAriaLabel}
             aria-haspopup="true"

--- a/src/components/tooltip/_tooltip.scss
+++ b/src/components/tooltip/_tooltip.scss
@@ -137,7 +137,6 @@
   &.show {
     visibility: visible;
     opacity: 1;
-    z-index: 1;
   }
 
   &.hide {

--- a/src/components/tooltip/_tooltip.scss
+++ b/src/components/tooltip/_tooltip.scss
@@ -137,6 +137,7 @@
   &.show {
     visibility: visible;
     opacity: 1;
+    z-index: 1;
   }
 
   &.hide {


### PR DESCRIPTION
issue:
forwardRef didn't pass the ref properly. thus in play-pause component the ref call back when rendering the button component wasn't executed, and so the focus didn't execute as the button was undefined.

solution:
after discussing it with @semarche-kaltura , it was decided to set the reference manually.
since the reference can be a function or an object, I've added two cases to handle that, and adjust the compoents accordingly to send the right props.
now the focus works as expected.