### PR TITLE
fix(FEC-14449): When CC button display on upper bar outside of more plugins, open it with spacebar \ enter doesnt work 

### DIFF
--- a/src/components/captions-control/captions-control-mini.tsx
+++ b/src/components/captions-control/captions-control-mini.tsx
@@ -14,6 +14,7 @@ import {CaptionsMenu} from '../captions-menu';
 import {SmartContainer} from '../smart-container';
 import {CaptionsControl} from './captions-control';
 import {getOverlayPortalElement} from '../overlay-portal';
+import { isEnter, isSpace } from "../../utils/key-map";
 
 const mapStateToProps = state => ({
   controlsToMove: state.bottomBar.controlsToMove
@@ -87,6 +88,13 @@ const CaptionsControlMini = connect(mapStateToProps)((props, context) => {
     });
   };
 
+  const onKeyDown = (e: KeyboardEvent): void => {
+    if (isEnter(e) || isSpace(e)) {
+      e.preventDefault();
+      onButtonClick();
+    }
+  };
+
   return shouldRender ? (
     <ButtonControl name={COMPONENT_NAME} className={style.upperBarIcon}>
       <Tooltip label={props.captionsLabelText}>
@@ -95,7 +103,8 @@ const CaptionsControlMini = connect(mapStateToProps)((props, context) => {
           aria-label={props.captionsLabelText}
           aria-haspopup="true"
           className={style.controlButton}
-          onClick={onButtonClick}>
+          onClick={onButtonClick}
+          onKeyDown={onKeyDown}>
           <Icon type={isCaptionsEnabled() ? IconType.ClosedCaptionsOn : IconType.ClosedCaptionsOff} />
         </Button>
       </Tooltip>

--- a/src/components/captions-control/captions-control.tsx
+++ b/src/components/captions-control/captions-control.tsx
@@ -14,6 +14,7 @@ import {createPortal} from 'preact/compat';
 import {CVAAOverlay} from '../cvaa-overlay';
 import {CaptionsControlMini} from './captions-control-mini';
 import {getOverlayPortalElement} from '../overlay-portal';
+import { isEnter, isSpace } from "../../utils/key-map";
 
 /**
  * mapping state to props
@@ -59,6 +60,13 @@ const CaptionsControl = connect(mapStateToProps)(
       }
     };
 
+    const onKeyDown = (e: KeyboardEvent): void => {
+      if (isEnter(e) || isSpace(e)) {
+        e.preventDefault();
+        onControlButtonClick(e, true);
+      }
+    };
+
     const toggleCVAAOverlay = (): void => {
       setCVAAOverlay(cvaaOverlay => !cvaaOverlay);
     };
@@ -97,7 +105,8 @@ const CaptionsControl = connect(mapStateToProps)(
               aria-label={props.captionsLabelText}
               aria-haspopup="true"
               className={[style.controlButton, smartContainerOpen ? style.active : ''].join(' ')}
-              onClick={onControlButtonClick}>
+              onClick={onControlButtonClick}
+              onKeyDown={onKeyDown}>
               <Icon type={ccOn ? IconType.ClosedCaptionsOn : IconType.ClosedCaptionsOff} />
             </Button>
           </Tooltip>

--- a/src/components/closed-captions/closed-captions.tsx
+++ b/src/components/closed-captions/closed-captions.tsx
@@ -12,6 +12,7 @@ import {ButtonControl} from '../button-control';
 import {registerToBottomBar} from '../bottom-bar';
 import {redux} from '../../index';
 import {types} from '../../reducers/settings';
+import { isEnter, isSpace } from "../../utils/key-map";
 
 /**
  * mapping state to props
@@ -93,6 +94,13 @@ const ClosedCaptions = connect(mapStateToProps)(
         }
       };
 
+        const onKeyDown = (e: KeyboardEvent): void => {
+          if (isEnter(e) || isSpace(e)) {
+            e.preventDefault();
+            onClick();
+          }
+        };
+
         const shouldRender = !!textTracks?.length && props.showCCButton && !props.openMenuFromCCButton;
         props.onToggle(COMPONENT_NAME, shouldRender);
         if (!shouldRender) return undefined;
@@ -110,6 +118,7 @@ const ClosedCaptions = connect(mapStateToProps)(
                     player.hideTextTrack();
                     redux.useStore().dispatch({type: types.UPDATE_IS_CAPTIONS_ENABLED, isCaptionsEnabled: false});
                   }}
+                  onKeyDown={onKeyDown}
                 >
                   <Icon type={IconType.ClosedCaptionsOn} />
                 </Button>
@@ -125,6 +134,7 @@ const ClosedCaptions = connect(mapStateToProps)(
                     props.notifyClick(false);
                     redux.useStore().dispatch({type: types.UPDATE_IS_CAPTIONS_ENABLED, isCaptionsEnabled: true});
                   }}
+                  onKeyDown={onKeyDown}
                 >
                   <Icon type={IconType.ClosedCaptionsOff} />
                 </Button>

--- a/src/utils/key-map.ts
+++ b/src/utils/key-map.ts
@@ -85,34 +85,42 @@ export function getKeyName(keyCode: number): string {
 }
 
 /**
- * @param {number} keyCode - key code
+ * @param {KeyboardEvent} e - Keyboard event
  * @returns {boolean} - whether the given key code is a tab key
  */
-export function isTab(keyCode: number): boolean {
-  return isKeyEqual(keyCode, KeyMap.TAB);
+export function isTab(e: KeyboardEvent): boolean {
+  return isKeyEqual(e.code, KeyCode.Tab);
 }
 
 /**
- * @param {number} keyCode - key code
+ * @param {KeyboardEvent} e - Keyboard event
  * @returns {boolean} - whether the given key code is an enter key
  */
-export function isEnter(keyCode: number): boolean {
-  return isKeyEqual(keyCode, KeyMap.ENTER);
+export function isEnter(e: KeyboardEvent): boolean {
+  return isKeyEqual(e.code, KeyCode.Enter);
 }
 
 /**
- * @param {number} keyCode - key code
+ * @param {KeyboardEvent} e - Keyboard event
+ * @returns {boolean} - whether the given key code is an enter key
+ */
+export function isSpace(e: KeyboardEvent): boolean {
+  return isKeyEqual(e.code, KeyCode.Space);
+}
+
+/**
+ * @param {KeyboardEvent} e - Keyboard event
  * @returns {boolean} - whether the given key code is an esc key
  */
-export function isEsc(keyCode: number): boolean {
-  return isKeyEqual(keyCode, KeyMap.ESC);
+export function isEsc(e: KeyboardEvent): boolean {
+  return isKeyEqual(e.code, KeyCode.Escape);
 }
 
 /**
- * @param {number} inputKeyCode - input key code
- * @param {number} targetKeyCode - target key code
+ * @param {string} inputKeyCode - input key
+ * @param {string} targetKeyCode - target key
  * @returns {boolean} - whether the given key code is equals to the input key
  */
-function isKeyEqual(inputKeyCode: number, targetKeyCode: number): boolean {
+function isKeyEqual(inputKeyCode: string, targetKeyCode: string): boolean {
   return inputKeyCode === targetKeyCode;
 }


### PR DESCRIPTION
**Issue:**
When CC button display on upper bar outside of more plugins, open it with spacebar \ enter doesnt work.

**Fix:**
- Added keyboard event handlers to CC button components to respond to Enter and Space key presses
- Fixed accessibility issue where CC buttons in the upper toolbar weren't keyboard-activatable
- Implemented consistent keyboard handling across all three CC-related components (ClosedCaptions, CaptionsControl, CaptionsControlMini)

[FEC-14449](https://kaltura.atlassian.net/browse/FEC-14449)




[FEC-14449]: https://kaltura.atlassian.net/browse/FEC-14449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ