### PR TITLE
fix (SUP-47965): Hotkey F is not working when the focus is on another button in the video

### DIFF
--- a/src/components/fullscreen/fullscreen.tsx
+++ b/src/components/fullscreen/fullscreen.tsx
@@ -106,9 +106,7 @@ class Fullscreen extends Component<
           this.toggleFullscreen();
         }
       case KeyMap.F:
-        if (!this.props.player!.isFullscreen()) {
-          this.toggleFullscreen();
-        }
+        this.toggleFullscreen();
         break;
       case KeyMap.ESC:
         if (this.props.player!.isFullscreen()) {

--- a/src/components/shell/shell.tsx
+++ b/src/components/shell/shell.tsx
@@ -144,12 +144,8 @@ class Shell extends Component<any, any> {
     }
   }
 
-  toggleFullscreen(): void {
-    if (this.props.player.isFullscreen()) {
-      this.props.player.exitFullscreen();
-    } else {
-      this.props.player.enterFullscreen();
-    }
+  toggleFullscreen(): void { 
+    this.props.player.isFullscreen() ? this.props.player.exitFullscreen() : this.props.player.enterFullscreen();
   }
 
   /**

--- a/src/components/shell/shell.tsx
+++ b/src/components/shell/shell.tsx
@@ -144,6 +144,12 @@ class Shell extends Component<any, any> {
     }
   }
 
+  enterFullScreen(): void {
+    if (!this.props.player.isFullscreen()) {
+      this.props.player.enterFullscreen();
+    }
+  }
+
   /**
    * on touch end handler
    * @param {TouchEvent} e - touch event
@@ -176,6 +182,9 @@ class Shell extends Component<any, any> {
       this.props.updatePlayerNavState(true);
     }
 
+    if (this.state.nav && (e.keyCode === KeyMap.F)) {
+      this.enterFullScreen();
+    }
     if (this.state.nav && (e.keyCode === KeyMap.ENTER || e.keyCode === KeyMap.SPACE)) {
       this.unMuteFallback();
       // @ts-ignore

--- a/src/components/shell/shell.tsx
+++ b/src/components/shell/shell.tsx
@@ -145,7 +145,11 @@ class Shell extends Component<any, any> {
   }
 
   toggleFullscreen(): void { 
-    this.props.player.isFullscreen() ? this.props.player.exitFullscreen() : this.props.player.enterFullscreen();
+    if (this.props.player.isFullscreen()) {
+      this.props.player.exitFullscreen();
+    } else {
+      this.props.player.enterFullscreen();
+    }
   }
 
   /**

--- a/src/components/shell/shell.tsx
+++ b/src/components/shell/shell.tsx
@@ -144,8 +144,10 @@ class Shell extends Component<any, any> {
     }
   }
 
-  enterFullScreen(): void {
-    if (!this.props.player.isFullscreen()) {
+  toggleFullscreen(): void {
+    if (this.props.player.isFullscreen()) {
+      this.props.player.exitFullscreen();
+    } else {
       this.props.player.enterFullscreen();
     }
   }
@@ -183,7 +185,7 @@ class Shell extends Component<any, any> {
     }
 
     if (this.state.nav && (e.keyCode === KeyMap.F)) {
-      this.enterFullScreen();
+      this.toggleFullscreen();
     }
     if (this.state.nav && (e.keyCode === KeyMap.ENTER || e.keyCode === KeyMap.SPACE)) {
       this.unMuteFallback();

--- a/src/components/shell/shell.tsx
+++ b/src/components/shell/shell.tsx
@@ -179,12 +179,15 @@ class Shell extends Component<any, any> {
    * @returns {void}
    */
   onKeyDown = (e: KeyboardEvent): void => {
+    const target = e.target as HTMLElement;
+    const isInput = target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable;
+
     if (!this.state.nav && e.keyCode === KeyMap.TAB) {
       this.setState({nav: true});
       this.props.updatePlayerNavState(true);
     }
 
-    if (this.state.nav && (e.keyCode === KeyMap.F)) {
+    if (this.state.nav && (e.keyCode === KeyMap.F) && !isInput) {
       this.toggleFullscreen();
     }
     if (this.state.nav && (e.keyCode === KeyMap.ENTER || e.keyCode === KeyMap.SPACE)) {

--- a/src/components/shell/shell.tsx
+++ b/src/components/shell/shell.tsx
@@ -180,7 +180,9 @@ class Shell extends Component<any, any> {
    */
   onKeyDown = (e: KeyboardEvent): void => {
     const target = e.target as HTMLElement;
-    const isInput = target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable;
+    const isInput = target instanceof HTMLInputElement ||
+                target instanceof HTMLTextAreaElement ||
+                target.isContentEditable;
 
     if (!this.state.nav && e.keyCode === KeyMap.TAB) {
       this.setState({nav: true});
@@ -190,7 +192,7 @@ class Shell extends Component<any, any> {
     if (this.state.nav && (e.keyCode === KeyMap.F) && !isInput) {
       this.toggleFullscreen();
     }
-    
+
     if (this.state.nav && (e.keyCode === KeyMap.ENTER || e.keyCode === KeyMap.SPACE)) {
       this.unMuteFallback();
       // @ts-ignore


### PR DESCRIPTION
**Issue:**
On text box, when navigate to the text box with tab, and press F it opens the fullscreen mode instead write the letter 'f'

**Fix:**
In a case of text area or input or any text box, ignore the hotkey F.

solved [SUP-47965](https://kaltura.atlassian.net/browse/SUP-47965)

[SUP-47965]: https://kaltura.atlassian.net/browse/SUP-47965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ