### PR TITLE
fix(SUP-51932): Player Volume Control Slider - Scrolling outside of slider window stops livestream

### DIFF
--- a/src/components/overlay-action/overlay-action.tsx
+++ b/src/components/overlay-action/overlay-action.tsx
@@ -24,6 +24,7 @@ const mapStateToProps = state => ({
   isSmartContainerOpen: state.shell.smartContainerOpen,
   fullscreenConfig: state.config.components.fullscreen,
   seekbarDraggingActive: state.seekbar.draggingActive,
+  volumeDraggingActive: state.volume.draggingActive,
   allowPlayPause: state.config.allowPlayPause,
   allowLivePlayPause: state.config.allowLivePlayPause
 });
@@ -183,6 +184,7 @@ class OverlayAction extends Component<any, any> {
     };
     return (
       this.props.seekbarDraggingActive ||
+      this.props.volumeDraggingActive ||
       Math.abs(points.clientX - this._pointerDownPosX) > DRAGGING_THRESHOLD ||
       Math.abs(points.clientY - this._pointerDownPosY) > DRAGGING_THRESHOLD
     );


### PR DESCRIPTION
issue:
when click on volume slider, move the slider, and do another click to release the slider outside of the slider on the player itself, it trigger play/pause.

solution:
add the volume dragging to the check if the user dragging some component

solved [SUP-51932](https://kaltura.atlassian.net/browse/SUP-51932)






[SUP-51932]: https://kaltura.atlassian.net/browse/SUP-51932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ