### PR TITLE
feat(FEC-12933): Prevent copy base

### DIFF
--- a/src/components/shell/shell.tsx
+++ b/src/components/shell/shell.tsx
@@ -39,7 +39,8 @@ const mapStateToProps = state => ({
   fullscreen: state.engine.fullscreen,
   fallbackToMutedAutoPlay: state.engine.fallbackToMutedAutoPlay,
   playlist: state.engine.playlist,
-  tinySizeDisabled: state.config.tinySizeDisabled
+  tinySizeDisabled: state.config.tinySizeDisabled,
+  isProtected: state.config.isProtected
 });
 
 const ON_PLAYER_RECT_CHANGE_DEBOUNCE_DELAY: number = 100;
@@ -417,6 +418,7 @@ class Shell extends Component<any, any> {
 
     if (this.props.prePlayback) playerClasses.push(style.prePlayback);
     if (this.props.isCasting) playerClasses.push(`${__CSS_MODULE_PREFIX__}-casting`);
+    if (this.props.isProtected) playerClasses.push(`protected`);
     if (this.props.isMobile) playerClasses.push(style.touch);
     if (this.props.playerNav) playerClasses.push(style.nav);
     if (this.props.playerHover || this.props.playerNav) playerClasses.push(style.hover);

--- a/src/styles/_shell.scss
+++ b/src/styles/_shell.scss
@@ -80,6 +80,13 @@
   transition: transform 100ms;
 }
 
+.player.no-copy-allowed {
+  :global(.no-copy) {
+    .noselect { user-select: none; }
+    .noselect::selection { background: none; }
+  }
+}
+
 .player:not(.ad-break).metadata-loaded {
   &.hover :global([id^='playkit-ads-container']),
   &.state-paused :global([id^='playkit-ads-container']),

--- a/src/types/ui-options.ts
+++ b/src/types/ui-options.ts
@@ -24,4 +24,5 @@ export interface UIOptionsObject {
   translations?: {[langKey: string]: any};
   locale?: string;
   userTheme?: UserTheme;
+  isProtected?: boolean;
 }


### PR DESCRIPTION
### Description of the Changes

Added conditional class for root of UI. It is dependend on flag:
ui: {
    isProtected: boolean
}

**Issue:**
User can copy certain elements of the player. We want to prevent this.

**Fix:**
Class itself add just styles for a children, if no children with this class there - then there won't be any changes.

#### Resolves FEC-12933

