### PR TITLE
fix(SUP-48817): Entries Under Moderation Are Still Playing

### DIFF
--- a/src/components/error-overlay/error-message-provider.ts
+++ b/src/components/error-overlay/error-message-provider.ts
@@ -35,7 +35,9 @@ const errorsMap: Map<number, ErrorDetails> = new Map<number, ErrorDetails>([
   /** SCHEDULED RESTRICTION */
   [17, {title: 'media_unavailable_error_title', message: 'scheduled_restricted_error_message'}],
   /** ACCESS CONTROL */
-  [18, {title: 'error_title', message: 'access_control_error_message'}]
+  [18, {title: 'error_title', message: 'access_control_error_message'}],
+  /** MODERATION RESTRICTION */
+  [19, {title: 'moderation_error_title', message: 'moderation_error_message'}]
 ]);
 
 const defaultError: ErrorDetails = {

--- a/translations/en.i18n.json
+++ b/translations/en.i18n.json
@@ -48,7 +48,7 @@
       "volume_button_aria_label": "Volume",
       "volume_button_description": "Click to volume control",
       "volume_slider_aria_label": "Volume control",
-      "volume_slider_description": "Use the arrows to control the volume"      
+      "volume_slider_description": "Use the arrows to control the volume"
     },
     "copy": {
       "button": "Copy URL"
@@ -83,6 +83,8 @@
       "network_error_message": "Please check your network connection and try again.",
       "media_unavailable_error_title": "Media unavailable",
       "media_unavailable_error_message": "This media has been restricted. Please obtain relevant permissions to access content.",
+      "moderation_error_title": "Entry is awaiting moderation",
+      "moderation_error_message": "Media is awaiting moderation",
       "text_error_title": "Text stream error",
       "text_error_message": "Text stream error occurred",
       "media_error_title": "Media stream error",


### PR DESCRIPTION
### Description of the Changes

Adding error messages for moderation restriction

Part of https://github.com/kaltura/playkit-js-providers/pull/265, https://github.com/kaltura/playkit-js/pull/822, https://github.com/kaltura/playkit-js-ui/pull/1053

#### Resolves [SUP-48817](https://kaltura.atlassian.net/browse/SUP-48817)




[SUP-48817]: https://kaltura.atlassian.net/browse/SUP-48817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ