### PR TITLE
fix(SUP-45003): [IKEA Ingka] - past scheduled embedded entries will show a wrong error message for V7 player

### DIFF
--- a/src/components/error-overlay/error-message-provider.ts
+++ b/src/components/error-overlay/error-message-provider.ts
@@ -29,7 +29,11 @@ const errorsMap: Map<number, ErrorDetails> = new Map<number, ErrorDetails>([
   /** KS RESTRICTION */
   [14, {title: 'media_unavailable_error_title', message: 'media_unavailable_error_message'}],
   /** IP RESTRICTION */
-  [15, {title: 'media_unavailable_error_title', message: 'ip_restricted_error_message'}]
+  [15, {title: 'media_unavailable_error_title', message: 'ip_restricted_error_message'}],
+  /** SITE RESTRICTION */
+  [16, {title: 'media_unavailable_error_title', message: 'site_restricted_error_message'}],
+  /** SCHEDULED RESTRICTION */
+  [17, {title: 'media_unavailable_error_title', message: 'scheduled_restricted_error_message'}]
 ]);
 
 const defaultError: ErrorDetails = {

--- a/translations/en.i18n.json
+++ b/translations/en.i18n.json
@@ -93,6 +93,8 @@
       "geo_location_error_title": "Geo location unavailable",
       "geo_location_error_message": "This content is unavailable in your region.",
       "ip_restricted_error_message": "This media has been restricted to certain IP addresses.",
+      "site_restricted_error_message": "This content is unavailable in this domain.",
+      "scheduled_restricted_error_message": "This content is currently unavailable.",
       "default_session_text": "Copy for customer care: session ID",
       "retry": "Try again"
     },


### PR DESCRIPTION
### Description of the Changes

Adding error messages to site restriction and scheduled restriction

Part of - https://github.com/kaltura/playkit-js/pull/805, https://github.com/kaltura/kaltura-player-js/pull/897, https://github.com/kaltura/playkit-js-providers/pull/245

#### Resolves [SUP-45003](https://kaltura.atlassian.net/browse/SUP-45003)




[SUP-45003]: https://kaltura.atlassian.net/browse/SUP-45003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ