### PR TITLE
fix(FEC-14772): Add display name to MediaInfoDisplay component

### DIFF
--- a/src/components/media-info-display/media-info-display.tsx
+++ b/src/components/media-info-display/media-info-display.tsx
@@ -220,6 +220,6 @@ const MediaInfoDisplay = withText({
   seeLessText: 'mediaInfo.seeLess'
 })(withLogger(COMPONENT_NAME)(withPlayer(connect(mapStateToProps)(MediaInfoDisplayComponent))));
 
-MediaInfoDisplay.displayName = COMPONENT_NAME;
+(MediaInfoDisplay as any).displayName = COMPONENT_NAME;
 
 export {MediaInfoDisplay};


### PR DESCRIPTION
Add display name to MediaInfoDisplay component.

[FEC-14772](https://kaltura.atlassian.net/browse/FEC-14772)

[FEC-14772]: https://kaltura.atlassian.net/browse/FEC-14772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ