### PR TITLE
fix(SUP-48333): Player local setting not saved/used anymore

### DIFF
--- a/src/components/event-dispatcher/event-dispatcher-provider.tsx
+++ b/src/components/event-dispatcher/event-dispatcher-provider.tsx
@@ -107,6 +107,7 @@ function onCaptionsStyleSelected(store: any, action: any, player: KalturaPlayer)
     } else if (currentStyles?.[key] !== newStyles?.[key]) {
       player.dispatchEvent(new FakeEvent(eventType, newStyles?.[key]));
     }
+    player.dispatchEvent(new CaptionsStyleSelectedEvent(newStyles))
   });
 }
 


### PR DESCRIPTION
**Issue:**
When user changes captions styling, the preference are not saved to the local storage.

**Fix:**
Dispatch the event that should handle this logic.

solved [SUP-48333](https://kaltura.atlassian.net/browse/SUP-48333)