### PR TITLE
fix(FEC-14573): The gap between player controls should be 8px

### DIFF
--- a/src/components/time-display/time-display.tsx
+++ b/src/components/time-display/time-display.tsx
@@ -24,15 +24,24 @@ const mapStateToProps = state => ({
 class TimeDisplay extends Component<any, any> {
   private timeDisplayRef: RefObject<HTMLDivElement> = createRef<HTMLDivElement>();
 
-  componentDidUpdate(prevProps: any) {
-    if (prevProps.timeDisplayIsMinimized !== this.props.timeDisplayIsMinimized) {
-      if (this.props.timeDisplayIsMinimized){
-          this.timeDisplayRef.current?.classList.add(`${style.paddingStyle}`);
+  addPaddingStyleClass(){
+    if (this.props.timeDisplayIsMinimized){
+        this.timeDisplayRef.current?.classList.add(`${style.paddingStyle}`);
       } else {
         this.timeDisplayRef.current?.classList.remove(`${style.paddingStyle}`);
       }
+  }
+
+  componentDidUpdate(prevProps: any) {
+    if (prevProps.timeDisplayIsMinimized !== this.props.timeDisplayIsMinimized) {
+      this.addPaddingStyleClass();
     }
-}
+  }
+
+  componentDidMount(){
+    this.addPaddingStyleClass();
+  }
+
   /**
    * get formatted time display based on defined format
    *


### PR DESCRIPTION
### Description of the Changes

continue of - https://github.com/kaltura/playkit-js-ui/pull/1117

**Issue:**
In player resizing, time is removed and added according to the space in the bottom bar(for example when open a panel side like transcript) then padding style is not added correctly.

Root cause: 
In the above case the time-display component is re-initialized, so componentDidUpdate hasn’t been called yet.

**Fix:**
Add functionality both in componentDidMount and componentDidUpdate (need both cause in the first time the state is updated after the the initial render)


#### Resolves [FEC-14573](https://kaltura.atlassian.net/browse/FEC-14573)




[FEC-14573]: https://kaltura.atlassian.net/browse/FEC-14573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ