### PR TITLE
fix(FEC-14828): Add control for playback speed in video player contro…

### DIFF
--- a/src/components/speed-control/speed-control.tsx
+++ b/src/components/speed-control/speed-control.tsx
@@ -20,6 +20,7 @@ const mapStateToProps = state => ({
   isMobile: state.shell.isMobile,
   isSmallSize: state.shell.isSmallSize,
   isLive: state.engine.isLive,
+  metadataLoaded: state.engine.metadataLoaded
 });
 
 const COMPONENT_NAME = 'SpeedControl';
@@ -80,7 +81,7 @@ const SpeedControl = connect(mapStateToProps)(
 
     const hasPlaybackRates = useMemo(() => {
       return player.playbackRates?.length > 1;
-    }, [player.playbackRates]);
+    }, [props.metadataLoaded]);
 
     const registerComponent = () =>  {
       return {


### PR DESCRIPTION
…ls | Sometimes after page refresh speed button doesn't display at all, only after top or bottom bar changed (kitchen sink open or closed).

### Description of the Changes

**Issue:**
PlaybackRates and playbackRate is updated only after engine is loaded so we used it too early when it's empty.

**Fix:**
Check playbackRates value only after metadata is loaded.


#### Resolves [FEC-14827](https://kaltura.atlassian.net/browse/FEC-14827)




[FEC-14827]: https://kaltura.atlassian.net/browse/FEC-14827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ