### PR TITLE
fix(FEC-14289): Player v7 | Player doesn't recover well after network disconnection

### DIFF
--- a/src/components/error-overlay/error-overlay.tsx
+++ b/src/components/error-overlay/error-overlay.tsx
@@ -10,6 +10,7 @@ import {withLogger} from '../../components/logger';
 import {withPlayer} from '../../components/player';
 import {Button} from '../../components/button';
 import {getErrorDetailsByCategory} from "./error-message-provider";
+import {actions as overlayActions} from '../../reducers/overlay';
 
 /**
  * mapping state to props
@@ -30,7 +31,7 @@ const COMPONENT_NAME = 'ErrorOverlay';
  * @class errorOverlay
  * @extends {Component}
  */
-@connect(mapStateToProps, bindActions(actions))
+@connect(mapStateToProps, bindActions({...actions, ...overlayActions}))
 @withPlayer
 @withLogger(COMPONENT_NAME)
 class ErrorOverlay extends Component<any, any> {
@@ -59,6 +60,7 @@ class ErrorOverlay extends Component<any, any> {
    */
   handleClick = (): void => {
     const mediaInfo = this.props.player.getMediaInfo();
+    this.props.updateOverlay(false);
     this.props.player.loadMedia(mediaInfo);
   };
 


### PR DESCRIPTION
### Description of the Changes

After player had network disconnection error and user clicked on 'Try Again', player stucks with 'overlay: true'.
We need to update to 'overlay: false'.

Resolves [FEC-14289](https://kaltura.atlassian.net/browse/FEC-14289)




[FEC-14289]: https://kaltura.atlassian.net/browse/FEC-14289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ