### PR TITLE
fix(SUP-50612): Standard Audio Description track selection broken in V7 Player

### DIFF
--- a/src/components/audio-desc/audio-description-updater.tsx
+++ b/src/components/audio-desc/audio-description-updater.tsx
@@ -134,7 +134,6 @@ function updateDefaultAudioDescription(props, audioDescriptionLanguages): boolea
     props.updateAudioDescriptionEnabled?.(false);
     props.updateAudioDescriptionType(AUDIO_DESCRIPTION_TYPE.AUDIO_DESCRIPTION);
     props.updateSelectionByLanguage(activeAudioLanguage, false, AUDIO_DESCRIPTION_TYPE.AUDIO_DESCRIPTION);
-    props.updateDefaultValueSet(true);
 
     return true;
   } else if (
@@ -153,7 +152,6 @@ function updateDefaultAudioDescription(props, audioDescriptionLanguages): boolea
     props.updateAudioDescriptionEnabled?.(isEnabled);
     props.updateAudioDescriptionType(AUDIO_DESCRIPTION_TYPE.AUDIO_DESCRIPTION);
     props.updateSelectionByLanguage(activeAudioLanguage, isEnabled, AUDIO_DESCRIPTION_TYPE.AUDIO_DESCRIPTION);
-    props.updateDefaultValueSet(true);
 
     const newLanguageKey = getAudioDescriptionLanguageKey(activeAudioLanguage);
     const newAudioTrack = props.player?.getTracks('audio')?.find(t => t.language === newLanguageKey);
@@ -200,7 +198,6 @@ function updateDefaultAdvancedAudioDescription(props, advancedAudioDescriptionLa
     props.updateAudioDescriptionEnabled?.(isEnabled);
     props.updateAudioDescriptionType(AUDIO_DESCRIPTION_TYPE.EXTENDED_AUDIO_DESCRIPTION);
     props.updateSelectionByLanguage(activeAudioLanguage, isEnabled, AUDIO_DESCRIPTION_TYPE.EXTENDED_AUDIO_DESCRIPTION);
-    props.updateDefaultValueSet(true);
 
     return true;
   }

--- a/src/components/engine-connector/engine-connector.tsx
+++ b/src/components/engine-connector/engine-connector.tsx
@@ -230,6 +230,7 @@ class EngineConnector extends Component<EngineConnectorProps, any> {
         if (!didUpdate) {
           updateDefaultAdvancedAudioDescription(this.props, store.getState().audioDescription.advancedAudioDescriptionLanguages, audioTracks);
         }
+        this.props.updateDefaultValueSet(true);
       }
     });
 


### PR DESCRIPTION
### Description of the Changes

isDefaultValueSet needs to be set to true to allow AD dropdown selection to work
In a case where there is no local storage value for audioDescription and prioritizeAudioDescription is false, the value was not set to true, which blocked the dropdown functionality
Solution - always set the value to true after attempting to set a default value, whether a default value was set or not

Resolves SUP-50612


