### PR TITLE
fix(SUP-48894): Audio flavor selector bug

### DIFF
--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -99,7 +99,7 @@ class Menu extends Component<MenuProps & WithEventManagerProps, any> {
     } else {
       // If we cannot render it on top of the label or below it, we will reduce the height of the menu to be
       // 80% of the player height and put it at the bottom of the player.
-      this._menuElement.style.maxHeight = guiClientRect!.height - style.topBarMaxHeight - style.bottomBarMaxHeight + 'px';
+      this._menuElement.style.maxHeight = guiClientRect!.height - Number(style.topBarMaxHeight) - Number(style.bottomBarMaxHeight) + 'px';
       return [style.stickBottom, style.left];
     }
   }

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -99,7 +99,7 @@ class Menu extends Component<MenuProps & WithEventManagerProps, any> {
     } else {
       // If we cannot render it on top of the label or below it, we will reduce the height of the menu to be
       // 80% of the player height and put it at the bottom of the player.
-      this._menuElement.style.maxHeight = guiClientRect!.height * 0.8 + 'px';
+      this._menuElement.style.maxHeight = guiClientRect!.height - style.topBarMaxHeight - style.bottomBarMaxHeight + 'px';
       return [style.stickBottom, style.left];
     }
   }


### PR DESCRIPTION
### Description of the Changes

**Issue:**
In case dropdown under settings (audio, captions) has many items, the most top item is not clickable because top-bar element overlapping it.

**Fix:**
Change the max-height value by subtract the top-bar and the bottom-bar height.

#### Resolves [SUP-48894](https://kaltura.atlassian.net/browse/SUP-48894)




[SUP-48894]: https://kaltura.atlassian.net/browse/SUP-48894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ