### PR TITLE
fix(SUP-46391): Player Live Full Screen Bug when browser window is not maximized

### DIFF
--- a/src/components/shell/shell.tsx
+++ b/src/components/shell/shell.tsx
@@ -43,6 +43,7 @@ const mapStateToProps = state => ({
 });
 
 const ON_PLAYER_RECT_CHANGE_DEBOUNCE_DELAY: number = 100;
+const RESIZE_DEBOUNCE_DELAY: number = 0;
 
 const PLAYER_SIZE: {[size: string]: string} = {
   TINY: 'tiny',
@@ -212,7 +213,7 @@ class Shell extends Component<any, any> {
    */
   componentDidMount() {
     const {player, eventManager} = this.props;
-    eventManager.listen(window, 'resize', debounce(this._onWindowResize, ON_PLAYER_RECT_CHANGE_DEBOUNCE_DELAY));
+    eventManager.listen(window, 'resize', debounce(this._onWindowResize, RESIZE_DEBOUNCE_DELAY));
     eventManager.listen(document, 'scroll', debounce(this._updatePlayerClientRect, ON_PLAYER_RECT_CHANGE_DEBOUNCE_DELAY));
     eventManager.listen(document, 'click', debounce(this._handleClickOutside, ON_PLAYER_RECT_CHANGE_DEBOUNCE_DELAY));
     this._playerResizeWatcher = new ResizeWatcher();
@@ -258,17 +259,23 @@ class Shell extends Component<any, any> {
    * @memberof Shell
    */
   _updatePlayerClientRect = () => {
-    const updateClientRect = () => {
-      const playerContainer = document.getElementById(this.props.targetId);
-      if (playerContainer) {
-        this.props.updatePlayerClientRect(playerContainer.getBoundingClientRect());
-      }
-    };
-
-    const animationFrameId = requestAnimationFrame(updateClientRect);
-    return () => cancelAnimationFrame(animationFrameId);
+    const playerContainer = document.getElementById(this.props.targetId);
+    if (playerContainer) {
+      this.props.updatePlayerClientRect(playerContainer.getBoundingClientRect());
+    }
   };
 
+  // _updatePlayerClientRect = () => {
+  //   const updateClientRect = () => {
+  //     const playerContainer = document.getElementById(this.props.targetId);
+  //     if (playerContainer) {
+  //       this.props.updatePlayerClientRect(playerContainer.getBoundingClientRect());
+  //     }
+  //   };
+  //   setTimeout(() => {
+  //     updateClientRect();
+  //   }, 100);
+  // };
 
   /**
    * before component mounted, remove event listeners

--- a/src/components/shell/shell.tsx
+++ b/src/components/shell/shell.tsx
@@ -43,7 +43,7 @@ const mapStateToProps = state => ({
 });
 
 const ON_PLAYER_RECT_CHANGE_DEBOUNCE_DELAY: number = 100;
-const RESIZE_DEBOUNCE_DELAY: number = 0;
+const DOM_UPDATE_DELAY = 50;
 
 const PLAYER_SIZE: {[size: string]: string} = {
   TINY: 'tiny',
@@ -213,7 +213,7 @@ class Shell extends Component<any, any> {
    */
   componentDidMount() {
     const {player, eventManager} = this.props;
-    eventManager.listen(window, 'resize', debounce(this._onWindowResize, RESIZE_DEBOUNCE_DELAY));
+    eventManager.listen(window, 'resize', debounce(this._onWindowResize, ON_PLAYER_RECT_CHANGE_DEBOUNCE_DELAY));
     eventManager.listen(document, 'scroll', debounce(this._updatePlayerClientRect, ON_PLAYER_RECT_CHANGE_DEBOUNCE_DELAY));
     eventManager.listen(document, 'click', debounce(this._handleClickOutside, ON_PLAYER_RECT_CHANGE_DEBOUNCE_DELAY));
     this._playerResizeWatcher = new ResizeWatcher();
@@ -259,10 +259,12 @@ class Shell extends Component<any, any> {
    * @memberof Shell
    */
   _updatePlayerClientRect = () => {
-    const playerContainer = document.getElementById(this.props.targetId);
-    if (playerContainer) {
-      this.props.updatePlayerClientRect(playerContainer.getBoundingClientRect());
-    }
+    setTimeout(() => {
+      const playerContainer = document.getElementById(this.props.targetId);
+      if (playerContainer) {
+        this.props.updatePlayerClientRect(playerContainer.getBoundingClientRect());
+      }
+    }, DOM_UPDATE_DELAY);
   };
 
   /**

--- a/src/components/shell/shell.tsx
+++ b/src/components/shell/shell.tsx
@@ -43,7 +43,6 @@ const mapStateToProps = state => ({
 });
 
 const ON_PLAYER_RECT_CHANGE_DEBOUNCE_DELAY: number = 100;
-const DOM_UPDATE_DELAY = 50;
 
 const PLAYER_SIZE: {[size: string]: string} = {
   TINY: 'tiny',
@@ -259,12 +258,13 @@ class Shell extends Component<any, any> {
    * @memberof Shell
    */
   _updatePlayerClientRect = () => {
+    const playerContainer = document.getElementById(this.props.targetId);
+    if (playerContainer) {
+      this.props.updatePlayerClientRect(playerContainer.getBoundingClientRect());
+    }
     setTimeout(() => {
-      const playerContainer = document.getElementById(this.props.targetId);
-      if (playerContainer) {
-        this.props.updatePlayerClientRect(playerContainer.getBoundingClientRect());
-      }
-    }, DOM_UPDATE_DELAY);
+      this.props.updatePlayerClientRect(playerContainer.getBoundingClientRect());
+    }, ON_PLAYER_RECT_CHANGE_DEBOUNCE_DELAY);
   };
 
   /**

--- a/src/components/shell/shell.tsx
+++ b/src/components/shell/shell.tsx
@@ -265,18 +265,6 @@ class Shell extends Component<any, any> {
     }
   };
 
-  // _updatePlayerClientRect = () => {
-  //   const updateClientRect = () => {
-  //     const playerContainer = document.getElementById(this.props.targetId);
-  //     if (playerContainer) {
-  //       this.props.updatePlayerClientRect(playerContainer.getBoundingClientRect());
-  //     }
-  //   };
-  //   setTimeout(() => {
-  //     updateClientRect();
-  //   }, 100);
-  // };
-
   /**
    * before component mounted, remove event listeners
    *

--- a/src/components/shell/shell.tsx
+++ b/src/components/shell/shell.tsx
@@ -258,11 +258,17 @@ class Shell extends Component<any, any> {
    * @memberof Shell
    */
   _updatePlayerClientRect = () => {
-    const playerContainer = document.getElementById(this.props.targetId);
-    if (playerContainer) {
-      this.props.updatePlayerClientRect(playerContainer.getBoundingClientRect());
-    }
+    const updateClientRect = () => {
+      const playerContainer = document.getElementById(this.props.targetId);
+      if (playerContainer) {
+        this.props.updatePlayerClientRect(playerContainer.getBoundingClientRect());
+      }
+    };
+
+    const animationFrameId = requestAnimationFrame(updateClientRect);
+    return () => cancelAnimationFrame(animationFrameId);
   };
+
 
   /**
    * before component mounted, remove event listeners


### PR DESCRIPTION
Issue: 
When browser width is small, side pannel is on, and enter full screen, there is a gap between side pannel and player.

Fix:
Fix timing issue : the issue related to the timing of the DOM updates. When resizing the window or triggering an actions that affect the layout, the client rect of the player container getBoundingClientRect() is not updated immediately after the resize. This causes discrepancies between the actual layout and the values being used in the state.

solved [SUP-46391](https://kaltura.atlassian.net/browse/SUP-46391)

[SUP-46391]: https://kaltura.atlassian.net/browse/SUP-46391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ