### PR TITLE
fix(SUP-49217): [Minn State] Cannot select Download Pre-Test in Video…

### DIFF
--- a/src/components/pre-playback-play-overlay/pre-playback-play-overlay.tsx
+++ b/src/components/pre-playback-play-overlay/pre-playback-play-overlay.tsx
@@ -81,6 +81,21 @@ class PrePlaybackPlayOverlay extends Component<any, any> {
   };
 
   /**
+   * create class name for prePlaybackOverlay element
+   * @returns {string}
+   * @memberof PrePlaybackPlayOverlay
+   */
+  createPrePlaybackClassName = () => {
+    const prePlaybackPlayOverlayClassName = [style.prePlaybackPlayOverlay];
+    const isQuizEntry = this.props.player.sources.capabilities.includes('quiz.quiz');
+
+    if (this.props.player.engineType === this.props.player.EngineType.YOUTUBE && !isQuizEntry) {
+      prePlaybackPlayOverlayClassName.push(style.prePlaybackPlayOverlayYoutube);
+    }
+    return prePlaybackPlayOverlayClassName;
+  };
+
+  /**
    * render component
    *
    * @param {*} props - component props
@@ -94,10 +109,7 @@ class PrePlaybackPlayOverlay extends Component<any, any> {
     }
     const entryName = `${this.props.title}: ${this.props.player.sources.metadata?.name}`;
     const labelText = props.isPlaybackEnded ? props.startOverText : props.playText;
-    const prePlaybackPlayOverlayClassName = [style.prePlaybackPlayOverlay];
-    if (props.player.engineType === props.player.EngineType.YOUTUBE) {
-      prePlaybackPlayOverlayClassName.push(style.prePlaybackPlayOverlayYoutube);
-    }
+    const prePlaybackPlayOverlayClassName = this.createPrePlaybackClassName();
     return (
       <div className={prePlaybackPlayOverlayClassName.join(' ')} onMouseOver={this.onMouseOver} onClick={this.handleClick}>
         <Button className={style.prePlaybackPlayButton} tabIndex="0" aria-label={`${labelText}, ${entryName}`} onKeyDown={this.onKeyDown}>


### PR DESCRIPTION
… Quiz based on YouTube entry in v7 player

### Description of the Changes

**Issue:**
In case of youtube + quiz entry, the Download Pre-Test button is not clickable

**Root cause:** 
The prePlaybackOverlay is covering the quiz overlay  (it has z-index: 2)

**Fix:**
Add the z-index: 2 only if it's not a quiz entry. 
In quiz entries, it is not possible (also on non youtube entries) to play the video by clicking on the overlay, only on the play button.

#### Resolves [SUP-49217](https://kaltura.atlassian.net/browse/SUP-49217)




[SUP-49217]: https://kaltura.atlassian.net/browse/SUP-49217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ