### PR TITLE
fix(FEC-14482): Unmute button overlaps top bar controls

### DIFF
--- a/src/components/unmute-indication/_unmute-indication.scss
+++ b/src/components/unmute-indication/_unmute-indication.scss
@@ -1,15 +1,8 @@
 $color: #ffffff;
-.interactive-area {
-  .unmute-button-container {
-    top: 0;
-    left: 0;
-  }
-}
+
 .unmute-button-container {
   display: inline-block;
   position: absolute;
-  top: 16px;
-  left: 16px;
   z-index: 15;
 
   a {
@@ -23,40 +16,53 @@ $color: #ffffff;
       span {
         transform: translateX(10px);
         opacity: 0;
+        margin-left: 0;
+        max-width: 0;
       }
     }
   }
 }
 
 .btn.unmute-button {
-  font-size: 15px;
+  font-size: 14px;
   max-width: 200px;
   transition: max-width 200ms;
-  padding: 0 16px;
+  padding: 8px 12px;
   white-space: nowrap;
+  display: flex;
+  align-items: center;
+  height: 32px;
+  border-radius: 4px;
+  border: none;
 
   span {
     transform: translateX(0px);
+    max-width: 51px;
     opacity: 1;
     transition:
+      max-width 100ms,
       transform 100ms,
       opacity 100ms;
     display: inline-block;
     color: $color;
+    margin-left: 4px;
   }
 
   &.has-top-bar {
     transition: 100ms transform;
   }
+
+  &:hover {
+    border: none;
+  }
 }
 
 .unmute-icon-container {
-  width: 32px;
-  height: 32px;
+  width: 24px;
+  height: 24px;
   display: inline-block;
   vertical-align: top;
   position: relative;
-  margin-right: 3px;
 
   i {
     position: absolute;

--- a/src/components/unmute-indication/unmute-indication.tsx
+++ b/src/components/unmute-indication/unmute-indication.tsx
@@ -3,10 +3,11 @@ import {h, Component, VNode} from 'preact';
 import {connect} from 'react-redux';
 import {default as Icon, IconType} from '../icon';
 import {KeyMap} from '../../utils';
-import {Localizer, Text} from 'preact-i18n';
+import {Localizer, Text, withText} from 'preact-i18n';
 import {withPlayer} from '../player';
 import {withEventManager} from '../../event';
 import {withLogger} from '../logger';
+import {Button} from '../button';
 
 /**
  * The icon only default timeout
@@ -27,6 +28,15 @@ const mapStateToProps = state => ({
 const COMPONENT_NAME = 'UnmuteIndication';
 
 /**
+ * translates
+ * @returns {Object} - The object translations
+ */
+const translates = {
+  unmuteAriaLabel: <Text id={'controls.unmute'}>Unmute</Text>,
+  unmuteButtonText: <Text id={'unmute.unmute'}>Unmute</Text>
+};
+
+/**
  * UnmuteIndication component
  *
  * @class UnmuteIndication
@@ -37,6 +47,7 @@ const COMPONENT_NAME = 'UnmuteIndication';
 @withPlayer
 @withEventManager
 @withLogger(COMPONENT_NAME)
+@withText(translates)
 class UnmuteIndication extends Component<any, any> {
   _iconTimeout: number | null = null;
 
@@ -134,25 +145,22 @@ class UnmuteIndication extends Component<any, any> {
 
     return (
       <Localizer>
-        <div
-          tabIndex={0}
-          aria-label={(<Text id="controls.unmute" />) as unknown as string}
-          className={styleClass.join(' ')}
-          onMouseOver={this.onMouseOver}
-          onMouseOut={this.onMouseOut}
-          onMouseUp={this.onMouseUp}
-          onTouchEnd={this.onTouchEnd}
-          onKeyDown={this.onKeyDown}
-        >
-          <a className={[style.btn, style.btnDarkTransparent, style.unmuteButton].join(' ')}>
+        <div className={styleClass.join(' ')}>
+          <Button
+            className={[style.btn, style.btnDarkTransparent, style.unmuteButton, style.btnTranslucent].join(' ')}
+            tabIndex={0}
+            aria-label={props.unmuteAriaLabel}
+            onMouseOver={this.onMouseOver}
+            onMouseOut={this.onMouseOut}
+            onMouseUp={this.onMouseUp}
+            onTouchEnd={this.onTouchEnd}
+            onKeyDown={this.onKeyDown}>
             <div className={style.unmuteIconContainer}>
               <Icon type={IconType.VolumeBase} />
               <Icon type={IconType.VolumeMute} />
             </div>
-            <span>
-              <Text id={'unmute.unmute'} />
-            </span>
-          </a>
+            <span>{props.unmuteButtonText}</span>
+          </Button>
         </div>
       </Localizer>
     );

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -20,8 +20,8 @@ $spinner-colors: rgb(218, 31, 38), rgb(6, 168, 133), rgb(0, 147, 68), rgb(248, 1
 $default-transition-time: 500;
 $default-hovering-offset: 60px;
 $hover-animation-time: 100;
-$top-bar-max-height: 60;
-$top-bar-top-bottom-gutter: 14;
+$top-bar-max-height: 75;
+$top-bar-top-bottom-gutter: 12;
 $bottom-bar-max-height: 60;
 $bottom-bar-bottom-gutter: 4;
 $gui-gutter: 16;

--- a/src/ui-presets/playback.tsx
+++ b/src/ui-presets/playback.tsx
@@ -72,7 +72,6 @@ class PlaybackUI extends Component<any, any> {
             <GuiArea>
               <Fragment>
                 <AudioEntryDetails />
-                <UnmuteIndication />
                 <Loading />
                 <OverlayPortal />
                 <PictureInPictureOverlay />
@@ -85,6 +84,7 @@ class PlaybackUI extends Component<any, any> {
                 <Fragment>
                   <TopBar />
                   <InteractiveArea>
+                    <UnmuteIndication />
                     <Watermark />
                     <PlaylistCountdown />
                   </InteractiveArea>


### PR DESCRIPTION
### Description of the Changes

**Issue:**
`Unmute indicator` button overlaps top-bar left controls.

**Fix:**
- align current appearance of `unmute` component with design
- for `playback` preset move `unmute` component to `interactive-area` - other presets do not have controls in the top-bar left area


<img width="881" alt="image" src="https://github.com/user-attachments/assets/94533cc5-3162-4323-8f46-5311bb76faa7" />

#### Resolves FEC-14482


