### PR TITLE
feat(FEC-14949): Add entryId configuration support to Logo, Watermark, Error Slate and Bumper plugins

### DIFF
--- a/src/components/engine-connector/engine-connector.tsx
+++ b/src/components/engine-connector/engine-connector.tsx
@@ -354,6 +354,10 @@ class EngineConnector extends Component<EngineConnectorProps, any> {
     eventManager.listen(player, player.Event.Core.EXIT_FULLSCREEN, () => {
       this.props.updateFullscreen(false);
     });
+
+    eventManager.listen(player, 'componentdataupdated', event => {
+      this.props.updateComponentData(event.payload.data);
+    });
   }
 
   /**

--- a/src/components/error-overlay/error-overlay.tsx
+++ b/src/components/error-overlay/error-overlay.tsx
@@ -11,6 +11,7 @@ import {withPlayer} from '../../components/player';
 import {Button} from '../../components/button';
 import {getErrorDetailsByCategory} from './error-message-provider';
 import {actions as overlayActions} from '../../reducers/overlay';
+import {withEventManager} from '../../event';
 
 /**
  * mapping state to props
@@ -33,9 +34,27 @@ const COMPONENT_NAME = 'ErrorOverlay';
  */
 @connect(mapStateToProps, bindActions({...actions, ...overlayActions}))
 @withPlayer
+@withEventManager
 @withLogger(COMPONENT_NAME)
 class ErrorOverlay extends Component<any, any> {
   private sessionEl!: HTMLDivElement;
+
+   /**
+   * @constructor
+   * @param {*} props props
+   */
+  constructor(props: any) {
+    super(props);
+    this.props.eventManager.listen(this.props.player, this.props.player.Event.COMPONENTS_URLS_LOADED, event => {
+      this._updateImgUrl(event.payload.data);
+    });
+  }
+
+  private _updateImgUrl(data: any): void {
+    if (data.errorOverlay) {
+      this.setState({entryUrl: data.errorOverlay});
+    }
+  }
 
   /**
    * copy input text based on input element.
@@ -67,7 +86,7 @@ class ErrorOverlay extends Component<any, any> {
    */
   private getBackgroundUrl = (): string | undefined => {
     const {errorOverlaConfig} = this.props;
-    return errorOverlaConfig?.backgroundUrl;
+    return this.state.entryUrl || errorOverlaConfig?.backgroundUrl;
   };
 
   /**

--- a/src/components/error-overlay/error-overlay.tsx
+++ b/src/components/error-overlay/error-overlay.tsx
@@ -11,7 +11,6 @@ import {withPlayer} from '../../components/player';
 import {Button} from '../../components/button';
 import {getErrorDetailsByCategory} from './error-message-provider';
 import {actions as overlayActions} from '../../reducers/overlay';
-import {withEventManager} from '../../event';
 
 /**
  * mapping state to props
@@ -21,7 +20,8 @@ import {withEventManager} from '../../event';
 const mapStateToProps = state => ({
   hasError: state.engine.hasError,
   errorOverlaConfig: state.config.components?.errorOverlay,
-  errorDetails: state.engine.errorDetails
+  errorDetails: state.engine.errorDetails,
+  componentData: state.engine.componentData
 });
 
 const COMPONENT_NAME = 'ErrorOverlay';
@@ -34,25 +34,14 @@ const COMPONENT_NAME = 'ErrorOverlay';
  */
 @connect(mapStateToProps, bindActions({...actions, ...overlayActions}))
 @withPlayer
-@withEventManager
 @withLogger(COMPONENT_NAME)
 class ErrorOverlay extends Component<any, any> {
   private sessionEl!: HTMLDivElement;
 
-   /**
-   * @constructor
-   * @param {*} props props
-   */
-  constructor(props: any) {
-    super(props);
-    this.props.eventManager.listen(this.props.player, this.props.player.Event.COMPONENTS_URLS_LOADED, event => {
-      this._updateImgUrl(event.payload.data);
-    });
-  }
-
-  private _updateImgUrl(data: any): void {
-    if (data.errorOverlay) {
-      this.setState({entryUrl: data.errorOverlay});
+  public componentDidUpdate(prevProps: any): void {
+    const errorOverlayData = this.props.componentData.errorOverlay;
+    if (errorOverlayData && prevProps.componentData.errorOverlay !== errorOverlayData) {
+      this.setState({entryUrl: errorOverlayData});
     }
   }
 

--- a/src/components/logo/logo.tsx
+++ b/src/components/logo/logo.tsx
@@ -149,7 +149,7 @@ class Logo extends Component<any, any> {
           rel="noopener noreferrer"
           tabIndex={0}
           >
-          <img className={style.icon} src={this.state.entryUrl ||props.config.img} alt='' />
+          <img className={style.icon} src={this.state.entryUrl || props.config.img} alt='' />
         </a>
         ) : (
           <span

--- a/src/components/logo/logo.tsx
+++ b/src/components/logo/logo.tsx
@@ -44,6 +44,9 @@ class Logo extends Component<any, any> {
   constructor(props: any) {
     super(props);
     this.setState({isUrlClickable: typeof props.config.url === 'string', urlLink: props.config.url});
+    this.props.eventManager.listen(this.props.player, this.props.player.Event.COMPONENTS_URLS_LOADED, event => {
+      this._updateImgUrl(event.payload.data);
+    });
   }
 
   /**
@@ -54,6 +57,12 @@ class Logo extends Component<any, any> {
    */
   public componentDidMount(): void {
     this._handleLogoUrl();
+  }
+
+  private _updateImgUrl(data: any): void {
+    if (data.logo) {
+      this.setState({entryUrl: data.logo});
+    }
   }
 
   /**
@@ -111,7 +120,7 @@ class Logo extends Component<any, any> {
    * @returns {boolean} - whether to render the component
    */
   private _shouldRender(): boolean {
-    const isActive = !(Object.keys(this.props.config).length === 0 && this.props.config.constructor === Object) && (this.props.config.img || this.props.config.entryUrl);
+    const isActive = !(Object.keys(this.props.config).length === 0 && this.props.config.constructor === Object) && (this.props.config.img || this.state.entryUrl);
     this.props.onToggle(COMPONENT_NAME, isActive);
     return isActive;
   }
@@ -142,14 +151,14 @@ class Logo extends Component<any, any> {
           rel="noopener noreferrer"
           tabIndex={0}
           >
-          <img className={style.icon} src={props.config.img} alt='' />
+          <img className={style.icon} src={this.state.entryUrl ||props.config.img} alt='' />
         </a>
         ) : (
           <span
             className={style.controlButton}
             aria-label={props.config.text || props.logoText}
           >
-            <img className={style.icon} src={props.config.img} alt='' />
+            <img className={style.icon} src={this.state.entryUrl || props.config.img} alt='' />
           </span>
         )}
       </div>

--- a/src/components/logo/logo.tsx
+++ b/src/components/logo/logo.tsx
@@ -111,7 +111,7 @@ class Logo extends Component<any, any> {
    * @returns {boolean} - whether to render the component
    */
   private _shouldRender(): boolean {
-    const isActive = !(Object.keys(this.props.config).length === 0 && this.props.config.constructor === Object) && this.props.config.img;
+    const isActive = !(Object.keys(this.props.config).length === 0 && this.props.config.constructor === Object) && (this.props.config.img || this.props.config.entryUrl);
     this.props.onToggle(COMPONENT_NAME, isActive);
     return isActive;
   }

--- a/src/components/logo/logo.tsx
+++ b/src/components/logo/logo.tsx
@@ -18,7 +18,8 @@ const COMPONENT_NAME = 'Logo';
 const mapStateToProps = state => ({
   isMobile: state.shell.isMobile,
   playerSize: state.shell.playerSize,
-  config: state.config.components.logo
+  config: state.config.components.logo,
+  componentData: state.engine.componentData
 });
 
 const ENTRY_VAR = '{entryId}';
@@ -32,7 +33,6 @@ const ENTRY_VAR = '{entryId}';
  */
 @connect(mapStateToProps)
 @withPlayer
-@withEventManager
 @withLogger(COMPONENT_NAME)
 @withEventDispatcher(COMPONENT_NAME)
 @withText({logoText: 'controls.logo'})
@@ -44,9 +44,6 @@ class Logo extends Component<any, any> {
   constructor(props: any) {
     super(props);
     this.setState({isUrlClickable: typeof props.config.url === 'string', urlLink: props.config.url});
-    this.props.eventManager.listen(this.props.player, this.props.player.Event.COMPONENTS_URLS_LOADED, event => {
-      this._updateImgUrl(event.payload.data);
-    });
   }
 
   /**
@@ -59,9 +56,10 @@ class Logo extends Component<any, any> {
     this._handleLogoUrl();
   }
 
-  private _updateImgUrl(data: any): void {
-    if (data.logo) {
-      this.setState({entryUrl: data.logo});
+  public componentDidUpdate(prevProps: any): void {
+    const logoData = this.props.componentData.logo;
+    if (logoData && prevProps.componentData.logo !== logoData) {
+      this.setState({entryUrl: logoData});
     }
   }
 

--- a/src/components/watermark/watermark.tsx
+++ b/src/components/watermark/watermark.tsx
@@ -84,6 +84,9 @@ class Watermark extends Component<any, any> {
       this.onPlayerResize();
     });
     this._handleWatermarkUrl();
+    this.props.eventManager.listen(this.props.player, this.props.player.Event.COMPONENTS_URLS_LOADED, event => {
+      this._updateImgUrl(event.payload.data);
+    });
   }
 
   /**
@@ -114,11 +117,20 @@ class Watermark extends Component<any, any> {
     }
   }
 
+  private _updateImgUrl(data: any): void {
+    if (data.watermark) {
+      this.setState({entryUrl: data.watermark});
+    }
+    this.setState({entryUrlResolved: true});
+  }
+
   private _loadImageDimension(): void {
-    if (!this.props.config.img) return;
+    if (!this.props.config.img && !this.state.entryUrl) return;
+
+    const imgUrl = this.state.entryUrl || this.props.config.img;
 
     const img = new Image();
-    img.src = this.props.config.img;
+    img.src = imgUrl;
     img.onload = () => {
       this._originalImgWidth = img.naturalWidth;
       this._originalImgHeight = img.naturalHeight;
@@ -166,6 +178,14 @@ class Watermark extends Component<any, any> {
     return false;
   }
 
+  private isEntryUrlResolved(): boolean {
+    const shouldResolvedEntryId = this.props.player.config?.playback?.entriesForUiComponents?.watermark;
+    if (shouldResolvedEntryId && !this.state.entryUrlResolved){
+      return true;
+    }
+    return false;
+  }
+
   /**
    * componentWillUnmount
    *
@@ -186,7 +206,7 @@ class Watermark extends Component<any, any> {
    * @memberof Watermark
    */
   render(props: any): VNode<any> | undefined {
-    if (!props.config.img) {
+    if ((!props.config.img && !this.state.entryUrl) || this.isEntryUrlResolved()) {
       return undefined;
     }
     const styleClass = [style.watermark];
@@ -205,7 +225,7 @@ class Watermark extends Component<any, any> {
           <Localizer>
             {this.state.imgWidth && this.state.imgHeight && (
               <img
-                src={props.config.img}
+                src={this.state.entryUrl || props.config.img}
                 alt={(<Text id="watermark.watermark_alt_text" />) as unknown as string}
                 style={{
                   width: `${this.state.imgWidth}px`,

--- a/src/components/watermark/watermark.tsx
+++ b/src/components/watermark/watermark.tsx
@@ -54,7 +54,6 @@ class Watermark extends Component<any, any> {
 
   componentWillMount(): void {
     this._loadPlayerDimension();
-    this._loadImageDimension();
   }
 
   /**
@@ -85,6 +84,16 @@ class Watermark extends Component<any, any> {
       this.onPlayerResize();
     });
     this._handleWatermarkUrl();
+  }
+
+  /**
+   * After component updated, load image dimensions
+   * @method componentDidUpdate
+   * @returns {void}
+   * @memberof Watermark
+   */
+  componentDidUpdate(): void {
+    this._loadImageDimension();
   }
   /**
    * handles the watermark url

--- a/src/components/watermark/watermark.tsx
+++ b/src/components/watermark/watermark.tsx
@@ -20,7 +20,8 @@ const mapStateToProps = state => ({
     },
     state.config.components.watermark
   ),
-  targetId: state.config.targetId
+  targetId: state.config.targetId,
+  componentData: state.engine.componentData
 });
 
 const COMPONENT_NAME = 'Watermark';
@@ -84,9 +85,6 @@ class Watermark extends Component<any, any> {
       this.onPlayerResize();
     });
     this._handleWatermarkUrl();
-    this.props.eventManager.listen(this.props.player, this.props.player.Event.COMPONENTS_URLS_LOADED, event => {
-      this._updateImgUrl(event.payload.data);
-    });
   }
 
   /**
@@ -95,7 +93,15 @@ class Watermark extends Component<any, any> {
    * @returns {void}
    * @memberof Watermark
    */
-  componentDidUpdate(): void {
+  componentDidUpdate(prevProps: any): void {
+    const dataProps = this.props.componentData;
+    const prevDataProps = prevProps.componentData;
+    if (prevDataProps !== dataProps) {
+      this.setState({entryUrlResolved: true});
+    }
+    if (dataProps.watermark && prevDataProps.watermark !== dataProps.watermark) {
+      this.setState({entryUrl: dataProps.watermark});
+    }
     this._loadImageDimension();
   }
   /**
@@ -115,13 +121,6 @@ class Watermark extends Component<any, any> {
         });
       }
     }
-  }
-
-  private _updateImgUrl(data: any): void {
-    if (data.watermark) {
-      this.setState({entryUrl: data.watermark});
-    }
-    this.setState({entryUrlResolved: true});
   }
 
   private _loadImageDimension(): void {
@@ -179,7 +178,7 @@ class Watermark extends Component<any, any> {
   }
 
   private isEntryUrlResolved(): boolean {
-    const shouldResolvedEntryId = this.props.player.config?.playback?.entriesForUiComponents?.watermark;
+    const shouldResolvedEntryId = this.props.player.config?.uiComponentData?.watermark;
     if (shouldResolvedEntryId && !this.state.entryUrlResolved){
       return true;
     }

--- a/src/reducers/engine.ts
+++ b/src/reducers/engine.ts
@@ -54,7 +54,8 @@ export const types = {
   UPDATE_SOURCES: `${component}/UPDATE_SOURCES`,
   UPDATE_PICTURE_IN_PICTURE_SUPPORTED: `${component}/UPDATE_PICTURE_IN_PICTURE_SUPPORTED`,
   UPDATE_PICTURE_IN_PICTURE_MODE: `${component}/UPDATE_PICTURE_IN_PICTURE_MODE`,
-  UPDATE_FULLSCREEN: `${component}/UPDATE_FULLSCREEN`
+  UPDATE_FULLSCREEN: `${component}/UPDATE_FULLSCREEN`,
+  UPDATE_COMPONENT_DATA: `${component}/UPDATE_COMPONENT_DATA`
 };
 
 export const initialState = {
@@ -115,7 +116,8 @@ export const initialState = {
   isInPictureInPicture: false,
   playlist: null,
   sources: null,
-  fullscreen: false
+  fullscreen: false,
+  componentData: {}
 };
 
 export default (state: EngineState = initialState, action: any) => {
@@ -423,6 +425,15 @@ export default (state: EngineState = initialState, action: any) => {
         fullscreen: action.fullscreen
       };
 
+    case types.UPDATE_COMPONENT_DATA:
+      return {
+        ...state,
+        componentData: {
+          ...state.componentData,
+          ...action.componentData
+        }
+      };
+
     default:
       return state;
   }
@@ -498,5 +509,6 @@ export const actions = {
     isPictureInPictureSupported
   }),
   updateIsInPictureInPicture: (isInPictureInPicture: boolean) => ({type: types.UPDATE_PICTURE_IN_PICTURE_MODE, isInPictureInPicture}),
-  updateFullscreen: (fullscreen: boolean) => ({type: types.UPDATE_FULLSCREEN, fullscreen})
+  updateFullscreen: (fullscreen: boolean) => ({type: types.UPDATE_FULLSCREEN, fullscreen}),
+  updateComponentData: (componentData: any) => ({type: types.UPDATE_COMPONENT_DATA, componentData})
 } as const;

--- a/src/types/reducers/engine.ts
+++ b/src/types/reducers/engine.ts
@@ -54,4 +54,5 @@ export interface EngineState {
   playlist: any; // Specify a more detailed type if possible
   sources: any; // Current sources object
   fullscreen: boolean;
+  componentData: any; // Data for UI components
 }


### PR DESCRIPTION
### Description of the Changes

Adding support for entryId configuration in logo, errorOverlay and watermark.

logo - render the component also if entryId is configured.
watermark - calculate the img dimension when component is updated and not in the initialization

related to - https://github.com/kaltura/kaltura-player-js/pull/1203 

#### Resolves [FEC-14949](https://kaltura.atlassian.net/browse/FEC-14949)




[FEC-14949]: https://kaltura.atlassian.net/browse/FEC-14949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ