### PR TITLE
fix(SUP-48552): Missing translation in player v7

### DIFF
--- a/translations/pt_br.i18n.json
+++ b/translations/pt_br.i18n.json
@@ -25,9 +25,7 @@
       "logo": "Logo",
       "seekBarSlider": "Controle deslizante",
       "readLess": "Menos",
-      "readMore": "Mais",
-      "secondsRewind": "Buscar {{seconds}} segundos para trás",
-      "secondsForward": "Buscar {{seconds}} segundos para frente"
+      "readMore": "Mais"
     },
     "unmute": {
       "unmute": "Cancelar silenciamento"


### PR DESCRIPTION
### Description of the Changes

Remove duplicated translations for secondsRewind and secondsForward in Portuguese file 


#### Resolves FEC-[Please add the ticket reference here]


