### PR TITLE
fix(FEC-14421): For youtube entries, kitchen sink isn't visible when opening summary plugin with "expandMode": "over"

### DIFF
--- a/src/components/side-panel/_side-panel.scss
+++ b/src/components/side-panel/_side-panel.scss
@@ -2,7 +2,7 @@
   position: absolute;
   transition: all #{$default-transition-time}ms;
   transition-property: left, right, bottom, top, opacity;
-  z-index: 0;
+  z-index: 1;
   &.small-size {
     // for small sizes the side panel should be over player controls
     z-index: 2;


### PR DESCRIPTION
### Description of the Changes

bugfix.

**Issue:**
youtube overlay has z-index which overlays the kitchen sink of the side panel when the `expandMode` is `over`.

**Fix:**
increase `z-index` of sidePanel component to `1`.

**Note:**
`z-index` of sidePanel was decreased to `0` following this [commit](https://github.com/kaltura/playkit-js-ui/commit/e3fa3c6cff9c407c0efea847cae7bae4487fab6a); i've tested this issue with `z-index: 1` to make sure we are avoiding regression; works well with both expand modes `over` and `alongSide`.

#### Resolves FEC-14421


