### PR TITLE
fix(FEC-14796): Player v7 | Wrong icon for "Audio" & "Audio description" inside settings menu layout for small players.

### DIFF
--- a/src/components/audio-description-menu/audio-description-menu.tsx
+++ b/src/components/audio-description-menu/audio-description-menu.tsx
@@ -139,7 +139,7 @@ const _AudioDescriptionMenu = (props: AudioDescriptionMenuProps) => {
         pushRef={el => {
           props.pushRef?.(el);
         }}
-        icon={IconType.Captions}
+        icon={IconType.AdvancedAudioDescriptionActive}
         label={audioDescriptionText}
         options={options}
         onMenuChosen={enabledState => onAudioDescriptionChange(enabledState)}

--- a/src/components/audio-menu/audio-menu.tsx
+++ b/src/components/audio-menu/audio-menu.tsx
@@ -124,7 +124,7 @@ const _AudioMenu = (props: AudioMenuProps) => {
     return (
       <SmartContainerItem
         pushRef={el => props.pushRef?.(el)}
-        icon={IconType.Captions}
+        icon={IconType.Audio}
         label={props.audioLabelText}
         options={audioOptions}
         onMenuChosen={(audioTrack: any) => onAudioChange(audioTrack)}


### PR DESCRIPTION
**Issue:**
In settings overlay, Caption icon is displayed to audio and audio description items

**Fix:**
Change the caption icons to the right icons.

#### Resolves [FEC-14796](https://kaltura.atlassian.net/browse/FEC-14796)




[FEC-14796]: https://kaltura.atlassian.net/browse/FEC-14796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ