### PR TITLE
fix(FEC-14716): pause functionality still available using keyboard keys and clicking on the player

### DIFF
--- a/src/components/keyboard/keyboard.tsx
+++ b/src/components/keyboard/keyboard.tsx
@@ -22,7 +22,9 @@ const mapStateToProps = state => ({
   isPlayingAdOrPlayback: isPlayingAdOrPlayback(state.engine),
   playerNav: state.shell.playerNav,
   textTracks: state.engine.textTracks,
-  overlayOpen: state.overlay.isOpen
+  overlayOpen: state.overlay.isOpen,
+  allowPlayPause: state.config.allowPlayPause,
+  allowLivePlayPause: state.config.allowLivePlayPause
 });
 
 /**
@@ -106,8 +108,11 @@ class Keyboard extends Component<any, any> {
    *
    * @memberof Keyboard
    */
-  keyboardHandlers: {[key: number]: (event: KeyboardEvent) => KeyboardEventResult} = {
+  private keyboardHandlers: {[key: number]: (event: KeyboardEvent) => KeyboardEventResult} = {
     [KeyMap.SPACE]: (): KeyboardEventResult => {
+      if ((!this.props.player.isLive() && !this.props.allowPlayPause) || (this.props.player.isLive() && !this.props.allowLivePlayPause))
+        return UNHANDLED_KEYBOARD_EVENT_RESULT;
+
       if (this.props.isPlayingAdOrPlayback) {
         this.props.player.pause();
         this.props.updateOverlayActionIcon(IconType.Pause);

--- a/src/components/overlay-action/overlay-action.tsx
+++ b/src/components/overlay-action/overlay-action.tsx
@@ -23,7 +23,9 @@ const mapStateToProps = state => ({
   guiStyles: state.shell.layoutStyles.gui,
   isSmartContainerOpen: state.shell.smartContainerOpen,
   fullscreenConfig: state.config.components.fullscreen,
-  seekbarDraggingActive: state.seekbar.draggingActive
+  seekbarDraggingActive: state.seekbar.draggingActive,
+  allowPlayPause: state.config.allowPlayPause,
+  allowLivePlayPause: state.config.allowLivePlayPause
 });
 
 /**
@@ -91,8 +93,9 @@ class OverlayAction extends Component<any, any> {
    * @returns {void}
    * @memberof OverlayAction
    */
-  togglePlayPause = (): void => {
+  private togglePlayPause = (): void => {
     const showPauseButton = !this.props.player.isLive() || this.props.player.isDvr();
+    if ((!this.props.player.isLive() && !this.props.allowPlayPause) || (this.props.player.isLive() && !this.props.allowLivePlayPause)) return;
 
     if (this.props.isPlayingAdOrPlayback) {
       this.props.player.pause();

--- a/src/components/play-pause/play-pause.tsx
+++ b/src/components/play-pause/play-pause.tsx
@@ -27,8 +27,8 @@ const mapStateToProps = state => ({
   adBreak: state.engine.adBreak,
   isPlaybackEnded: state.engine.isPlaybackEnded,
   playerSize: state.shell.playerSize,
-  showPlayPauseButton: state.config.showPlayPauseButton,
-  showLivePlayPauseButton: state.config.showLivePlayPauseButton
+  allowPlayPause: state.config.allowPlayPause,
+  allowLivePlayPause: state.config.allowLivePlayPause
 });
 
 const COMPONENT_NAME = 'PlayPause';
@@ -114,7 +114,7 @@ class PlayPause extends Component<any, any> {
    * @memberof PlayPause
    */
   public render(props: any): VNode<any> | undefined {
-    if ((!props.player.isLive() && !props.showPlayPauseButton) || (props.player.isLive() && !props.showLivePlayPauseButton)) return undefined;
+    if ((!props.player.isLive() && !props.allowPlayPause) || (props.player.isLive() && !props.allowLivePlayPause)) return undefined;
 
     const controlButtonClass = this.props.isPlayingAdOrPlayback ? [style.controlButton, style.isPlaying].join(' ') : style.controlButton;
     const isStartOver = props.isPlaybackEnded && !this.props.adBreak;

--- a/src/components/seekbar/seekbar.tsx
+++ b/src/components/seekbar/seekbar.tsx
@@ -31,7 +31,9 @@ const mapStateToProps = state => ({
   segments: state.seekbar.segments,
   seekbarClasses: state.seekbar.seekbarClasses,
   isPreventSeek: state.seekbar.isPreventSeek,
-  playerSize: state.shell.playerSize
+  playerSize: state.shell.playerSize,
+  allowPlayPause: state.config.allowPlayPause,
+  allowLivePlayPause: state.config.allowLivePlayPause
 });
 
 const COMPONENT_NAME = 'SeekBar';
@@ -122,7 +124,7 @@ class SeekBar extends Component<any, any> {
         }
       });
     });
-    
+
     eventManager.listen(player, EventType.BOTTOM_BAR_CLIENT_RECT_CHANGED, this.handleUpdateSeekBarClientRect);
     document.addEventListener('mouseup', this.onPlayerMouseUp);
     document.addEventListener('mousemove', this.onPlayerMouseMove);
@@ -334,7 +336,8 @@ class SeekBar extends Component<any, any> {
    * @returns {void}
    * @memberof SeekBar
    */
-  togglePlayPause = (): void => {
+  private togglePlayPause = (): void => {
+    if ((!this.props.player.isLive() && !this.props.allowPlayPause) || (this.props.player.isLive() && !this.props.allowLivePlayPause)) return;
     this.props.player.paused ? this.props.player.play() : this.props.player.pause();
   };
 

--- a/src/components/shell/shell.tsx
+++ b/src/components/shell/shell.tsx
@@ -40,7 +40,9 @@ const mapStateToProps = state => ({
   fallbackToMutedAutoPlay: state.engine.fallbackToMutedAutoPlay,
   playlist: state.engine.playlist,
   tinySizeDisabled: state.config.tinySizeDisabled,
-  isCopyProtected: state.config.isCopyProtected
+  isCopyProtected: state.config.isCopyProtected,
+  allowPlayPause: state.config.allowPlayPause,
+  allowLivePlayPause: state.config.allowLivePlayPause
 });
 
 const ON_PLAYER_RECT_CHANGE_DEBOUNCE_DELAY: number = 100;
@@ -145,7 +147,7 @@ class Shell extends Component<any, any> {
     }
   }
 
-  toggleFullscreen(): void { 
+  toggleFullscreen(): void {
     if (this.props.player.isFullscreen()) {
       this.props.player.exitFullscreen();
     } else {
@@ -179,18 +181,16 @@ class Shell extends Component<any, any> {
    * @param {KeyboardEvent} e - event object
    * @returns {void}
    */
-  onKeyDown = (e: KeyboardEvent): void => {
+  private onKeyDown = (e: KeyboardEvent): void => {
     const target = e.target as HTMLElement;
-    const isInput = target instanceof HTMLInputElement ||
-                target instanceof HTMLTextAreaElement ||
-                target.isContentEditable;
+    const isInput = target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement || target.isContentEditable;
 
     if (!this.state.nav && e.keyCode === KeyMap.TAB) {
       this.setState({nav: true});
       this.props.updatePlayerNavState(true);
     }
 
-    if (this.state.nav && (e.keyCode === KeyMap.F) && !isInput) {
+    if (this.state.nav && e.keyCode === KeyMap.F && !isInput) {
       this.toggleFullscreen();
     }
 
@@ -199,6 +199,9 @@ class Shell extends Component<any, any> {
       // @ts-ignore
       if (e.srcElement!.contains(this._playerRef)) {
         e.preventDefault();
+
+        if ((!this.props.player.isLive() && !this.props.allowPlayPause) || (this.props.player.isLive() && !this.props.allowLivePlayPause)) return;
+
         this.props.player.paused ? this.props.player.play() : this.props.player.pause();
       }
     }

--- a/src/reducers/config.ts
+++ b/src/reducers/config.ts
@@ -12,8 +12,8 @@ export const types = {
 export const initialState = {
   targetId: undefined as unknown as string,
   forceTouchUI: false,
-  showPlayPauseButton: true,
-  showLivePlayPauseButton: true,
+  allowPlayPause: true,
+  allowLivePlayPause: true,
   showCCButton: true,
   showAudioButton: true,
   showAudioDescriptionButton: true,

--- a/src/types/ui-options.ts
+++ b/src/types/ui-options.ts
@@ -7,8 +7,8 @@ export interface UIOptionsObject {
   targetId: string;
   debugActions?: boolean;
   forceTouchUI?: boolean;
-  showPlayPauseButton?: boolean;
-  showLivePlayPauseButton?: boolean;
+  allowPlayPause?: boolean;
+  allowLivePlayPause?: boolean;
   showCCButton?: boolean;
   showAudioDescriptionButton?: boolean;
   openMenuFromCCButton?: boolean;


### PR DESCRIPTION
### Description of the Changes

- Block play pause toggle via overlay click
- Block play pause toggle via keydown
- Rename props to allowPlayPause and allowLivePlayPause to reflect them affecting functionality and not just button visibility

Resolves FEC-14716


