### PR TITLE
[Triage Fix] SUP-52289: Honor customLabels.audio resolver in AudioMenu

### DIFF
--- a/src/components/audio-menu/audio-menu.tsx
+++ b/src/components/audio-menu/audio-menu.tsx
@@ -54,6 +54,8 @@ const _AudioMenu = (props: AudioMenuProps) => {
   const activeAudioLanguage = props.player ? getActiveAudioLanguage(props.player) : undefined;
 
   const audioOptions = useMemo(() => {
+    const customLabelsAudio = (props.player?.config as any)?.customLabels?.audio;
+
     return props.audioTracks?.length
       ? props.audioTracks
           .filter((t: any) => t.label || t.language)
@@ -61,10 +63,13 @@ const _AudioMenu = (props: AudioMenuProps) => {
             const hasAudioDescription = !!props.audioDescriptionLanguages?.find((l: string) => l === t.language);
             const hasAdvancedAudioDescription = !!props.advancedAudioDescriptionLanguages?.find((l: string) => l === t.language);
 
-            const label = `${t.label || t.language} ${
+            const rawLabel =
+              typeof customLabelsAudio === 'function' ? customLabelsAudio(t) || t.label || t.language : t.label || t.language;
+
+            const label = `${rawLabel} ${
               hasAudioDescription || hasAdvancedAudioDescription ? `(${props.audioDescriptionAvailableText})` : ''
             }`;
-            const ariaLabel = `${t.label || t.language} - ${
+            const ariaLabel = `${rawLabel} - ${
               hasAudioDescription || hasAdvancedAudioDescription
                 ? props.thereIsAudioDescriptionAvailableText
                 : props.thereIsNoAudioDescriptionAvailableText
@@ -85,6 +90,7 @@ const _AudioMenu = (props: AudioMenuProps) => {
     props.audioDescriptionAvailableText,
     props.thereIsAudioDescriptionAvailableText,
     props.thereIsNoAudioDescriptionAvailableText,
+    props.player,
     activeAudioLanguage
   ]);
 

--- a/tests/e2e/audio-menu-custom-labels.spec.js
+++ b/tests/e2e/audio-menu-custom-labels.spec.js
@@ -1,0 +1,130 @@
+import '../../src/index';
+import {h, render, Component} from 'preact';
+import {Provider} from 'react-redux';
+import {AudioMenu} from '../../src/components/audio-menu';
+
+class TestProvider extends Component {
+  getChildContext() {
+    return {
+      player: this.props.player,
+      notifyClick: () => {},
+      notifyChange: () => {},
+      notifyHoverChange: () => {}
+    };
+  }
+  render() {
+    return this.props.children;
+  }
+}
+
+function createMockStore(audioTracks) {
+  const state = {
+    engine: {audioTracks},
+    audioDescription: {
+      isEnabled: false,
+      audioDescriptionLanguages: [],
+      advancedAudioDescriptionLanguages: [],
+      selectionByLanguage: new Map(),
+      isDefaultValueSet: false,
+      selectedAudioLanguage: null
+    },
+    shell: {
+      isMobile: false,
+      isSmallSize: false,
+      guiClientRect: {bottom: 1000, height: 800},
+      topBarClientRect: {bottom: 0, height: 50}
+    },
+    settings: {}
+  };
+  return {
+    getState: () => state,
+    subscribe: () => () => {},
+    dispatch: () => {}
+  };
+}
+
+function createMockPlayer(customLabelsAudio) {
+  return {
+    config: customLabelsAudio ? {customLabels: {audio: customLabelsAudio}} : {},
+    Track: {AUDIO: 'audio'},
+    selectTrack: () => {},
+    getActiveTracks: () => ({audio: {language: 'en'}}),
+    ui: {
+      store: {
+        getState: () => ({overlay: {isOpen: false}})
+      }
+    }
+  };
+}
+
+const mockAudioTracks = [
+  {id: 0, label: 'English', language: 'en'},
+  {id: 1, label: 'French', language: 'fr'}
+];
+
+describe('AudioMenu - customLabels.audio resolver', () => {
+  let container;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    render(null, container);
+    document.body.removeChild(container);
+  });
+
+  it('should apply customLabels.audio resolver to rendered audio track labels', done => {
+    const customResolver = track => `Resolved-${track.language.toUpperCase()}`;
+    const mockPlayer = createMockPlayer(customResolver);
+
+    render(
+      <Provider store={createMockStore(mockAudioTracks)}>
+        <TestProvider player={mockPlayer}>
+          <AudioMenu />
+        </TestProvider>
+      </Provider>,
+      container
+    );
+
+    setTimeout(() => {
+      try {
+        const options = container.querySelectorAll('[role="option"]');
+        options.length.should.equal(2);
+        const labels = Array.from(options).map(el => el.querySelector('span').textContent.trim());
+        labels[0].should.include('Resolved-EN');
+        labels[1].should.include('Resolved-FR');
+        done();
+      } catch (e) {
+        done(e);
+      }
+    }, 0);
+  });
+
+  it('should fall back to track.label when customLabels.audio is not configured', done => {
+    const mockPlayer = createMockPlayer(null);
+
+    render(
+      <Provider store={createMockStore(mockAudioTracks)}>
+        <TestProvider player={mockPlayer}>
+          <AudioMenu />
+        </TestProvider>
+      </Provider>,
+      container
+    );
+
+    setTimeout(() => {
+      try {
+        const options = container.querySelectorAll('[role="option"]');
+        options.length.should.equal(2);
+        const labels = Array.from(options).map(el => el.querySelector('span').textContent.trim());
+        labels[0].should.include('English');
+        labels[1].should.include('French');
+        done();
+      } catch (e) {
+        done(e);
+      }
+    }, 0);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds support for the `customLabels.audio` player config resolver in `AudioMenu`
- Previously, audio track labels were always resolved as `t.label || t.language`, ignoring any custom label function configured on the player
- On mobile the audio flavor overlay is rendered via `player.ui.addComponent()` (bottom-bar path), where the manifest-provided `t.label` may differ from desktop; this fix ensures the customer-configured resolver is applied consistently in both rendering paths

## Changes

**`src/components/audio-menu/audio-menu.tsx`**
- Read `customLabels.audio` from `props.player.config` inside the `useMemo` that builds `audioOptions`
- If the resolver is a function, call it with the track object and use the result as `rawLabel` (falling back to `t.label || t.language`)
- Apply `rawLabel` to both the visible `label` and the accessibility `ariaLabel`
- Added `props.player` to the `useMemo` dependency array

## Test plan

- [ ] Verify audio labels render correctly on desktop (no regression)
- [ ] Verify audio labels render correctly on mobile bottom-bar overlay
- [ ] Configure `customLabels.audio` returning native language names and confirm they appear on both platforms
- [ ] Confirm aria-labels also use the resolved label

🤖 Generated with [Claude Code](https://claude.ai/claude-code)