### PR TITLE
fix(SUP-52316): When you change the caption view on the video and then go back to the video, The settings pop up shows like you are hovering over the button even when you are not.

### DIFF
--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -260,16 +260,18 @@ class Tooltip extends Component<TooltipProps & WithEventManagerProps, any> {
    * @memberof Tooltip
    */
   handleClickOutside(e: any) {
-    if (!this.tooltipElement?.contains(e.target) && this.state.showTooltip) {
-      this.hideTooltip();
-    }
+    setTimeout(() => {
+      if (!this.tooltipElement?.contains(e.target) && this.state.showTooltip) {
+        this.hideTooltip();
+      }
+    }, 100);
   }
 
   handleRef = (el: HTMLButtonElement | null) => {
     this.setButtonRef(el);
 
     // Forward the child’s original ref (callback or ref object)
-    // so Tooltip keeps its own ref without breaking the child’s.    
+    // so Tooltip keeps its own ref without breaking the child’s.
     const { ref } = (this.props.children as VNode<any>);
     if (typeof ref === 'function') {
       ref(el);


### PR DESCRIPTION
issue:
when click on settings so the popup is open, and then click outside of the popup, the popup is closed but then the tooltip of setting is appears

root cause:
when click outside there is an event handler in settings that change the state and cause to focus on the last element and do show for tooltip, on the same time there is event handler in tooltip for click outside that hide the tooltip

solution:
add small delay for the tooltip event handler so first the focus element will be, then hide the tooltip

solved https://kaltura.atlassian.net/browse/SUP-52316


