### PR TITLE
fix(SUP-51551): Captions cannot be turned back on while the Advanced …

### DIFF
--- a/src/styles/_dropdown.scss
+++ b/src/styles/_dropdown.scss
@@ -154,7 +154,7 @@
   }
 }
 
-[data-captions-menu] .dropdown-menu-item:nth-last-child(2) {
+[data-captions-menu] .dropdown-menu-item:has(span[aria-label="__separator__"]) {
   all: unset;
   display: block;
   width: 100%;


### PR DESCRIPTION
issue:
when config showAdvancedCaptionsMenu as false, can't click on last language as it merged with off button.

root cause:
regression from https://github.com/kaltura/playkit-js-ui/commit/355425781b60ba82d43a6aa29069c8c165fe967d, there is css change for 2 child from end to put separator, but it should exist only before  Advanced Captions Menu.

solution:
put the css change for the element that contains a separator child.

solved [SUP-51551](https://kaltura.atlassian.net/browse/SUP-51551)



[SUP-51551]: https://kaltura.atlassian.net/browse/SUP-51551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ