### PR TITLE
fix(ADA-1623): OnClose focus on plugin button

### DIFF
--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -249,6 +249,19 @@ class Tooltip extends Component<TooltipProps & WithEventManagerProps, any> {
     }
   }
 
+  handleRef = (el: HTMLButtonElement | null) => {
+    this.setButtonRef(el);
+
+    // Forward the child’s original ref (callback or ref object)
+    // so Tooltip keeps its own ref without breaking the child’s.    
+    const { ref } = (this.props.children as VNode<any>);
+    if (typeof ref === 'function') {
+      ref(el);
+    } else if (ref && typeof ref === 'object') {
+      (ref as any).current = el;
+    }
+  };
+
   /**
    * checks if after the render the tooltip is within boundaries of the player
    * if not it will try to set a new type which will be checked after the next render
@@ -303,7 +316,7 @@ class Tooltip extends Component<TooltipProps & WithEventManagerProps, any> {
     const children = cloneElement(props.children, {
       onFocus: this.handleFocusOnChildren,
       onBlur: this.handleBlurOnChildren,
-      ref: this.setButtonRef
+      ref: this.handleRef
     });
     return (
       <div


### PR DESCRIPTION
This pr solves this https://kaltura.atlassian.net/browse/ADA-1623. It returns the focus on the plugin button after close. _setPluginButtonRef was never running, because of wrapping the button with <Toolbar>. The problem was that Tooltip was overwriting the child’s ref. I updated Tooltip to merge refs, so it keeps its own reference and still forwards the child’s.

### Description of the Changes

Please add a detailed description of the change, whether it's an enhancement or a bugfix.
If the PR is related to an open issue please link to it.

**Issue:**

**Fix:**

#### Resolves FEC-[Please add the ticket reference here]


