### PR TITLE
fix(CR-317): player crushes on reload

### DIFF
--- a/src/components/shell/shell.tsx
+++ b/src/components/shell/shell.tsx
@@ -263,7 +263,9 @@ class Shell extends Component<any, any> {
       this.props.updatePlayerClientRect(playerContainer.getBoundingClientRect());
     }
     setTimeout(() => {
-      this.props.updatePlayerClientRect(playerContainer?.getBoundingClientRect());
+      if (playerContainer) {
+        this.props.updatePlayerClientRect(playerContainer.getBoundingClientRect());
+      }
     }, ON_PLAYER_RECT_CHANGE_DEBOUNCE_DELAY);
   };
 


### PR DESCRIPTION
### Description of the Changes

bugfix, regression from [fix](https://github.com/kaltura/playkit-js-ui/pull/982).

**Issue:**
player crushes when executing `updatePlayerClientRect` with an undefined `playerContainer`.

**Fix:**
execute `updatePlayerClientRect` only if `playerContainer` exists.

#### Resolves CR-317


