### PR TITLE
fix(ADA-2432): Focus on settings button on close

### DIFF
--- a/src/components/cvaa-overlay/cvaa-overlay.tsx
+++ b/src/components/cvaa-overlay/cvaa-overlay.tsx
@@ -144,7 +144,13 @@ class CVAAOverlay extends Component<any, any> {
         open
         handleKeyDown={this.props.handleKeyDown}
         addAccessibleChild={this.props.addAccessibleChild}
-        onClose={props.onClose}
+        onClose={() => {
+          props.onClose();
+          setTimeout(() => {
+            const button = document.querySelector('.playkit-button-badge') as HTMLElement;
+            if (button) button.focus();
+          }, 0);
+        }}
         type="cvaa"
         {...ariaProps}
       >


### PR DESCRIPTION
This solves this https://kaltura.atlassian.net/browse/ADA-2432.
The issue appeared because the captions menu and settings menu are closing when the Advanced captions settings is selected. Now on modal close, the focus searches for Settings button class and focuses on it.

### Description of the Changes

Please add a detailed description of the change, whether it's an enhancement or a bugfix.
If the PR is related to an open issue please link to it.

**Issue:**

**Fix:**

#### Resolves FEC-[Please add the ticket reference here]


