### PR TITLE
fix(SUP-46685): Multiple Chapters in Quiz Break the Timeline

### DIFF
--- a/src/components/bottom-bar/bottom-bar.tsx
+++ b/src/components/bottom-bar/bottom-bar.tsx
@@ -10,6 +10,7 @@ import {withEventManager} from '../../event';
 import {withPlayer} from '../player';
 import {filterControlsByPriority} from './bottom-bar-utils';
 import {BottomBarRegistryManager, bottomBarRegistryManager} from './bottom-bar-registry-manager';
+import {BottomBarClientRectEvent} from '../../event/events/bottom-bar-client-rect-event';
 
 const LOWER_PRIORITY_CONTROLS: string[][] = [
   ['PictureInPicture'],
@@ -99,7 +100,8 @@ class BottomBar extends Component<any, any> {
     const currentControlsWidth = this._getControlsWidth(resizeObserverEntry.target as HTMLElement);
     this._maxControlsWidth = Math.max(this._maxControlsWidth, currentControlsWidth);
     if (barWidth !== this.currentBarWidth) {
-      document.dispatchEvent(new Event('bottomBarClientRectChanged'));
+      const {player} = this.props;
+      player.dispatchEvent(new BottomBarClientRectEvent());
       this.currentBarWidth = barWidth;
       const currCrlWidth = this.props.guiClientRect.width <= PLAYER_BREAK_POINTS.SMALL ? CRL_WIDTH + CRL_MARGIN / 2 : CRL_WIDTH + CRL_MARGIN;
       const lowerPriorityControls = LOWER_PRIORITY_CONTROLS.filter(c => this.state.activeControls[c[0]]);

--- a/src/components/bottom-bar/bottom-bar.tsx
+++ b/src/components/bottom-bar/bottom-bar.tsx
@@ -99,6 +99,7 @@ class BottomBar extends Component<any, any> {
     const currentControlsWidth = this._getControlsWidth(resizeObserverEntry.target as HTMLElement);
     this._maxControlsWidth = Math.max(this._maxControlsWidth, currentControlsWidth);
     if (barWidth !== this.currentBarWidth) {
+      window.dispatchEvent(new Event('bottomBarClientRectUpdated'));
       this.currentBarWidth = barWidth;
       const currCrlWidth = this.props.guiClientRect.width <= PLAYER_BREAK_POINTS.SMALL ? CRL_WIDTH + CRL_MARGIN / 2 : CRL_WIDTH + CRL_MARGIN;
       const lowerPriorityControls = LOWER_PRIORITY_CONTROLS.filter(c => this.state.activeControls[c[0]]);

--- a/src/components/bottom-bar/bottom-bar.tsx
+++ b/src/components/bottom-bar/bottom-bar.tsx
@@ -99,7 +99,7 @@ class BottomBar extends Component<any, any> {
     const currentControlsWidth = this._getControlsWidth(resizeObserverEntry.target as HTMLElement);
     this._maxControlsWidth = Math.max(this._maxControlsWidth, currentControlsWidth);
     if (barWidth !== this.currentBarWidth) {
-      window.dispatchEvent(new Event('bottomBarClientRectUpdated'));
+      document.dispatchEvent(new Event('bottomBarClientRectChanged'));
       this.currentBarWidth = barWidth;
       const currCrlWidth = this.props.guiClientRect.width <= PLAYER_BREAK_POINTS.SMALL ? CRL_WIDTH + CRL_MARGIN / 2 : CRL_WIDTH + CRL_MARGIN;
       const lowerPriorityControls = LOWER_PRIORITY_CONTROLS.filter(c => this.state.activeControls[c[0]]);

--- a/src/components/seekbar/seekbar.tsx
+++ b/src/components/seekbar/seekbar.tsx
@@ -11,7 +11,7 @@ import {actions as overlayIconActions} from '../../reducers/overlay-action';
 import {IconType} from '../icon';
 import {Text, withText} from 'preact-i18n';
 import {PlayerArea} from '../player-area';
-import {withEventManager} from '../../event';
+import {EventType, withEventManager} from '../../event';
 import {SeekBarPreview} from '../seekbar-preview';
 import {ProgressIndicator} from '../progress-indicator';
 import {KeyboardEventHandlers} from '../../types';
@@ -99,6 +99,7 @@ class SeekBar extends Component<any, any> {
   ];
 
   handleUpdateSeekBarClientRect = () => {
+    console.log('hi');
     const clientRect = this._seekBarElement.getBoundingClientRect();
     this.props.updateSeekbarClientRect(clientRect);
   };
@@ -123,7 +124,7 @@ class SeekBar extends Component<any, any> {
       });
     });
 
-    this.props.eventManager.listen(document, 'bottomBarClientRectChanged', () => this.handleUpdateSeekBarClientRect());
+    eventManager.listen(player, EventType.BOTTOM_BAR_CLIENT_RECT_CHANGED, () => this.handleUpdateSeekBarClientRect());
     document.addEventListener('mouseup', this.onPlayerMouseUp);
     document.addEventListener('mousemove', this.onPlayerMouseMove);
     this.props.registerKeyboardEvents(this._keyboardEventHandlers);

--- a/src/components/seekbar/seekbar.tsx
+++ b/src/components/seekbar/seekbar.tsx
@@ -98,6 +98,11 @@ class SeekBar extends Component<any, any> {
     }
   ];
 
+  updateSeekBarClientRect = () => {
+    const clientRect = this._seekBarElement.getBoundingClientRect();
+    this.props.updateSeekbarClientRect(clientRect);
+  };
+
   /**
    * on component mount, bind mouseup and mousemove events to top player element
    *
@@ -108,14 +113,7 @@ class SeekBar extends Component<any, any> {
     const {player, eventManager} = this.props;
     const clientRect = this._seekBarElement.getBoundingClientRect();
     this.props.updateSeekbarClientRect(clientRect);
-    eventManager.listen(player, EventType.GUI_RESIZE, () => {
-      this.setState({resizing: true});
-      setTimeout(() => {
-        const clientRect = this._seekBarElement.getBoundingClientRect();
-        this.props.updateSeekbarClientRect(clientRect);
-        this.setState({resizing: false});
-      }, Number(style.defaultTransitionTime));
-    });
+
     const smallSizes = [PLAYER_SIZE.TINY, PLAYER_SIZE.EXTRA_SMALL, PLAYER_SIZE.SMALL];
     eventManager.listenOnce(player, player.Event.UI.USER_CLICKED_PLAY, () => {
       eventManager.listenOnce(player, player.Event.Core.FIRST_PLAY, () => {
@@ -124,6 +122,8 @@ class SeekBar extends Component<any, any> {
         }
       });
     });
+
+    window.addEventListener('bottomBarClientRectUpdated', this.updateSeekBarClientRect);
     document.addEventListener('mouseup', this.onPlayerMouseUp);
     document.addEventListener('mousemove', this.onPlayerMouseMove);
     this.props.registerKeyboardEvents(this._keyboardEventHandlers);
@@ -138,6 +138,7 @@ class SeekBar extends Component<any, any> {
   componentWillUnmount(): void {
     document.removeEventListener('mouseup', this.onPlayerMouseUp);
     document.removeEventListener('mousemove', this.onPlayerMouseMove);
+    window.removeEventListener('updateSeekBar', this.updateSeekBarClientRect);
   }
 
   /**
@@ -519,8 +520,7 @@ class SeekBar extends Component<any, any> {
       <div
         className={this.props.hidePreview ? [style.framePreview, style.hideFramePreview].join(' ') : style.framePreview}
         style={this._getFramePreviewStyle()}
-        ref={c => (c ? (this._framePreviewElement = c) : undefined)}
-      >
+        ref={c => (c ? (this._framePreviewElement = c) : undefined)}>
         <SeekBarPreview virtualTime={this.props.virtualTime} />
       </div>
     );
@@ -591,8 +591,7 @@ class SeekBar extends Component<any, any> {
         onTouchStart={this.onSeekbarTouchStart}
         onTouchMove={this.onSeekbarTouchMove}
         onTouchEnd={this.onSeekbarTouchEnd}
-        onKeyDown={this.onKeyDown}
-      >
+        onKeyDown={this.onKeyDown}>
         <div className={style.progressBar}>
           <PlayerArea name={'SeekBar'} shouldUpdate={true}>
             {this.renderFramePreview()}

--- a/src/components/seekbar/seekbar.tsx
+++ b/src/components/seekbar/seekbar.tsx
@@ -99,7 +99,6 @@ class SeekBar extends Component<any, any> {
   ];
 
   handleUpdateSeekBarClientRect = () => {
-    console.log('hi');
     const clientRect = this._seekBarElement.getBoundingClientRect();
     this.props.updateSeekbarClientRect(clientRect);
   };

--- a/src/components/seekbar/seekbar.tsx
+++ b/src/components/seekbar/seekbar.tsx
@@ -139,7 +139,7 @@ class SeekBar extends Component<any, any> {
   componentWillUnmount(): void {
     document.removeEventListener('mouseup', this.onPlayerMouseUp);
     document.removeEventListener('mousemove', this.onPlayerMouseMove);
-    this.props.eventManager.unlisten(window, 'bottomBarClientRectChanged', this.updateSeekBarClientRect);
+    this.props.eventManager.unlisten(document, 'bottomBarClientRectChanged', this.handleUpdateSeekBarClientRect);
   }
 
   /**

--- a/src/components/seekbar/seekbar.tsx
+++ b/src/components/seekbar/seekbar.tsx
@@ -11,7 +11,7 @@ import {actions as overlayIconActions} from '../../reducers/overlay-action';
 import {IconType} from '../icon';
 import {Text, withText} from 'preact-i18n';
 import {PlayerArea} from '../player-area';
-import {EventType, withEventManager} from '../../event';
+import {withEventManager} from '../../event';
 import {SeekBarPreview} from '../seekbar-preview';
 import {ProgressIndicator} from '../progress-indicator';
 import {KeyboardEventHandlers} from '../../types';
@@ -98,7 +98,8 @@ class SeekBar extends Component<any, any> {
     }
   ];
 
-  updateSeekBarClientRect = () => {
+  handleUpdateSeekBarClientRect = () => {
+    console.log('hi');
     const clientRect = this._seekBarElement.getBoundingClientRect();
     this.props.updateSeekbarClientRect(clientRect);
   };
@@ -123,7 +124,7 @@ class SeekBar extends Component<any, any> {
       });
     });
 
-    window.addEventListener('bottomBarClientRectUpdated', this.updateSeekBarClientRect);
+    this.props.eventManager.listen(document, 'bottomBarClientRectChanged', () => this.handleUpdateSeekBarClientRect());
     document.addEventListener('mouseup', this.onPlayerMouseUp);
     document.addEventListener('mousemove', this.onPlayerMouseMove);
     this.props.registerKeyboardEvents(this._keyboardEventHandlers);
@@ -138,7 +139,9 @@ class SeekBar extends Component<any, any> {
   componentWillUnmount(): void {
     document.removeEventListener('mouseup', this.onPlayerMouseUp);
     document.removeEventListener('mousemove', this.onPlayerMouseMove);
-    window.removeEventListener('updateSeekBar', this.updateSeekBarClientRect);
+    //window.removeEventListener('updateSeekBar', this.updateSeekBarClientRect);
+    this.props.eventManager.unlisten(window, 'bottomBarClientRectChanged', this.updateSeekBarClientRect);
+    //  this.props.eventManager?.unlisten(document, 'click', this._closePupup);
   }
 
   /**

--- a/src/components/seekbar/seekbar.tsx
+++ b/src/components/seekbar/seekbar.tsx
@@ -99,7 +99,6 @@ class SeekBar extends Component<any, any> {
   ];
 
   handleUpdateSeekBarClientRect = () => {
-    console.log('hi');
     const clientRect = this._seekBarElement.getBoundingClientRect();
     this.props.updateSeekbarClientRect(clientRect);
   };
@@ -124,7 +123,7 @@ class SeekBar extends Component<any, any> {
       });
     });
 
-    eventManager.listen(player, EventType.BOTTOM_BAR_CLIENT_RECT_CHANGED, () => this.handleUpdateSeekBarClientRect());
+    eventManager.listen(player, EventType.BOTTOM_BAR_CLIENT_RECT_CHANGED, this.handleUpdateSeekBarClientRect);
     document.addEventListener('mouseup', this.onPlayerMouseUp);
     document.addEventListener('mousemove', this.onPlayerMouseMove);
     this.props.registerKeyboardEvents(this._keyboardEventHandlers);

--- a/src/components/seekbar/seekbar.tsx
+++ b/src/components/seekbar/seekbar.tsx
@@ -138,7 +138,6 @@ class SeekBar extends Component<any, any> {
   componentWillUnmount(): void {
     document.removeEventListener('mouseup', this.onPlayerMouseUp);
     document.removeEventListener('mousemove', this.onPlayerMouseMove);
-    this.props.eventManager.unlisten(document, 'bottomBarClientRectChanged', this.handleUpdateSeekBarClientRect);
   }
 
   /**

--- a/src/components/seekbar/seekbar.tsx
+++ b/src/components/seekbar/seekbar.tsx
@@ -139,9 +139,7 @@ class SeekBar extends Component<any, any> {
   componentWillUnmount(): void {
     document.removeEventListener('mouseup', this.onPlayerMouseUp);
     document.removeEventListener('mousemove', this.onPlayerMouseMove);
-    //window.removeEventListener('updateSeekBar', this.updateSeekBarClientRect);
     this.props.eventManager.unlisten(window, 'bottomBarClientRectChanged', this.updateSeekBarClientRect);
-    //  this.props.eventManager?.unlisten(document, 'click', this._closePupup);
   }
 
   /**

--- a/src/components/shell/shell.tsx
+++ b/src/components/shell/shell.tsx
@@ -43,6 +43,7 @@ const mapStateToProps = state => ({
 });
 
 const ON_PLAYER_RECT_CHANGE_DEBOUNCE_DELAY: number = 100;
+const RESIZE_DEBOUNCE_DELAY: number = 0;
 
 const PLAYER_SIZE: {[size: string]: string} = {
   TINY: 'tiny',
@@ -212,7 +213,7 @@ class Shell extends Component<any, any> {
    */
   componentDidMount() {
     const {player, eventManager} = this.props;
-    eventManager.listen(window, 'resize', debounce(this._onWindowResize, ON_PLAYER_RECT_CHANGE_DEBOUNCE_DELAY));
+    eventManager.listen(window, 'resize', debounce(this._onWindowResize, RESIZE_DEBOUNCE_DELAY));
     eventManager.listen(document, 'scroll', debounce(this._updatePlayerClientRect, ON_PLAYER_RECT_CHANGE_DEBOUNCE_DELAY));
     eventManager.listen(document, 'click', debounce(this._handleClickOutside, ON_PLAYER_RECT_CHANGE_DEBOUNCE_DELAY));
     this._playerResizeWatcher = new ResizeWatcher();
@@ -258,17 +259,23 @@ class Shell extends Component<any, any> {
    * @memberof Shell
    */
   _updatePlayerClientRect = () => {
-    const updateClientRect = () => {
-      const playerContainer = document.getElementById(this.props.targetId);
-      if (playerContainer) {
-        this.props.updatePlayerClientRect(playerContainer.getBoundingClientRect());
-      }
-    };
-
-    const animationFrameId = requestAnimationFrame(updateClientRect);
-    return () => cancelAnimationFrame(animationFrameId);
+    const playerContainer = document.getElementById(this.props.targetId);
+    if (playerContainer) {
+      this.props.updatePlayerClientRect(playerContainer.getBoundingClientRect());
+    }
   };
 
+  // _updatePlayerClientRect = () => {
+  //   const updateClientRect = () => {
+  //     const playerContainer = document.getElementById(this.props.targetId);
+  //     if (playerContainer) {
+  //       this.props.updatePlayerClientRect(playerContainer.getBoundingClientRect());
+  //     }
+  //   };
+  //   setTimeout(() => {
+  //     updateClientRect();
+  //   }, 100);
+  // };
 
   /**
    * before component mounted, remove event listeners

--- a/src/components/shell/shell.tsx
+++ b/src/components/shell/shell.tsx
@@ -43,7 +43,6 @@ const mapStateToProps = state => ({
 });
 
 const ON_PLAYER_RECT_CHANGE_DEBOUNCE_DELAY: number = 100;
-const RESIZE_DEBOUNCE_DELAY: number = 0;
 
 const PLAYER_SIZE: {[size: string]: string} = {
   TINY: 'tiny',
@@ -213,7 +212,7 @@ class Shell extends Component<any, any> {
    */
   componentDidMount() {
     const {player, eventManager} = this.props;
-    eventManager.listen(window, 'resize', debounce(this._onWindowResize, RESIZE_DEBOUNCE_DELAY));
+    eventManager.listen(window, 'resize', debounce(this._onWindowResize, ON_PLAYER_RECT_CHANGE_DEBOUNCE_DELAY));
     eventManager.listen(document, 'scroll', debounce(this._updatePlayerClientRect, ON_PLAYER_RECT_CHANGE_DEBOUNCE_DELAY));
     eventManager.listen(document, 'click', debounce(this._handleClickOutside, ON_PLAYER_RECT_CHANGE_DEBOUNCE_DELAY));
     this._playerResizeWatcher = new ResizeWatcher();

--- a/src/components/shell/shell.tsx
+++ b/src/components/shell/shell.tsx
@@ -265,18 +265,6 @@ class Shell extends Component<any, any> {
     }
   };
 
-  // _updatePlayerClientRect = () => {
-  //   const updateClientRect = () => {
-  //     const playerContainer = document.getElementById(this.props.targetId);
-  //     if (playerContainer) {
-  //       this.props.updatePlayerClientRect(playerContainer.getBoundingClientRect());
-  //     }
-  //   };
-  //   setTimeout(() => {
-  //     updateClientRect();
-  //   }, 100);
-  // };
-
   /**
    * before component mounted, remove event listeners
    *

--- a/src/components/shell/shell.tsx
+++ b/src/components/shell/shell.tsx
@@ -258,11 +258,17 @@ class Shell extends Component<any, any> {
    * @memberof Shell
    */
   _updatePlayerClientRect = () => {
-    const playerContainer = document.getElementById(this.props.targetId);
-    if (playerContainer) {
-      this.props.updatePlayerClientRect(playerContainer.getBoundingClientRect());
-    }
+    const updateClientRect = () => {
+      const playerContainer = document.getElementById(this.props.targetId);
+      if (playerContainer) {
+        this.props.updatePlayerClientRect(playerContainer.getBoundingClientRect());
+      }
+    };
+
+    const animationFrameId = requestAnimationFrame(updateClientRect);
+    return () => cancelAnimationFrame(animationFrameId);
   };
+
 
   /**
    * before component mounted, remove event listeners

--- a/src/event/event-type.ts
+++ b/src/event/event-type.ts
@@ -37,7 +37,8 @@ const EventType = {
   USER_SELECTED_CAPTIONS_FONT_STYLE: `${namespace}-userselectedcaptionsfontstyle`,
   USER_SELECTED_CAPTIONS_FONT_OPACITY: `${namespace}-userselectedcaptionsfontopacity`,
   USER_SELECTED_CAPTIONS_BACKGROUND_COLOR: `${namespace}-userselectedcaptionsbackgroundcolor`,
-  USER_SELECTED_CAPTIONS_BACKGROUND_OPACITY: `${namespace}-userselectedcaptionsbackgroundopacity`
+  USER_SELECTED_CAPTIONS_BACKGROUND_OPACITY: `${namespace}-userselectedcaptionsbackgroundopacity`,
+  BOTTOM_BAR_CLIENT_RECT_CHANGED: `${namespace}-bottombarclientrectchanged`
 } as const;
 
 export {EventType};

--- a/src/event/events/bottom-bar-client-rect-event.ts
+++ b/src/event/events/bottom-bar-client-rect-event.ts
@@ -1,0 +1,20 @@
+import {FakeEvent} from '@playkit-js/playkit-js';
+import {EventType} from '../event-type';
+
+/**
+ * BottomBarClientRectEvent event
+ *
+ * @class BottomBarClientRectEvent
+ * @extends {FakeEvent}
+ */
+class BottomBarClientRectEvent extends FakeEvent {
+  /**
+   * @constructor
+   *
+   */
+  constructor() {
+    super(EventType.BOTTOM_BAR_CLIENT_RECT_CHANGED);
+  }
+}
+
+export {BottomBarClientRectEvent};


### PR DESCRIPTION
**Issue:**
Timing issue: in some cases the delay in the setTimeOut in SeekBar.tsx file is not enough, and the bottomBarClientRect in BottomBar.tsx being updated too late, just after the set time out scope is being executed. This affects the seekBar width, which creates a problem with position the cue-points on the seekBar.

**Fix:**
Add an event that will update the seekBar every time the bottomBarClientRect is being updated. The seekBar.tsx will always get the most updated width.

solved-[SUP-46685](https://kaltura.atlassian.net/browse/SUP-46685)

[SUP-46685]: https://kaltura.atlassian.net/browse/SUP-46685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ