### PR TITLE
fix(FEC-14623): Player v7 | Player controls are missing on kms with theming enabled.

### DIFF
--- a/src/components/pre-playback-play-overlay/pre-playback-play-overlay.tsx
+++ b/src/components/pre-playback-play-overlay/pre-playback-play-overlay.tsx
@@ -87,7 +87,7 @@ class PrePlaybackPlayOverlay extends Component<any, any> {
    */
   createPrePlaybackClassName = () => {
     const prePlaybackPlayOverlayClassName = [style.prePlaybackPlayOverlay];
-    const isQuizEntry = this.props.player.sources.capabilities.includes('quiz.quiz');
+    const isQuizEntry = this.props.player.sources.capabilities?.includes('quiz.quiz');
 
     if (this.props.player.engineType === this.props.player.EngineType.YOUTUBE && !isQuizEntry) {
       prePlaybackPlayOverlayClassName.push(style.prePlaybackPlayOverlayYoutube);


### PR DESCRIPTION
### Description of the Changes

Add protection in case sources do not contain capabilities array
This can happen when using setMedia or in certain scenarios in kms

Resolves FEC-14623


