### PR TITLE
fix(SUP-52427): prevent infinite setState loop in Watermark component

### DIFF
--- a/src/components/watermark/watermark.tsx
+++ b/src/components/watermark/watermark.tsx
@@ -85,15 +85,16 @@ class Watermark extends Component<any, any> {
       this.onPlayerResize();
     });
     this._handleWatermarkUrl();
+    this._loadImageDimension();
   }
 
   /**
-   * After component updated, load image dimensions
+   * After component updated, reload image dimensions only when the image URL changes
    * @method componentDidUpdate
    * @returns {void}
    * @memberof Watermark
    */
-  componentDidUpdate(prevProps: any): void {
+  componentDidUpdate(prevProps: any, prevState: any): void {
     const dataProps = this.props.componentData;
     const prevDataProps = prevProps.componentData;
     if (prevDataProps !== dataProps) {
@@ -102,7 +103,11 @@ class Watermark extends Component<any, any> {
     if (dataProps.watermark && prevDataProps.watermark !== dataProps.watermark) {
       this.setState({entryUrl: dataProps.watermark});
     }
-    this._loadImageDimension();
+    const prevImgUrl = prevState.entryUrl || prevProps.config.img;
+    const currImgUrl = this.state.entryUrl || this.props.config.img;
+    if (currImgUrl !== prevImgUrl) {
+      this._loadImageDimension();
+    }
   }
   /**
    * handles the watermark url


### PR DESCRIPTION
## Problem

`componentDidUpdate` called `_loadImageDimension()` unconditionally on every render. Inside `_loadImageDimension`, `img.onload` calls `setState({imgWidth, imgHeight})`, which triggers another `componentDidUpdate` — creating an infinite loop of re-renders and repeated HTTP requests for the watermark image.

The loop was introduced in [feat(FEC-14949) #1160](https://github.com/kaltura/playkit-js-ui/pull/1160) which moved `_loadImageDimension` from `componentWillMount` into `componentDidUpdate` without adding a guard.

**Observed:** Watermark image URL requested 2000+ times per session. Visible in Network tab as endless repeated requests. Reproduces after a few seek operations on the player.

## Fix

1. Restore the initial load call in `componentDidMount` (after `_handleWatermarkUrl`), so static `config.img` URLs load dimensions on mount.
2. Guard `componentDidUpdate` to only call `_loadImageDimension` when the image URL actually changes (`entryUrl || config.img` vs previous values) — prevents the setState feedback loop.

## Test page

Verified with local reproduction pages:
- **Repro:** `SUP-52427-repro.html` — counter climbs to 2000+ showing the loop
- **Fix:** `SUP-52427-fix.html` — counter stays at 1, loop blocked after first load

🤖 Generated with [Claude Code](https://claude.ai/claude-code)