### PR TITLE
fix(ADA-2781): Play buttons focus management

### DIFF
--- a/src/components/play-pause/_play-pause.scss
+++ b/src/components/play-pause/_play-pause.scss
@@ -24,4 +24,9 @@
       display: none;
     }
   }
+  &:focus {
+    outline: 2px solid $tab-focus-color !important;
+    box-shadow: 0 0 0 2px white !important;
+    outline-offset: 2px;
+  }
 }

--- a/src/components/play-pause/play-pause.tsx
+++ b/src/components/play-pause/play-pause.tsx
@@ -7,7 +7,7 @@ import {isPlayingAdOrPlayback} from '../../reducers/getters';
 import {withPlayer} from '../player';
 import {withEventDispatcher} from '../event-dispatcher';
 import {withLogger} from '../logger';
-import {bindActions} from '../../utils';
+import {bindActions, focusElement, KeyMap} from '../../utils';
 import {actions as settingActions} from '../../reducers/settings';
 import {actions as overlayIconActions} from '../../reducers/overlay-action';
 import {Tooltip} from '../../components/tooltip';
@@ -65,12 +65,13 @@ class PlayPause extends Component<any, any> {
    */
   componentDidMount(): void {
     const {eventManager, player} = this.props;
-    const smallSizes = [PLAYER_SIZE.TINY, PLAYER_SIZE.EXTRA_SMALL, PLAYER_SIZE.SMALL];
 
     eventManager.listenOnce(player, player.Event.UI.USER_CLICKED_PLAY, () => {
       eventManager.listenOnce(player, player.Event.Core.FIRST_PLAY, () => {
-        if (!smallSizes.includes(this.props.playerSize)) {
-          this._playPauseButtonRef?.current?.querySelector("button")?.focus();
+        const wrapper = this._playPauseButtonRef?.current;
+        if (wrapper) {
+          const button = wrapper.querySelector('button') as HTMLButtonElement | null;
+          focusElement(button);
         }
       });
     });
@@ -94,6 +95,14 @@ class PlayPause extends Component<any, any> {
     this.props.notifyClick();
   };
 
+  handleKeyDown = (e: KeyboardEvent): void => {
+    if (e.keyCode === KeyMap.ENTER || e.keyCode === KeyMap.SPACE) {
+      e.preventDefault();
+      e.stopPropagation(); 
+      this.togglePlayPause();
+    }
+  };
+  
   /**
    * render component
    *
@@ -117,6 +126,7 @@ class PlayPause extends Component<any, any> {
               aria-label={`${labelText}, ${entryName}`}
               className={controlButtonClass}
               onClick={this.togglePlayPause}
+              onKeyDown={this.handleKeyDown}
             >
               {isStartOver ? (
                 <Icon type={IconType.StartOver} />

--- a/src/components/pre-playback-play-overlay/pre-playback-play-overlay.tsx
+++ b/src/components/pre-playback-play-overlay/pre-playback-play-overlay.tsx
@@ -21,7 +21,8 @@ const mapStateToProps = state => ({
   prePlayback: state.engine.prePlayback,
   isPlaybackEnded: state.engine.isPlaybackEnded,
   playlist: state.engine.playlist,
-  loading: state.loading.show
+  loading: state.loading.show,
+  targetId: state.config.targetId
 });
 
 const COMPONENT_NAME = 'PrePlaybackPlayOverlay';

--- a/src/components/seekbar/seekbar.tsx
+++ b/src/components/seekbar/seekbar.tsx
@@ -114,15 +114,6 @@ class SeekBar extends Component<any, any> {
     const clientRect = this._seekBarElement.getBoundingClientRect();
     this.props.updateSeekbarClientRect(clientRect);
 
-    const smallSizes = [PLAYER_SIZE.TINY, PLAYER_SIZE.EXTRA_SMALL, PLAYER_SIZE.SMALL];
-    eventManager.listenOnce(player, player.Event.UI.USER_CLICKED_PLAY, () => {
-      eventManager.listenOnce(player, player.Event.Core.FIRST_PLAY, () => {
-        if (smallSizes.includes(this.props.playerSize)) {
-          this._seekBarElement?.focus();
-        }
-      });
-    });
-
     eventManager.listen(player, EventType.BOTTOM_BAR_CLIENT_RECT_CHANGED, this.handleUpdateSeekBarClientRect);
     document.addEventListener('mouseup', this.onPlayerMouseUp);
     document.addEventListener('mousemove', this.onPlayerMouseMove);

--- a/src/utils/focus-element.ts
+++ b/src/utils/focus-element.ts
@@ -9,7 +9,7 @@
 export function focusElement(element: HTMLElement | null, delay: number = 100): void {
   const interval = setInterval(() => {
     if (element && getComputedStyle(element).visibility !== 'hidden') {
-      element.focus();
+      element.focus({preventScroll: true});
       clearInterval(interval);
     }
   }, delay);


### PR DESCRIPTION
This solves the entering fullscreen mode on play/pause button https://kaltura.atlassian.net/browse/ADA-2781.
This includes the code used https://github.com/kaltura/playkit-js-ui/pull/1029/files that created the black line regression. I am not seeing the black line locally.

### Description of the Changes

Please add a detailed description of the change, whether it's an enhancement or a bugfix.
If the PR is related to an open issue please link to it.

**Issue:**

**Fix:**

#### Resolves FEC-[Please add the ticket reference here]


