### PR TITLE
fix(SUP-47502): Play/Pause button on images in embed

### DIFF
--- a/src/components/playback-controls/_playback-controls.scss
+++ b/src/components/playback-controls/_playback-controls.scss
@@ -31,18 +31,21 @@
       &.hover {
         .player-gui > .playback-controls,
         .center-playback-controls {
-          display: block;
 
-          .control-button {
-            width: auto;
-            height: auto;
-            padding: 0 16px;
-            -webkit-filter: drop-shadow(0px 0px 8px rgba(0, 0, 0, 0.5));
-            filter: drop-shadow(0px 0px 8px rgba(0, 0, 0, 0.5));
-          }
-          .icon {
-            width: 64px;
-            height: 64px;
+          &:not(.image) {
+            display: block;
+
+            .control-button {
+              width: auto;
+              height: auto;
+              padding: 0 16px;
+              -webkit-filter: drop-shadow(0px 0px 8px rgba(0, 0, 0, 0.5));
+              filter: drop-shadow(0px 0px 8px rgba(0, 0, 0, 0.5));
+            }
+            .icon {
+              width: 64px;
+              height: 64px;
+            }
           }
         }
       }

--- a/src/components/playback-controls/playback-controls.tsx
+++ b/src/components/playback-controls/playback-controls.tsx
@@ -11,7 +11,8 @@ import {PlayerArea} from '../../components/player-area';
  * @returns {Object} - mapped state to this component
  */
 const mapStateToProps = state => ({
-  playlist: state.engine.playlist
+  playlist: state.engine.playlist,
+  image: state.engine.isImg
 });
 
 const COMPONENT_NAME = 'PlaybackControls';
@@ -60,9 +61,10 @@ class PlaybackControls extends Component<any, any> {
     if (shouldUpdate) {
       this.setState({shouldUpdate: false});
     }
+    const imageClass = this.props.image ? 'playkit-image' : '';
 
     return (
-      <div className={[style.playbackControls, className].join(' ')}>
+      <div className={[style.playbackControls, className, imageClass].join(' ')}>
         <PlayerArea name={'BottomBarPlaybackControls'} shouldUpdate={shouldUpdate}>
           {playlist ? (
             <Fragment>

--- a/src/components/playback-controls/playback-controls.tsx
+++ b/src/components/playback-controls/playback-controls.tsx
@@ -61,7 +61,7 @@ class PlaybackControls extends Component<any, any> {
     if (shouldUpdate) {
       this.setState({shouldUpdate: false});
     }
-    const imageClass = this.props.image ? 'playkit-image' : '';
+    const imageClass = this.props.image ? style.image : '';
 
     return (
       <div className={[style.playbackControls, className, imageClass].join(' ')}>


### PR DESCRIPTION
issue:
on small sizes with image play/pause button can be seen on screen

root- cause
there is css style for the play/pause icon for small sizes

solution:
check if it image, then add class to make css not be implemented

solve [SUP-47502](https://kaltura.atlassian.net/browse/SUP-47502)




[SUP-47502]: https://kaltura.atlassian.net/browse/SUP-47502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ