### PR TITLE
feat(FEC-14520): Add analytics for Copy Debug Info

### DIFF
--- a/src/components/context-menu/context-menu-utils.ts
+++ b/src/components/context-menu/context-menu-utils.ts
@@ -1,4 +1,6 @@
 import {KalturaPlayer} from '@playkit-js/kaltura-player-js';
+import {FakeEvent} from '@playkit-js/playkit-js';
+import {EventType} from '../../event';
 
 class ContextMenuUtils {
   public static copyDebugInfoToClipboard(player: KalturaPlayer): void {
@@ -10,9 +12,14 @@ class ContextMenuUtils {
 
     const debugInfoString = JSON.stringify(debugInfo, null, 2);
 
-    ContextMenuUtils.copyToClipboard(debugInfoString).catch(() => {
-      ContextMenuUtils.copyToClipboardFallback(debugInfoString);
-    });
+    ContextMenuUtils.copyToClipboard(debugInfoString)
+      .then(() => {
+        player.dispatchEvent(new FakeEvent(EventType.USER_COPIED_DEBUG_INFO));
+      })
+      .catch(() => {
+        ContextMenuUtils.copyToClipboardFallback(debugInfoString);
+        player.dispatchEvent(new FakeEvent(EventType.USER_COPIED_DEBUG_INFO));
+      });
   }
 
   private static copyToClipboard(text: string): Promise<void> {

--- a/src/components/context-menu/context-menu.tsx
+++ b/src/components/context-menu/context-menu.tsx
@@ -23,7 +23,7 @@ interface ContextMenuProps {
 }
 
 const translations = {
-  copyDebugInfoLabel: <Text id="error.copt_debug_info">Copy debug info</Text>
+  copyDebugInfoLabel: <Text id="error.copy_debug_info">Copy debug info</Text>
 };
 
 function mapStateToProps(state): any {

--- a/src/event/event-type.ts
+++ b/src/event/event-type.ts
@@ -39,7 +39,8 @@ const EventType = {
   USER_SELECTED_CAPTIONS_BACKGROUND_COLOR: `${namespace}-userselectedcaptionsbackgroundcolor`,
   USER_SELECTED_CAPTIONS_BACKGROUND_OPACITY: `${namespace}-userselectedcaptionsbackgroundopacity`,
   BOTTOM_BAR_CLIENT_RECT_CHANGED: `${namespace}-bottombarclientrectchanged`,
-  PLAYER_HOVERED: `${namespace}-playerhovered`
+  PLAYER_HOVERED: `${namespace}-playerhovered`,
+  USER_COPIED_DEBUG_INFO: `${namespace}-usercopieddebuginfo`
 } as const;
 
 export {EventType};


### PR DESCRIPTION
Add analytics for Copy Debug Info

Related PR: https://github.com/kaltura/playkit-js-kava/pull/203

[FEC-14520](https://kaltura.atlassian.net/browse/FEC-14520)


[FEC-14520]: https://kaltura.atlassian.net/browse/FEC-14520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ