### PR TITLE
fix(FEC-14450): Fixed issue where the Closed Caption button icon didn't update immediately.

### DIFF
--- a/src/components/captions-menu/captions-menu.tsx
+++ b/src/components/captions-menu/captions-menu.tsx
@@ -3,6 +3,7 @@ import {withText} from 'preact-i18n';
 import {connect} from 'react-redux';
 import {bindActions} from '../../utils';
 import {actions} from '../../reducers/cvaa';
+import {redux} from '../../index';
 import {SmartContainerItem} from '../smart-container/smart-container-item';
 import {IconType} from '../icon';
 import {withPlayer} from '../player';
@@ -58,6 +59,9 @@ class CaptionsMenu extends Component<any, any> {
       return;
     }
     this.props.player.selectTrack(textTrack);
+    // Update the Redux state to reflect the current captions state
+    const isCaptionsEnabled = typeof textTrack === 'object' && textTrack.language !== 'off';
+    redux.useStore().dispatch({type: 'settings/UPDATE_IS_CAPTIONS_ENABLED', isCaptionsEnabled});
     this.props.notifyClick({
       type: this.props.player.Track.TEXT,
       track: textTrack
@@ -109,7 +113,7 @@ class CaptionsMenu extends Component<any, any> {
           }}
           options={textOptions}
           onMenuChosen={textTrack => this.onCaptionsChange(textTrack)}
-          onClose={() => {}} 
+          onClose={() => {}}
         />
       );
     }

--- a/src/components/closed-captions/closed-captions.tsx
+++ b/src/components/closed-captions/closed-captions.tsx
@@ -83,7 +83,13 @@ const ClosedCaptions = connect(mapStateToProps)(
       const onClick = () => {
         const isCCOn = isCaptionsEnabled();
         props.notifyClick(isCCOn);
-        isCCOn ? player.hideTextTrack() : player.showTextTrack();
+        if (isCCOn) {
+          player.hideTextTrack();
+          redux.useStore().dispatch({type: 'settings/UPDATE_IS_CAPTIONS_ENABLED', isCaptionsEnabled: false});
+        } else {
+          player.showTextTrack();
+          redux.useStore().dispatch({type: 'settings/UPDATE_IS_CAPTIONS_ENABLED', isCaptionsEnabled: true});
+        }
       };
 
         const shouldRender = !!textTracks?.length && props.showCCButton && !props.openMenuFromCCButton;
@@ -101,6 +107,7 @@ const ClosedCaptions = connect(mapStateToProps)(
                   onClick={() => {
                     props.notifyClick(true);
                     player.hideTextTrack();
+                    redux.useStore().dispatch({type: 'settings/UPDATE_IS_CAPTIONS_ENABLED', isCaptionsEnabled: false});
                   }}
                 >
                   <Icon type={IconType.ClosedCaptionsOn} />
@@ -115,6 +122,7 @@ const ClosedCaptions = connect(mapStateToProps)(
                   onClick={() => {
                     player.showTextTrack();
                     props.notifyClick(false);
+                    redux.useStore().dispatch({type: 'settings/UPDATE_IS_CAPTIONS_ENABLED', isCaptionsEnabled: true});
                   }}
                 >
                   <Icon type={IconType.ClosedCaptionsOff} />


### PR DESCRIPTION
**Issue:**
 When CC button display on the upperbar(in or outside of more plugins), after turn it on or off the icon doesn't change, only after closing & open again the kitchen sink or enter & exit advanced caption settings.

**Fix:**
- Fixed a UI issue where the Closed Caption (CC) button icon didn't update immediately after toggling captions on/off
- Added direct Redux state updates in the caption toggle handlers to ensure immediate visual feedback
- Implemented consistent state management in both `ClosedCaptions` component and `CaptionsMenu` component

[FEC-14450](https://kaltura.atlassian.net/browse/FEC-14450)