### PR TITLE
fix(FEC-14497): Add Debug Info Option to the Player | Long pressing on ios mobile doesnt show "Copy debug info" button".

### DIFF
--- a/src/components/context-menu/_context-menu.scss
+++ b/src/components/context-menu/_context-menu.scss
@@ -3,8 +3,8 @@
   z-index: 999;
   display: flex;
   align-items: center;
-  height: 40px;
-  width: 260px;
+  height: #{$context-menu-height}px;
+  width: #{$context-menu-width}px;
   padding: 8px 16px;
 
   box-shadow:

--- a/src/components/context-menu/context-menu-utils.ts
+++ b/src/components/context-menu/context-menu-utils.ts
@@ -1,0 +1,42 @@
+import {KalturaPlayer} from '@playkit-js/kaltura-player-js';
+
+class ContextMenuUtils {
+  public static copyDebugInfoToClipboard(player: KalturaPlayer): void {
+    const debugInfo = (player as any).debugInfo;
+
+    if (!debugInfo) {
+      return;
+    }
+
+    const debugInfoString = JSON.stringify(debugInfo, null, 2);
+
+    ContextMenuUtils.copyToClipboard(debugInfoString).catch(() => {
+      ContextMenuUtils.copyToClipboardFallback(debugInfoString);
+    });
+  }
+
+  private static copyToClipboard(text: string): Promise<void> {
+    try {
+      return navigator.clipboard.writeText(text);
+    } catch (e) {
+      return Promise.reject();
+    }
+  }
+
+  private static copyToClipboardFallback(text: string): void {
+    const textArea = document.createElement('textarea');
+    textArea.value = text;
+    document.body.appendChild(textArea);
+    textArea.focus();
+    textArea.select();
+
+    try {
+      document.execCommand('copy');
+    } catch (err) {
+    } finally {
+      document.body.removeChild(textArea);
+    }
+  }
+}
+
+export {ContextMenuUtils};

--- a/src/components/context-menu/context-menu.tsx
+++ b/src/components/context-menu/context-menu.tsx
@@ -12,6 +12,8 @@ import {KalturaPlayer} from '@playkit-js/kaltura-player-js';
 import {Env, EventManager} from '@playkit-js/playkit-js';
 import {ContextMenuUtils} from './context-menu-utils';
 
+import * as globalStyle from '../../styles/style.scss';
+
 interface ContextMenuProps {
   player: KalturaPlayer;
   eventManager: EventManager;
@@ -54,8 +56,8 @@ function _ContextMenu({player, eventManager, copyDebugInfoLabel, isFullscreen}: 
       const container = document.getElementById(player.config.targetId);
       if (!container) return;
 
-      const menuWidth = 130;
-      const menuHeight = 20;
+      const menuWidth = Number((globalStyle as any).contextMenuWidth);
+      const menuHeight = Number((globalStyle as any).contextMenuHeight);
 
       let posX = e.pageX;
       let posY = e.pageY;

--- a/src/components/context-menu/context-menu.tsx
+++ b/src/components/context-menu/context-menu.tsx
@@ -93,11 +93,10 @@ function _ContextMenu({player, eventManager, copyDebugInfoLabel, isFullscreen}: 
 
     if (!Env.isMobile) {
       eventManager!.listen(document, 'contextmenu', showContextMenu);
-      return;
+    } else {
+      eventManager!.listen(document, 'touchstart', handleTouchStart);
+      eventManager!.listen(document, 'touchend', handleTouchEnd);
     }
-
-    eventManager!.listen(document, 'touchstart', handleTouchStart);
-    eventManager!.listen(document, 'touchend', handleTouchEnd);
   }, []);
 
   useEffect(() => {

--- a/src/components/context-menu/context-menu.tsx
+++ b/src/components/context-menu/context-menu.tsx
@@ -86,10 +86,6 @@ function _ContextMenu({player, eventManager, copyDebugInfoLabel, isFullscreen}: 
       touchStartTime = null;
     };
 
-    const clearTouch = () => {
-      touchStartTime = null;
-    };
-
     if (!Env.isMobile) {
       eventManager!.listen(document, 'contextmenu', showContextMenu);
       return;
@@ -97,8 +93,6 @@ function _ContextMenu({player, eventManager, copyDebugInfoLabel, isFullscreen}: 
 
     eventManager!.listen(document, 'touchstart', handleTouchStart);
     eventManager!.listen(document, 'touchend', handleTouchEnd);
-    eventManager!.listen(document, 'touchmove', clearTouch);
-    eventManager!.listen(document, 'touchcancel', clearTouch);
   }, []);
 
   useEffect(() => {

--- a/src/components/context-menu/context-menu.tsx
+++ b/src/components/context-menu/context-menu.tsx
@@ -91,7 +91,7 @@ function _ContextMenu({player, eventManager, copyDebugInfoLabel, isFullscreen}: 
       touchStartTime = null;
     };
 
-    if (!Env.isMobile) {
+    if (!Env.isIOS) {
       eventManager!.listen(document, 'contextmenu', showContextMenu);
     } else {
       eventManager!.listen(document, 'touchstart', handleTouchStart);

--- a/src/components/context-menu/context-menu.tsx
+++ b/src/components/context-menu/context-menu.tsx
@@ -54,12 +54,18 @@ function _ContextMenu({player, eventManager, copyDebugInfoLabel, isFullscreen}: 
       const container = document.getElementById(player.config.targetId);
       if (!container) return;
 
-      const containerRect = container.getBoundingClientRect();
       const menuWidth = 130;
       const menuHeight = 20;
 
-      const posX = containerRect.left + (containerRect.width - menuWidth) / 2;
-      const posY = containerRect.top + (containerRect.height - menuHeight) / 2;
+      let posX = e.pageX;
+      let posY = e.pageY;
+
+      if (posX + menuWidth > window.innerWidth) {
+        posX = window.innerWidth - menuWidth;
+      }
+      if (posY + menuHeight > window.innerHeight) {
+        posY = window.innerHeight - menuHeight;
+      }
 
       ref.current.style.left = posX + 'px';
       ref.current.style.top = posY + 'px';
@@ -67,19 +73,18 @@ function _ContextMenu({player, eventManager, copyDebugInfoLabel, isFullscreen}: 
       setIsVisible(true);
     };
 
-    const handleTouchStart = () => {
+    const handleTouchStart = (e: any): void => {
       touchStartTime = Date.now();
+      e.preventDefault();
     };
 
-    const handleTouchEnd = e => {
+    const handleTouchEnd = (e: MouseEvent): void => {
       if (touchStartTime === null || (touchStartTime && Date.now() - touchStartTime < 500)) return;
-
-      const touch = e.touches[0];
 
       showContextMenu({
         target: e.target,
-        pageX: touch?.pageX,
-        pageY: touch?.pageY,
+        pageX: e.pageX,
+        pageY: e.pageY,
         preventDefault: e.preventDefault.bind(e)
       } as any as MouseEvent);
 
@@ -99,7 +104,7 @@ function _ContextMenu({player, eventManager, copyDebugInfoLabel, isFullscreen}: 
     isVisibleRef.current = isVisible;
   }, [isVisible]);
 
-  const renderContextMenu = () => {
+  const renderContextMenu = (): VNode => {
     return (
       <div ref={ref} className={[styles.contextMenu, isVisible ? '' : styles.hidden].join(' ')} role="menu">
         <div className={styles.contextMenuItem} onClick={() => ContextMenuUtils.copyDebugInfoToClipboard(player)} role="menuitem">

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -27,6 +27,8 @@ $bottom-bar-bottom-gutter: 4;
 $gui-gutter: 16;
 $gui-small-gutter: 8;
 $blur: 16px;
+$context-menu-height: 40;
+$context-menu-width: 260;
 // ***************  Backward Compatibility - Deprecated  **************
 $brand-color: #006bff; // - refs in playkit-ui and related-plugin
 $white: #ffffff; // - refs in playkit-ui and related-plugin
@@ -72,6 +74,8 @@ $new-live-color: #e12437; // - refs in related-plugin
   defaultTransitionTime: $default-transition-time;
   bottomBarMaxHeight: $bottom-bar-max-height;
   topBarMaxHeight: $top-bar-max-height;
+  contextMenuHeight: $context-menu-height;
+  contextMenuWidth: $context-menu-width;
   // ***************  Backward Compatibility - Deprecated  **************
   brandColor: $brand-color;
   white: $white;


### PR DESCRIPTION
### Description of the Changes

Handle debug info context menu in iOS:

- use touch events instead of contextmenu event, which doesnt fire in iOS
- protect against navigator.clipboard.writeText not working in iOS under certain conditions (for example, it works in some iframe pages but doesn't work in others)

Resolves FEC-14497


