### PR TITLE
fix: (SUP-48028): Player V7 does not display access control message

### DIFF
--- a/src/components/error-overlay/error-message-provider.ts
+++ b/src/components/error-overlay/error-message-provider.ts
@@ -33,7 +33,9 @@ const errorsMap: Map<number, ErrorDetails> = new Map<number, ErrorDetails>([
   /** SITE RESTRICTION */
   [16, {title: 'media_unavailable_error_title', message: 'site_restricted_error_message'}],
   /** SCHEDULED RESTRICTION */
-  [17, {title: 'media_unavailable_error_title', message: 'scheduled_restricted_error_message'}]
+  [17, {title: 'media_unavailable_error_title', message: 'scheduled_restricted_error_message'}],
+  /** ACCESS CONTROL */
+  [18, {title: 'access_control_error_title', message: 'access_control_error_message'}]
 ]);
 
 const defaultError: ErrorDetails = {

--- a/src/components/error-overlay/error-message-provider.ts
+++ b/src/components/error-overlay/error-message-provider.ts
@@ -35,7 +35,7 @@ const errorsMap: Map<number, ErrorDetails> = new Map<number, ErrorDetails>([
   /** SCHEDULED RESTRICTION */
   [17, {title: 'media_unavailable_error_title', message: 'scheduled_restricted_error_message'}],
   /** ACCESS CONTROL */
-  [18, {title: 'access_control_error_title', message: 'access_control_error_message'}]
+  [18, {title: 'error_title', message: 'access_control_error_message'}]
 ]);
 
 const defaultError: ErrorDetails = {

--- a/translations/en.i18n.json
+++ b/translations/en.i18n.json
@@ -97,7 +97,10 @@
       "site_restricted_error_message": "This content is unavailable in this domain.",
       "scheduled_restricted_error_message": "This content is currently unavailable.",
       "default_session_text": "Copy for customer care: session ID",
-      "retry": "Try again"
+      "retry": "Try again",
+      "access_control_error_title": "Error",
+      "access_control_error_message": "Blocked by Conditional Access"
+
     },
     "ads": {
       "ad_notice": "Advertisement",

--- a/translations/en.i18n.json
+++ b/translations/en.i18n.json
@@ -98,7 +98,7 @@
       "scheduled_restricted_error_message": "This content is currently unavailable.",
       "default_session_text": "Copy for customer care: session ID",
       "retry": "Try again",
-      "access_control_error_title": "Error",
+      "error_title": "Error",
       "access_control_error_message": "Blocked by Conditional Access"
 
     },


### PR DESCRIPTION
**Issue:**
Blocked Access Control error is not supported.

**Fix:**
Add support to new Error type

solved [SUP-48028](https://kaltura.atlassian.net/browse/SUP-48028)

related PRS:
https://github.com/kaltura/kaltura-player-js/pull/967
https://github.com/kaltura/playkit-js/pull/816

[SUP-48028]: https://kaltura.atlassian.net/browse/SUP-48028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ