### PR TITLE
fix(ADA-2122): Include modal title in close button aria-label

### DIFF
--- a/src/components/cvaa-overlay/cvaa-overlay.tsx
+++ b/src/components/cvaa-overlay/cvaa-overlay.tsx
@@ -45,6 +45,7 @@ const COMPONENT_NAME = 'CVAAOverlay';
 @withText({
   cvvaDialogText: 'cvaa.title',
   cvvaSetCustomCaptionsText: 'cvaa.set_custom_caption',
+  cvaaCloseLabel: 'cvaa.close_label'
 })
 class CVAAOverlay extends Component<any, any> {
   /**
@@ -147,6 +148,7 @@ class CVAAOverlay extends Component<any, any> {
         onClose={props.onClose}
         type="cvaa"
         {...ariaProps}
+        closeAriaLabel={this.props.cvaaCloseLabel}
       >
         {this.state.activeWindow === cvaaOverlayState.Main ? (
           <MainCaptionsWindow

--- a/src/components/overlay/overlay.tsx
+++ b/src/components/overlay/overlay.tsx
@@ -29,6 +29,7 @@ interface OverlayProps {
   player?: any;
   addAccessibleChild?: (el: HTMLElement) => void;
   pauseOnOpen?: boolean;
+  closeAriaLabel?: string;
 }
 
 /**

--- a/translations/en.i18n.json
+++ b/translations/en.i18n.json
@@ -119,7 +119,8 @@
       "background_color_label": "Background color",
       "background_opacity_label": "Background opacity",
       "apply": "Apply",
-      "caption_preview": "This is your caption preview"
+      "caption_preview": "This is your caption preview",
+      "close_label": "Close Advanced captions settings"
     },
     "cast": {
       "play_on_tv": "Play on TV",


### PR DESCRIPTION
This solves this https://kaltura.atlassian.net/browse/ADA-2122. It includes the modal title to the Advanced captions settings modal's close button.
This should be merged after this https://github.com/kaltura/playkit-js-ui/pull/984

### Description of the Changes

Please add a detailed description of the change, whether it's an enhancement or a bugfix.
If the PR is related to an open issue please link to it.

**Issue:**

**Fix:**

#### Resolves FEC-[Please add the ticket reference here]


