### PR TITLE
fix(FEC-14831): Player v7 | SR announce "4K" quality only on "inline" button when submenu is closed.

### DIFF
--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -284,6 +284,12 @@ class MenuItem extends Component<any, any> {
   public render(props: any): VNode<any> {
     const ariaLabel = props.data.ariaLabel || props.data.label;
     const badgeType: string | null = props.data.badgeType && !props.isSelected(props.data) ? BadgeType[props.data.badgeType] : BadgeType[props.data.badgeType + 'Active'];
+    let badgeText = '';
+    if (badgeType?.includes('quality-hd')) {
+      badgeText = ' HD';
+    } else if (badgeType?.includes('quality-4k')) {
+      badgeText = ' 4K';
+    }
     return (
       <div
         role={props?.role}
@@ -305,7 +311,7 @@ class MenuItem extends Component<any, any> {
         onKeyDown={this.onKeyDown}>
         <span
           className={badgeType ? [style.labelBadge, badgeType].join(' ') : ''}
-          aria-label={badgeType?.includes('quality-hd') ? `${ariaLabel} HD` : ariaLabel}>
+          aria-label={`${ariaLabel}${badgeText}`}>
           {props.data.label}
         </span>
         <span className={[style.menuIconContainer, style.active].join(' ')}>


### PR DESCRIPTION
### Description of the Changes

**Issue:**
In the quality menu, 4k text is missing from aria-label in 4k items

**Fix:**
Adding 4K text twhen flavor is 4K.

#### Resolves [FEC-14831](https://kaltura.atlassian.net/browse/FEC-14831)




[FEC-14831]: https://kaltura.atlassian.net/browse/FEC-14831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ