### PR TITLE
fix (SUP-47965): Hotkey F is not working when the focus is on another button in the video.

### DIFF
--- a/src/components/shell/shell.tsx
+++ b/src/components/shell/shell.tsx
@@ -144,6 +144,12 @@ class Shell extends Component<any, any> {
     }
   }
 
+  enterFullScreen(): void {
+    if (!this.props.player.isFullscreen()) {
+      this.props.player.enterFullscreen();
+    }
+  }
+
   /**
    * on touch end handler
    * @param {TouchEvent} e - touch event
@@ -176,6 +182,9 @@ class Shell extends Component<any, any> {
       this.props.updatePlayerNavState(true);
     }
 
+    if (this.state.nav && (e.keyCode === KeyMap.F)) {
+      this.enterFullScreen();
+    }
     if (this.state.nav && (e.keyCode === KeyMap.ENTER || e.keyCode === KeyMap.SPACE)) {
       this.unMuteFallback();
       // @ts-ignore


### PR DESCRIPTION
**Issue:**
When open the player, press tab until it focuses on any button in the video other than fullscreen, when press F should trigger the fullscreen.

**Fix:**
handle a case of F (for fullscreen) when tabbing.

fix [SUP-47965](https://kaltura.atlassian.net/browse/SUP-47965)

[SUP-47965]: https://kaltura.atlassian.net/browse/SUP-47965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ