### PR TITLE
fix(FEC-14969): Add entryId configuration support to Error Slate | After clicking "Try again", player display the backgroundUrl and not the entryId.

### DIFF
--- a/src/components/error-overlay/error-overlay.tsx
+++ b/src/components/error-overlay/error-overlay.tsx
@@ -38,6 +38,13 @@ const COMPONENT_NAME = 'ErrorOverlay';
 class ErrorOverlay extends Component<any, any> {
   private sessionEl!: HTMLDivElement;
 
+  constructor(props: any) {
+    super(props);
+    this.state = {
+      entryUrl: props.componentData?.errorOverlay || undefined
+    };
+  }
+
   public componentDidUpdate(prevProps: any): void {
     const errorOverlayData = this.props.componentData.errorOverlay;
     if (errorOverlayData && prevProps.componentData.errorOverlay !== errorOverlayData) {
@@ -63,6 +70,10 @@ class ErrorOverlay extends Component<any, any> {
    */
   private handleClick = (): void => {
     const mediaInfo = this.props.player.getMediaInfo();
+    // Save entryUrl before clearing overlay to prevent state loss
+    if (this.props.componentData.errorOverlay && !this.state.entryUrl) {
+      this.setState({entryUrl: this.props.componentData.errorOverlay});
+    }
     this.props.updateOverlay(false);
     this.props.player.loadMedia(mediaInfo);
   };
@@ -75,6 +86,8 @@ class ErrorOverlay extends Component<any, any> {
    */
   private getBackgroundUrl = (): string | undefined => {
     const {errorOverlaConfig} = this.props;
+    console.log('errorOverlaConfig', errorOverlaConfig?.backgroundUrl);
+    console.log('entryUrl', this.state.entryUrl);
     return this.state.entryUrl || errorOverlaConfig?.backgroundUrl;
   };
 

--- a/src/components/error-overlay/error-overlay.tsx
+++ b/src/components/error-overlay/error-overlay.tsx
@@ -70,10 +70,6 @@ class ErrorOverlay extends Component<any, any> {
    */
   private handleClick = (): void => {
     const mediaInfo = this.props.player.getMediaInfo();
-    // Save entryUrl before clearing overlay to prevent state loss
-    if (this.props.componentData.errorOverlay && !this.state.entryUrl) {
-      this.setState({entryUrl: this.props.componentData.errorOverlay});
-    }
     this.props.updateOverlay(false);
     this.props.player.loadMedia(mediaInfo);
   };
@@ -86,8 +82,6 @@ class ErrorOverlay extends Component<any, any> {
    */
   private getBackgroundUrl = (): string | undefined => {
     const {errorOverlaConfig} = this.props;
-    console.log('errorOverlaConfig', errorOverlaConfig?.backgroundUrl);
-    console.log('entryUrl', this.state.entryUrl);
     return this.state.entryUrl || errorOverlaConfig?.backgroundUrl;
   };
 


### PR DESCRIPTION
### Description of the Changes

Please add a detailed description of the change, whether it's an enhancement or a bugfix.
If the PR is related to an open issue please link to it.

**Issue:**
when clicking on "try again" button, the image in the background is taken from the url and not from the entryId

**Fix:**
Adding initialization for the url state so when component recreate the state values are saved 

#### Resolves [FEC-14969](https://kaltura.atlassian.net/browse/FEC-14969)




[FEC-14969]: https://kaltura.atlassian.net/browse/FEC-14969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ