### PR TITLE
fix(FEC-14757): Player v7 | User is able to upload EAD that doesn't match the regular audio track language, and therefore the EAD will not be available to select on the player.

### DIFF
--- a/src/components/audio-desc/audio-desc-mini.tsx
+++ b/src/components/audio-desc/audio-desc-mini.tsx
@@ -173,13 +173,12 @@ function getSvgIcon(props, store, isDropdown = false): any {
 }
 
 function shouldActivate(audioTracks, activeAudioLanguage, audioDescriptionLanguages, advancedAudioDescriptionLanguages): boolean {
-  const isEADWithoutAudioTracks = audioTracks.length === 0 && advancedAudioDescriptionLanguages.length === 1;
-  const isActive =
-    activeAudioLanguage &&
-    Boolean(
-      audioDescriptionLanguages.find(lang => lang.startsWith(activeAudioLanguage)) ||
-        advancedAudioDescriptionLanguages.find(lang => lang.startsWith(activeAudioLanguage))
-    );
+  const isEADWithoutAudioTracks =
+    audioTracks?.filter(t => t.language !== '' || t.label !== '').length === 0 && advancedAudioDescriptionLanguages.length === 1;
+  const isActive = Boolean(
+    (activeAudioLanguage && audioDescriptionLanguages.find(lang => lang.startsWith(activeAudioLanguage))) ||
+      advancedAudioDescriptionLanguages.find(lang => lang.startsWith(activeAudioLanguage))
+  );
 
   return isActive || isEADWithoutAudioTracks;
 }

--- a/src/components/audio-desc/audio-desc.tsx
+++ b/src/components/audio-desc/audio-desc.tsx
@@ -80,13 +80,12 @@ const _AudioDesc = (props: any) => {
   function shouldActivate(): boolean {
     const activeAudioLanguage = getActiveAudioLanguage(props.player);
 
-    const isEADWithoutAudioTracks = props.audioTracks.length === 0 && advancedAudioDescriptionLanguages.length === 1;
-    const isActive =
-      activeAudioLanguage &&
-      Boolean(
-        audioDescriptionLanguages.find(lang => lang.startsWith(activeAudioLanguage)) ||
-          advancedAudioDescriptionLanguages.find(lang => lang.startsWith(activeAudioLanguage))
-      );
+    const isEADWithoutAudioTracks =
+      props.audioTracks?.filter(t => t.language !== '' || t.label !== '').length === 0 && advancedAudioDescriptionLanguages.length === 1;
+    const isActive = Boolean(
+      (activeAudioLanguage && audioDescriptionLanguages.find(lang => lang.startsWith(activeAudioLanguage))) ||
+        advancedAudioDescriptionLanguages.find(lang => lang.startsWith(activeAudioLanguage))
+    );
 
     return isActive || isEADWithoutAudioTracks;
   }

--- a/src/components/audio-desc/audio-description-updater.tsx
+++ b/src/components/audio-desc/audio-description-updater.tsx
@@ -183,7 +183,7 @@ function updateDefaultAdvancedAudioDescription(props, advancedAudioDescriptionLa
   const activeAudioLanguage = getActiveAudioLanguage(props.player);
 
   const isActive = activeAudioLanguage && advancedAudioDescriptionLanguages.find(lang => lang.startsWith(activeAudioLanguage));
-  const isNoAudioEAD = audioTracks.length === 0 && advancedAudioDescriptionLanguages.length === 1;
+  const isNoAudioEAD = audioTracks?.filter(t => t.language !== '' || t.label !== '').length === 0 && advancedAudioDescriptionLanguages.length === 1;
 
   if (
     (isActive || isNoAudioEAD) &&

--- a/src/components/audio-description-menu/audio-description-menu.tsx
+++ b/src/components/audio-description-menu/audio-description-menu.tsx
@@ -95,7 +95,8 @@ const _AudioDescriptionMenu = (props: AudioDescriptionMenuProps) => {
   }, [audioDescriptionLanguages, audioLanguage]);
 
   const hasAdvancedAudioDescription = useMemo(() => {
-    const isEADWithoutAudioTracks = audioTracks?.length === 0 && advancedAudioDescriptionLanguages?.length === 1;
+    const isEADWithoutAudioTracks =
+      audioTracks?.filter(t => t.language !== '' || t.label !== '').length === 0 && advancedAudioDescriptionLanguages?.length === 1;
     const isActive = audioLanguage && !!advancedAudioDescriptionLanguages?.find(lang => lang.startsWith(audioLanguage));
 
     return isActive || isEADWithoutAudioTracks;


### PR DESCRIPTION
### Description of the Changes

Safari adds a default audio track with empty label and empty language even if the video has no audio flavors at all, so it avoids the check that we added for no audio tracks.
So instead of checking for no audio tracks when checking whether to enable the AD icon, we need to check for no audio tracks with label or language.

Resolves FEC-14757



