### PR TITLE
fix(FEC-14445): fix position of context menu

### DIFF
--- a/src/components/context-menu/_context-menu.scss
+++ b/src/components/context-menu/_context-menu.scss
@@ -14,6 +14,7 @@
   background-color: rgba(51, 51, 51, 1);
 
   border-radius: 4px;
+  font-family: $font-family;
 
   &.hidden {
     display: none;

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -60,3 +60,4 @@
 @import '../components/audio-entry-details/audio-entry-details';
 @import '../components/expandable-text/expandable-text';
 @import '../components/scrollable/scrollable';
+@import '../components/context-menu/_context-menu.scss';


### PR DESCRIPTION
1. render context menu in portal. Position of context menu sets relative to document.body;
2. use custom context menu and browser native context menu (approach taken from youtube). If custom context menu opened next right-button click trigger appearing of native context menu;

Resolves https://kaltura.atlassian.net/browse/FEC-14445;


