### PR TITLE
fix(FEC-14593): Add focus indicator to button component

### DIFF
--- a/src/styles/_buttons.scss
+++ b/src/styles/_buttons.scss
@@ -47,7 +47,9 @@
 .player {
   button {
     &:focus {
-      outline: none;
+      outline: 2px solid $tab-focus-color !important;
+      box-shadow: 0 0 0 2px white !important;
+      outline-offset: 2px;
     }
   }
 }


### PR DESCRIPTION
This adds focus indicator on initial focus for button component. Including this in the https://kaltura.atlassian.net/browse/FEC-14593 fix. Related PR https://github.com/kaltura/playkit-js-ivq/pull/174
### Description of the Changes

Please add a detailed description of the change, whether it's an enhancement or a bugfix.
If the PR is related to an open issue please link to it.

**Issue:**

**Fix:**

#### Resolves FEC-[Please add the ticket reference here]


