### PR TITLE
fix(FEC-14882): Bug on duration control for "Start playback muted"

### DIFF
--- a/src/components/unmute-indication/unmute-indication.tsx
+++ b/src/components/unmute-indication/unmute-indication.tsx
@@ -103,12 +103,19 @@ class UnmuteIndication extends Component<any, any> {
     _setValidSeconds(): void {
     const isValid = (value: any): boolean => {
       return (typeof value === 'number' && value >= 0);
+    };
+    const { unmuteTextSeconds, unmuteButtonSeconds } = this.props;
+    const isTextSecondsValid = isValid(unmuteTextSeconds);
+    const isButtonSecondsValid = isValid(unmuteButtonSeconds);
+
+    if (isTextSecondsValid) {
+      this._iconOnlySeconds = unmuteTextSeconds * 1000;
     }
-    if (isValid(this.props.unmuteTextSeconds)) {
-        this._iconOnlySeconds = this.props.unmuteTextSeconds * 1000;
+    if (isButtonSecondsValid) {
+      this._buttonRemoveSeconds = unmuteButtonSeconds * 1000;
     }
-    if (isValid(this.props.unmuteButtonSeconds)) {
-        this._buttonRemoveSeconds = this.props.unmuteButtonSeconds * 1000;
+    if (isButtonSecondsValid && isTextSecondsValid && unmuteTextSeconds > unmuteButtonSeconds) {
+      this._buttonRemoveSeconds = unmuteTextSeconds * 1000;
     }
   }
 


### PR DESCRIPTION
### Description of the Changes

**Issue:** 
When text value > from icon duration value, the button will disappear after icon duration value time

**Fix:**
In this case the button will disappear per the text duration value 

#### Resolves [FEC-14882](https://kaltura.atlassian.net/browse/FEC-14882)




[FEC-14882]: https://kaltura.atlassian.net/browse/FEC-14882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ