### PR TITLE
fix(FEC-14809): Save preset style from unmutable clone

### DIFF
--- a/src/components/cvaa-overlay/cvaa-overlay.tsx
+++ b/src/components/cvaa-overlay/cvaa-overlay.tsx
@@ -145,16 +145,17 @@ class CVAAOverlay extends Component<any, any> {
   };
 
   saveCustomPresetStyle = (style: any) => {
-    const json = style.toObject ? style.toObject() : { ...style };
+    const clonedStyle = style.clone();
+    const json = this.props.player.TextStyle.toJson(clonedStyle);
 
     // Save the fontSize label because style does not compute the font size.
-    if (style.fontSize) {
-      json.fontSize = style.fontSize;
+    if (clonedStyle.fontSize) {
+      json.fontSize = clonedStyle.fontSize;
     }
 
     localStorage.setItem("cvaaCustomPreset", JSON.stringify(json));
-    this.setState({ customPresetStyle: style });
-    this.changeCaptionsStyle(style);
+    this.setState({ customPresetStyle: clonedStyle });
+    this.changeCaptionsStyle(clonedStyle);
   };
 
 


### PR DESCRIPTION
This solves https://kaltura.atlassian.net/browse/FEC-14809. It creates a un-mutable clone that is saved as styling
### Description of the Changes

Please add a detailed description of the change, whether it's an enhancement or a bugfix.
If the PR is related to an open issue please link to it.

**Issue:**

**Fix:**

#### Resolves FEC-[Please add the ticket reference here]


