### PR TITLE
fix(ADA-2976): Prevent select to open on mount

### DIFF
--- a/src/utils/popup-keyboard-accessibility.tsx
+++ b/src/utils/popup-keyboard-accessibility.tsx
@@ -183,7 +183,13 @@ export const withKeyboardA11y = (WrappedComponent): any => {
       const defaultElement = this._defaultFocusedElement || (this._accessibleChildren.length && this._accessibleChildren[0]);
       if (defaultElement) {
         this._previouslyActiveElement = document.activeElement as HTMLElement;
-        defaultElement.focus();
+        if (defaultElement.tagName === 'SELECT') {
+          // Focusing a <select> on mount causes browsers to auto-expand the dropdown menu.
+          // Deferring focus to the next animation frame prevents that
+          requestAnimationFrame(() => defaultElement.focus({ preventScroll: true }));
+        } else {
+          defaultElement.focus({ preventScroll: true });
+        }
       }
     };
 


### PR DESCRIPTION
This solves this https://kaltura.atlassian.net/browse/ADA-2976.
I could not find a solution to fix this using only preact life cycle methods. requestAnimationFrame runs code right before the browser paints the next frame, and it’s part of the official rendering lifecycle. Deferring focus this way makes sure the DOM is ready. For <select> elements, it prevents browsers from auto-opening on mount.


### Description of the Changes

Please add a detailed description of the change, whether it's an enhancement or a bugfix.
If the PR is related to an open issue please link to it.

**Issue:**

**Fix:**

#### Resolves FEC-[Please add the ticket reference here]


