### PR TITLE
fix (SUP-47338): Watermark On Player Not Responsive

### DIFF
--- a/src/components/watermark/_watermark.scss
+++ b/src/components/watermark/_watermark.scss
@@ -4,7 +4,6 @@
     visibility 0s 1s,
     opacity 1s linear,
     transform ease-out 100ms;
-
   &.hide-watermark {
     visibility: hidden;
     opacity: 0;

--- a/src/components/watermark/_watermark.scss
+++ b/src/components/watermark/_watermark.scss
@@ -5,11 +5,6 @@
     opacity 1s linear,
     transform ease-out 100ms;
 
-  img {
-    width: 100%;
-    height: auto;
-  }
-
   &.hide-watermark {
     visibility: hidden;
     opacity: 0;

--- a/src/components/watermark/_watermark.scss
+++ b/src/components/watermark/_watermark.scss
@@ -4,6 +4,12 @@
     visibility 0s 1s,
     opacity 1s linear,
     transform ease-out 100ms;
+
+  img {
+    width: 100%;
+    height: auto;
+  }
+
   &.hide-watermark {
     visibility: hidden;
     opacity: 0;

--- a/src/components/watermark/watermark.tsx
+++ b/src/components/watermark/watermark.tsx
@@ -39,8 +39,8 @@ const ENTRY_VAR = '{entryId}';
 class Watermark extends Component<any, any> {
   _timeoutId: number | null = null;
   _imgAspectRatio: number | null = null;
-  _imgWidth: number | null = null;
-  _imgHeight: number | null = null;
+  _originalImgWidth: number | null = null;
+  _originalImgHeight: number | null = null;
   _playerHeight: number | null = null;
   _playerWidth: number | null = null;
   /**
@@ -109,8 +109,8 @@ class Watermark extends Component<any, any> {
     const img = new Image();
     img.src = this.props.config.img;
     img.onload = () => {
-      this._imgWidth = img.naturalWidth;
-      this._imgHeight = img.naturalHeight;
+      this._originalImgWidth = img.naturalWidth;
+      this._originalImgHeight = img.naturalHeight;
       this._imgAspectRatio = img.naturalWidth / img.naturalHeight;
       this.setState({imgWidth: img.naturalWidth, imgHeight: img.naturalHeight});
     };
@@ -127,12 +127,12 @@ class Watermark extends Component<any, any> {
 
   private onPlayerResize(): void {
     const playerContainer = document.getElementById(this.props.targetId);
-    if (!playerContainer || !this._imgAspectRatio || !this._imgWidth || !this._imgHeight) return;
+    if (!playerContainer || !this._imgAspectRatio || !this._originalImgWidth || !this._originalImgHeight) return;
 
     const {width: newPlayerWidth} = playerContainer.getBoundingClientRect();
 
     const scalingFactor = newPlayerWidth / (this._playerWidth || newPlayerWidth);
-    const newImageWidth = this._imgWidth * scalingFactor;
+    const newImageWidth = this._originalImgWidth * scalingFactor;
     const newImageHeight = newImageWidth / this._imgAspectRatio;
     this.setState({imgWidth: newImageWidth, imgHeight: newImageHeight});
   }

--- a/src/components/watermark/watermark.tsx
+++ b/src/components/watermark/watermark.tsx
@@ -82,7 +82,6 @@ class Watermark extends Component<any, any> {
     });
 
     this.props.eventManager.listen(player, EventType.RESIZE, () => {
-      console.log('resize');
       this.onPlayerResize();
     });
     this._handleWatermarkUrl();

--- a/src/components/watermark/watermark.tsx
+++ b/src/components/watermark/watermark.tsx
@@ -77,7 +77,6 @@ class Watermark extends Component<any, any> {
     });
 
     this.props.eventManager.listen(player, EventType.RESIZE, () => {
-      console.log('update from event');
       this.updateImageProportion();
     });
     this._handleWatermarkUrl();

--- a/src/components/watermark/watermark.tsx
+++ b/src/components/watermark/watermark.tsx
@@ -191,8 +191,8 @@ class Watermark extends Component<any, any> {
                 src={props.config.img}
                 alt={(<Text id="watermark.watermark_alt_text" />) as unknown as string}
                 style={{
-                  width: this.state.newWidth ? `${this.state.newWidth}px` : '100%',
-                  height: this.state.newHeight ? `${this.state.newHeight}px` : 'auto'
+                  width: `${this.state.newWidth}px`,
+                  height: `${this.state.newHeight}px`
                 }}
               />
             )}

--- a/src/components/watermark/watermark.tsx
+++ b/src/components/watermark/watermark.tsx
@@ -106,6 +106,9 @@ class Watermark extends Component<any, any> {
   }
 
   private _loadImageDimension(): void {
+    if (!this.props.config.img) {
+      return;
+    }
     const img = new Image();
     img.src = this.props.config.img;
     img.onload = () => {

--- a/src/components/watermark/watermark.tsx
+++ b/src/components/watermark/watermark.tsx
@@ -106,7 +106,6 @@ class Watermark extends Component<any, any> {
   }
 
   private _loadImageDimension(): void {
-    if (this._imgAspectRatio) return;
     const img = new Image();
     img.src = this.props.config.img;
     img.onload = () => {

--- a/src/components/watermark/watermark.tsx
+++ b/src/components/watermark/watermark.tsx
@@ -115,8 +115,10 @@ class Watermark extends Component<any, any> {
     if (playerContainer && this._aspectRatio) {
       const {width} = playerContainer.getBoundingClientRect();
       let scaleMultiplier = 0.3;
+      // image is wider than it is tall
       if (this._aspectRatio > 1) {
         scaleMultiplier = 0.6;
+        // image is taller than it is wide
       } else if (this._aspectRatio < 1) {
         scaleMultiplier = 0.3;
       }

--- a/src/components/watermark/watermark.tsx
+++ b/src/components/watermark/watermark.tsx
@@ -40,9 +40,9 @@ class Watermark extends Component<any, any> {
   _timeoutId: number | null = null;
   _imgAspectRatio: number | null = null;
   _imgWidth: number | null = null;
-  _imgHeight: number | null;
-  _playerHeight: number | null;
-  _playerWidth: number | null;
+  _imgHeight: number | null = null;
+  _playerHeight: number | null = null;
+  _playerWidth: number | null = null;
   /**
    * Creates an instance of Watermark.
    * @memberof Watermark

--- a/src/components/watermark/watermark.tsx
+++ b/src/components/watermark/watermark.tsx
@@ -112,7 +112,6 @@ class Watermark extends Component<any, any> {
 
   updateImageProportion = () => {
     const playerContainer = document.getElementById(this.props.targetId);
-    console.log('update 1 ' + playerContainer + ' ' + this._aspectRatio);
     if (playerContainer && this._aspectRatio) {
       const {width} = playerContainer.getBoundingClientRect();
       let scaleMultiplier = 0.3;

--- a/src/components/watermark/watermark.tsx
+++ b/src/components/watermark/watermark.tsx
@@ -102,12 +102,10 @@ class Watermark extends Component<any, any> {
   }
 
   private _loadImageDimension(): void {
-    console.log('load');
     if (this._aspectRatio) return;
     const img = new Image();
     img.src = this.props.config.img;
     img.onload = () => {
-      console.log('finish loading');
       this._aspectRatio = img.naturalWidth / img.naturalHeight;
       this.updateImageProportion();
     };


### PR DESCRIPTION
**Issue:**
Following the previous fix, for a player that does not have a watermark configuration, loading the image fails because it does not exist.

**Fix:**
Add a condition that checks whether the image exists in the configuration.

solved https://kaltura.atlassian.net/browse/SUP-47338


