### PR TITLE
fix(FEC-14475): Advanced captions settings cc bottom fix

### DIFF
--- a/src/components/bottom-bar/bottom-bar.tsx
+++ b/src/components/bottom-bar/bottom-bar.tsx
@@ -179,6 +179,14 @@ class BottomBar extends Component<any, any> {
     }
   }
 
+  private toggleObserver = (isActive: boolean): void => {
+    if (isActive) {
+      this.resizeObserver.disconnect();
+    } else {
+      this.resizeObserver.observe(this.bottomBarContainerRef.current!);
+    }
+  };
+
   /**
    * render component
    *
@@ -208,7 +216,9 @@ class BottomBar extends Component<any, any> {
                 props.leftControls.map(
                   Control =>
                     this.presetControls[Control.displayName] &&
-                    this.state.fitInControls[Control.displayName] && <Control key={Control.displayName} onToggle={this.onToggleControl} />
+                    this.state.fitInControls[Control.displayName] && (
+                      <Control key={Control.displayName} onToggle={this.onToggleControl} toggleObserver={this.toggleObserver} />
+                    )
                 )}
             </PlayerArea>
           </div>
@@ -219,7 +229,9 @@ class BottomBar extends Component<any, any> {
                 props.rightControls.map(
                   Control =>
                     this.presetControls[Control.displayName] &&
-                    this.state.fitInControls[Control.displayName] && <Control key={Control.displayName} onToggle={this.onToggleControl} />
+                    this.state.fitInControls[Control.displayName] && (
+                      <Control key={Control.displayName} onToggle={this.onToggleControl} toggleObserver={this.toggleObserver} />
+                    )
                 )}
             </PlayerArea>
           </div>

--- a/src/components/captions-control/captions-control.tsx
+++ b/src/components/captions-control/captions-control.tsx
@@ -69,6 +69,7 @@ const CaptionsControl = connect(mapStateToProps)(
     };
 
     const toggleCVAAOverlay = (): void => {
+      props.toggleObserver(!cvaaOverlay);
       setCVAAOverlay(cvaaOverlay => !cvaaOverlay);
     };
 

--- a/src/components/speed-menu/speed-menu.tsx
+++ b/src/components/speed-menu/speed-menu.tsx
@@ -54,6 +54,7 @@ class SpeedMenu extends Component<any, any> {
     const speedOptions = props.optionsRenderer
       ? props.optionsRenderer(props.player.playbackRates)
       : props.player.playbackRates.reduce((acc, speed) => {
+          const defaultPlaybackRate = props.player.defaultPlaybackRate || 1;
           let speedOption = {
             value: speed,
             label: speed === 1 ? props.speedNormalLabelText : speed,


### PR DESCRIPTION
### Description of the Changes

Opening advanced captions settings through cc bottom bar button doesn't work
https://kaltura.atlassian.net/browse/FEC-14475

**Issue:**
Opening advanced captions settings through cc bottom bar button doesn't work

**Fix:**
Introduced ability to toggle ResizeObserver from child element

#### Resolves [FEC-14475](https://kaltura.atlassian.net/browse/FEC-14475)


