### PR TITLE
fix(FEC-14289): Player v7 | Player doesn't recover well after network disconnection

### DIFF
--- a/src/components/error-overlay/error-overlay.tsx
+++ b/src/components/error-overlay/error-overlay.tsx
@@ -59,6 +59,16 @@ class ErrorOverlay extends Component<any, any> {
    */
   handleClick = (): void => {
     const mediaInfo = this.props.player.getMediaInfo();
+    const config = this.props.player.config;
+
+    // Destroy the existing player
+    this.props.player.destroy();
+    this.props.player = null;
+
+    // Setup player again
+    this.props.player = KalturaPlayer.setup(config);
+
+    // Load the media again
     this.props.player.loadMedia(mediaInfo);
   };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,6 +33,9 @@
     "outDir": "./lib/",
     "allowSyntheticDefaultImports": true
   },
-  "files": ["./src/types/kaltura-player-js.d.ts"],
+  "files": [
+    "./src/types/kaltura-player-js.d.ts",
+    "node_modules/@playkit-js/kaltura-player-js/ts-typed/kaltura-player.d.ts"
+  ],
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
### Description of the Changes
After player had network disconnection error and user clicked on 'Try Again', player should be **destroyed** and we should **setup** a new player before using **loadMedia**.

Related PR: https://github.com/kaltura/kaltura-player-js/pull/914

Resolves [FEC-14289](https://kaltura.atlassian.net/browse/FEC-14289)

[FEC-14289]: https://kaltura.atlassian.net/browse/FEC-14289