### PR TITLE
fix(FEC-14449): When CC button display on upper bar outside of more plugins, open it with spacebar \ enter doesnt work

### DIFF
--- a/src/components/captions-control/captions-control-mini.tsx
+++ b/src/components/captions-control/captions-control-mini.tsx
@@ -14,6 +14,7 @@ import {CaptionsMenu} from '../captions-menu';
 import {SmartContainer} from '../smart-container';
 import {CaptionsControl} from './captions-control';
 import {getOverlayPortalElement} from '../overlay-portal';
+import { isEnter, isSpace } from "../../utils/key-map";
 
 const mapStateToProps = state => ({
   controlsToMove: state.bottomBar.controlsToMove
@@ -88,7 +89,7 @@ const CaptionsControlMini = connect(mapStateToProps)((props, context) => {
   };
 
   const onKeyDown = (e: KeyboardEvent): void => {
-    if (e.key === 'Enter' || e.key === ' ' || e.keyCode === 13 || e.keyCode === 32) {
+    if (isEnter(e.keyCode) || isSpace(e.keyCode)) {
       e.preventDefault();
       onButtonClick();
     }

--- a/src/components/captions-control/captions-control-mini.tsx
+++ b/src/components/captions-control/captions-control-mini.tsx
@@ -87,6 +87,13 @@ const CaptionsControlMini = connect(mapStateToProps)((props, context) => {
     });
   };
 
+  const onKeyDown = (e: KeyboardEvent): void => {
+    if (e.key === 'Enter' || e.key === ' ' || e.keyCode === 13 || e.keyCode === 32) {
+      e.preventDefault();
+      onButtonClick();
+    }
+  };
+
   return shouldRender ? (
     <ButtonControl name={COMPONENT_NAME} className={style.upperBarIcon}>
       <Tooltip label={props.captionsLabelText}>
@@ -95,7 +102,8 @@ const CaptionsControlMini = connect(mapStateToProps)((props, context) => {
           aria-label={props.captionsLabelText}
           aria-haspopup="true"
           className={style.controlButton}
-          onClick={onButtonClick}>
+          onClick={onButtonClick}
+          onKeyDown={onKeyDown}>
           <Icon type={isCaptionsEnabled() ? IconType.ClosedCaptionsOn : IconType.ClosedCaptionsOff} />
         </Button>
       </Tooltip>

--- a/src/components/captions-control/captions-control-mini.tsx
+++ b/src/components/captions-control/captions-control-mini.tsx
@@ -89,7 +89,7 @@ const CaptionsControlMini = connect(mapStateToProps)((props, context) => {
   };
 
   const onKeyDown = (e: KeyboardEvent): void => {
-    if (isEnter(e.keyCode) || isSpace(e.keyCode)) {
+    if (isEnter(e) || isSpace(e)) {
       e.preventDefault();
       onButtonClick();
     }

--- a/src/components/captions-control/captions-control.tsx
+++ b/src/components/captions-control/captions-control.tsx
@@ -14,6 +14,7 @@ import {createPortal} from 'preact/compat';
 import {CVAAOverlay} from '../cvaa-overlay';
 import {CaptionsControlMini} from './captions-control-mini';
 import {getOverlayPortalElement} from '../overlay-portal';
+import { isEnter, isSpace } from "../../utils/key-map";
 
 /**
  * mapping state to props
@@ -60,7 +61,7 @@ const CaptionsControl = connect(mapStateToProps)(
     };
 
     const onKeyDown = (e: KeyboardEvent): void => {
-      if (e.key === 'Enter' || e.key === ' ' || e.keyCode === 13 || e.keyCode === 32) {
+      if (isEnter(e.keyCode) || isSpace(e.keyCode)) {
         e.preventDefault();
         onControlButtonClick(e, true);
       }

--- a/src/components/captions-control/captions-control.tsx
+++ b/src/components/captions-control/captions-control.tsx
@@ -61,7 +61,7 @@ const CaptionsControl = connect(mapStateToProps)(
     };
 
     const onKeyDown = (e: KeyboardEvent): void => {
-      if (isEnter(e.keyCode) || isSpace(e.keyCode)) {
+      if (isEnter(e) || isSpace(e)) {
         e.preventDefault();
         onControlButtonClick(e, true);
       }

--- a/src/components/captions-control/captions-control.tsx
+++ b/src/components/captions-control/captions-control.tsx
@@ -59,6 +59,13 @@ const CaptionsControl = connect(mapStateToProps)(
       }
     };
 
+    const onKeyDown = (e: KeyboardEvent): void => {
+      if (e.key === 'Enter' || e.key === ' ' || e.keyCode === 13 || e.keyCode === 32) {
+        e.preventDefault();
+        onControlButtonClick(e, true);
+      }
+    };
+
     const toggleCVAAOverlay = (): void => {
       setCVAAOverlay(cvaaOverlay => !cvaaOverlay);
     };
@@ -97,7 +104,8 @@ const CaptionsControl = connect(mapStateToProps)(
               aria-label={props.captionsLabelText}
               aria-haspopup="true"
               className={[style.controlButton, smartContainerOpen ? style.active : ''].join(' ')}
-              onClick={onControlButtonClick}>
+              onClick={onControlButtonClick}
+              onKeyDown={onKeyDown}>
               <Icon type={ccOn ? IconType.ClosedCaptionsOn : IconType.ClosedCaptionsOff} />
             </Button>
           </Tooltip>

--- a/src/components/closed-captions/closed-captions.tsx
+++ b/src/components/closed-captions/closed-captions.tsx
@@ -88,7 +88,7 @@ const ClosedCaptions = connect(mapStateToProps)(
       };
 
       const onKeyDown = (e: KeyboardEvent): void => {
-        if (isEnter(e.keyCode) || isSpace(e.keyCode)) {
+        if (isEnter(e) || isSpace(e)) {
           e.preventDefault();
           onClick();
         }

--- a/src/components/closed-captions/closed-captions.tsx
+++ b/src/components/closed-captions/closed-captions.tsx
@@ -86,6 +86,13 @@ const ClosedCaptions = connect(mapStateToProps)(
         isCCOn ? player.hideTextTrack() : player.showTextTrack();
       };
 
+      const onKeyDown = (e: KeyboardEvent): void => {
+        if (e.key === 'Enter' || e.key === ' ' || e.keyCode === 13 || e.keyCode === 32) {
+          e.preventDefault();
+          onClick();
+        }
+      };
+
         const shouldRender = !!textTracks?.length && props.showCCButton && !props.openMenuFromCCButton;
         props.onToggle(COMPONENT_NAME, shouldRender);
         if (!shouldRender) return undefined;
@@ -102,6 +109,7 @@ const ClosedCaptions = connect(mapStateToProps)(
                     props.notifyClick(true);
                     player.hideTextTrack();
                   }}
+                  onKeyDown={onKeyDown}
                 >
                   <Icon type={IconType.ClosedCaptionsOn} />
                 </Button>
@@ -116,6 +124,7 @@ const ClosedCaptions = connect(mapStateToProps)(
                     player.showTextTrack();
                     props.notifyClick(false);
                   }}
+                  onKeyDown={onKeyDown}
                 >
                   <Icon type={IconType.ClosedCaptionsOff} />
                 </Button>

--- a/src/components/closed-captions/closed-captions.tsx
+++ b/src/components/closed-captions/closed-captions.tsx
@@ -11,6 +11,7 @@ import {Button} from '../button';
 import {ButtonControl} from '../button-control';
 import {registerToBottomBar} from '../bottom-bar';
 import {redux} from '../../index';
+import { isEnter, isSpace } from "../../utils/key-map";
 
 /**
  * mapping state to props
@@ -87,7 +88,7 @@ const ClosedCaptions = connect(mapStateToProps)(
       };
 
       const onKeyDown = (e: KeyboardEvent): void => {
-        if (e.key === 'Enter' || e.key === ' ' || e.keyCode === 13 || e.keyCode === 32) {
+        if (isEnter(e.keyCode) || isSpace(e.keyCode)) {
           e.preventDefault();
           onClick();
         }

--- a/src/utils/key-map.ts
+++ b/src/utils/key-map.ts
@@ -102,6 +102,14 @@ export function isEnter(keyCode: number): boolean {
 
 /**
  * @param {number} keyCode - key code
+ * @returns {boolean} - whether the given key code is an enter key
+ */
+export function isSpace(keyCode: number): boolean {
+  return isKeyEqual(keyCode, KeyMap.SPACE);
+}
+
+/**
+ * @param {number} keyCode - key code
  * @returns {boolean} - whether the given key code is an esc key
  */
 export function isEsc(keyCode: number): boolean {

--- a/src/utils/key-map.ts
+++ b/src/utils/key-map.ts
@@ -37,7 +37,7 @@ export const KeyCode = {
   Pause: 'Pause',
   CapsLock: 'CapsLock',
   Escape: 'Escape',
-  Space: 'Space',
+  Space: ' ',
   PageUp: 'PageUp',
   PageDown: 'PageDown',
   End: 'End',
@@ -85,42 +85,42 @@ export function getKeyName(keyCode: number): string {
 }
 
 /**
- * @param {number} keyCode - key code
+ * @param {KeyboardEvent} e - Keyboard event
  * @returns {boolean} - whether the given key code is a tab key
  */
-export function isTab(keyCode: number): boolean {
-  return isKeyEqual(keyCode, KeyMap.TAB);
+export function isTab(e: KeyboardEvent): boolean {
+  return isKeyEqual(e.key, KeyCode.Tab);
 }
 
 /**
- * @param {number} keyCode - key code
+ * @param {KeyboardEvent} e - Keyboard event
  * @returns {boolean} - whether the given key code is an enter key
  */
-export function isEnter(keyCode: number): boolean {
-  return isKeyEqual(keyCode, KeyMap.ENTER);
+export function isEnter(e: KeyboardEvent): boolean {
+  return isKeyEqual(e.key, KeyCode.Enter);
 }
 
 /**
- * @param {number} keyCode - key code
+ * @param {KeyboardEvent} e - Keyboard event
  * @returns {boolean} - whether the given key code is an enter key
  */
-export function isSpace(keyCode: number): boolean {
-  return isKeyEqual(keyCode, KeyMap.SPACE);
+export function isSpace(e: KeyboardEvent): boolean {
+  return isKeyEqual(e.key, KeyCode.Space);
 }
 
 /**
- * @param {number} keyCode - key code
+ * @param {KeyboardEvent} e - Keyboard event
  * @returns {boolean} - whether the given key code is an esc key
  */
-export function isEsc(keyCode: number): boolean {
-  return isKeyEqual(keyCode, KeyMap.ESC);
+export function isEsc(e: KeyboardEvent): boolean {
+  return isKeyEqual(e.key, KeyCode.Escape);
 }
 
 /**
- * @param {number} inputKeyCode - input key code
- * @param {number} targetKeyCode - target key code
+ * @param {string} inputKey - input key
+ * @param {string} targetKey - target key
  * @returns {boolean} - whether the given key code is equals to the input key
  */
-function isKeyEqual(inputKeyCode: number, targetKeyCode: number): boolean {
-  return inputKeyCode === targetKeyCode;
+function isKeyEqual(inputKey: string, targetKey: string): boolean {
+  return inputKey === targetKey;
 }


### PR DESCRIPTION
**Issue:**
When CC button display on upper bar outside of more plugins, open it with spacebar \ enter doesnt work.

**Fix:**
- Added keyboard event handlers to CC button components to respond to Enter and Space key presses
- Fixed accessibility issue where CC buttons in the upper toolbar weren't keyboard-activatable
- Implemented consistent keyboard handling across all three CC-related components (ClosedCaptions, CaptionsControl, CaptionsControlMini)

[FEC-14449](https://kaltura.atlassian.net/browse/FEC-14449)




[FEC-14449]: https://kaltura.atlassian.net/browse/FEC-14449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ