### PR TITLE
FEC-14416 check if portal element exists before querying it

### DIFF
--- a/src/components/overlay/overlay.tsx
+++ b/src/components/overlay/overlay.tsx
@@ -85,7 +85,7 @@ class Overlay extends Component<OverlayProps, any> {
     } else {
       // Remove the overlay-active class only when overlay portal has a single child
       const overlayPortalEl = getOverlayPortalElement(this.props.player);
-      if (overlayPortalEl!.childElementCount <= 1) {
+      if (overlayPortalEl && overlayPortalEl?.childElementCount <= 1) {
         this.props.removePlayerClass!(style.overlayActive);
       }
     }

--- a/src/components/overlay/overlay.tsx
+++ b/src/components/overlay/overlay.tsx
@@ -85,7 +85,7 @@ class Overlay extends Component<OverlayProps, any> {
     } else {
       // Remove the overlay-active class only when overlay portal has a single child
       const overlayPortalEl = getOverlayPortalElement(this.props.player);
-      if (overlayPortalEl && overlayPortalEl?.childElementCount <= 1) {
+      if (overlayPortalEl && overlayPortalEl.childElementCount <= 1) {
         this.props.removePlayerClass!(style.overlayActive);
       }
     }


### PR DESCRIPTION
### Description of the Changes

**Issue:**
https://kaltura.atlassian.net/browse/FEC-14416

**Fix:**
Make sure that the portal element is not `null` or `undefined` before accessing its `childElementCount` property.

#### Resolves FEC-14416


