### PR TITLE
fix (SUP-47965): Hotkey F is not working when the focus is on another button in the video.

### DIFF
--- a/src/components/fullscreen/fullscreen.tsx
+++ b/src/components/fullscreen/fullscreen.tsx
@@ -106,9 +106,7 @@ class Fullscreen extends Component<
           this.toggleFullscreen();
         }
       case KeyMap.F:
-        if (!this.props.player!.isFullscreen()) {
-          this.toggleFullscreen();
-        }
+        this.toggleFullscreen();
         break;
       case KeyMap.ESC:
         if (this.props.player!.isFullscreen()) {

--- a/src/components/shell/shell.tsx
+++ b/src/components/shell/shell.tsx
@@ -144,12 +144,8 @@ class Shell extends Component<any, any> {
     }
   }
 
-  toggleFullscreen(): void {
-    if (this.props.player.isFullscreen()) {
-      this.props.player.exitFullscreen();
-    } else {
-      this.props.player.enterFullscreen();
-    }
+  toggleFullscreen(): void { 
+    this.props.player.isFullscreen() ? this.props.player.exitFullscreen() : this.props.player.enterFullscreen();
   }
 
   /**

--- a/src/components/shell/shell.tsx
+++ b/src/components/shell/shell.tsx
@@ -144,6 +144,12 @@ class Shell extends Component<any, any> {
     }
   }
 
+  enterFullScreen(): void {
+    if (!this.props.player.isFullscreen()) {
+      this.props.player.enterFullscreen();
+    }
+  }
+
   /**
    * on touch end handler
    * @param {TouchEvent} e - touch event
@@ -176,6 +182,9 @@ class Shell extends Component<any, any> {
       this.props.updatePlayerNavState(true);
     }
 
+    if (this.state.nav && (e.keyCode === KeyMap.F)) {
+      this.enterFullScreen();
+    }
     if (this.state.nav && (e.keyCode === KeyMap.ENTER || e.keyCode === KeyMap.SPACE)) {
       this.unMuteFallback();
       // @ts-ignore

--- a/src/components/shell/shell.tsx
+++ b/src/components/shell/shell.tsx
@@ -145,7 +145,11 @@ class Shell extends Component<any, any> {
   }
 
   toggleFullscreen(): void { 
-    this.props.player.isFullscreen() ? this.props.player.exitFullscreen() : this.props.player.enterFullscreen();
+    if (this.props.player.isFullscreen()) {
+      this.props.player.exitFullscreen();
+    } else {
+      this.props.player.enterFullscreen();
+    }
   }
 
   /**

--- a/src/components/shell/shell.tsx
+++ b/src/components/shell/shell.tsx
@@ -144,8 +144,10 @@ class Shell extends Component<any, any> {
     }
   }
 
-  enterFullScreen(): void {
-    if (!this.props.player.isFullscreen()) {
+  toggleFullscreen(): void {
+    if (this.props.player.isFullscreen()) {
+      this.props.player.exitFullscreen();
+    } else {
       this.props.player.enterFullscreen();
     }
   }
@@ -183,7 +185,7 @@ class Shell extends Component<any, any> {
     }
 
     if (this.state.nav && (e.keyCode === KeyMap.F)) {
-      this.enterFullScreen();
+      this.toggleFullscreen();
     }
     if (this.state.nav && (e.keyCode === KeyMap.ENTER || e.keyCode === KeyMap.SPACE)) {
       this.unMuteFallback();


### PR DESCRIPTION
**Issue:**
1. When focus on a button in the player using tab, and press F, the player doesn't enter to fullscreen mode.
2. Hotkey F is working only for one direction when the focus is on the player without using tab:
 when press on F when the player is not on fullscreen mode, makes the player enter to fullscreen mode but not on the oposite: when player is on fullscreen mode, and press F, nothing happens.

**Fix:**
support Hotkey F when player fullscreen mode is on for both in shells and using tab.

solved [SUP-47965](https://kaltura.atlassian.net/browse/SUP-47965)

[SUP-47965]: https://kaltura.atlassian.net/browse/SUP-47965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ