### PR TITLE
fix(FEC-14390): Fix accessability for small reels

### DIFF
--- a/src/components/captions-menu/captions-menu.tsx
+++ b/src/components/captions-menu/captions-menu.tsx
@@ -101,7 +101,17 @@ class CaptionsMenu extends Component<any, any> {
         />
       );
     } else {
-      return <Menu options={textOptions} onMenuChosen={textTrack => this.onCaptionsChange(textTrack)} onClose={() => {}} />;
+      return (
+        <Menu
+          pushRef={el => {
+            this.props.addAccessibleChild(el)
+            props.pushRef(el);
+          }}
+          options={textOptions}
+          onMenuChosen={textTrack => this.onCaptionsChange(textTrack)}
+          onClose={() => {}} 
+        />
+      );
     }
   }
 }


### PR DESCRIPTION
### Description of the Changes

https://kaltura.atlassian.net/browse/FEC-14390

**Issue:**
When reels was on small size property "openMenuFromCCButton": true caused issue that you can't use Tab to switch to dropdown.

**Fix:**
Add menu to accessibleChildren

#### Resolves FEC-14390

