### PR TITLE
feat(FEC-14367): add nonce to style tag

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,7 +38,17 @@ module.exports = (env, {mode}) => {
           use: [
             {
               loader: 'style-loader',
-              options: {attributes: {id: `${packageData.name}`}}
+              options: {
+                attributes: {
+                  id: `${packageData.name}`
+                },
+                insert: function insertStylesWithNonce(styleElement) {
+                  if (typeof window.kalturaGlobalConfig?.stylesNonce === 'string') {
+                    styleElement.setAttribute('nonce', window.kalturaGlobalConfig.stylesNonce);
+                  }
+                  document.head.appendChild(styleElement);
+                }
+              }
             },
             {
               loader: 'css-loader',


### PR DESCRIPTION
### Description of the Changes

add `nonce` attribute to the style tag pushed to DOM.

- override the default `insert` behavior of `style-loader`
- if `nonce` exists- add it to the style element

#### Resolves FEC-14367


