### PR TITLE
fix(FEC-14399): register EAD to bottom-bar manager only if media has EAD captions

### DIFF
--- a/src/components/advanced-audio-desc/advanced-audio-desc.tsx
+++ b/src/components/advanced-audio-desc/advanced-audio-desc.tsx
@@ -40,9 +40,10 @@ const mapStateToProps = ({config, settings}) => ({
   advancedAudioDescDisabledText: 'settings.advanced_audio_description_disabled'
 })
 class AdvancedAudioDesc extends Component<any, any> implements IconComponent {
-  constructor(props: any) {
-    super();
-    registerToBottomBar(COMPONENT_NAME, props.player, () => this.registerComponent());
+  componentDidUpdate(previousProps): void {
+    if (this.props.showAdvancedAudioDescToggle && !previousProps.showAdvancedAudioDescToggle) {
+      registerToBottomBar(COMPONENT_NAME, this.props.player, () => this.registerComponent());
+    }
   }
 
   get advancedAudioDesc(): boolean {


### PR DESCRIPTION
Issue: EAD button added to preset regardless if the media has EAD captions, inside `AdvancedAudioDesc` there logic when render button or not. In same time items (icons) that added to bottom-bar panel registry moves to upper-bar when there not enough space for render. It makes issue that if media doesn't have EAD captions the icon doesn't renders in bottom-bar but renders in upper-bar panel.

fix: register EAD to bottom-bar panel only if media has EAD captions.

Resolves: https://kaltura.atlassian.net/browse/FEC-14399


