### PR TITLE
fix(SUP-52516): Prevent settings tooltip from appearing after closing Advanced Caption Settings

### DIFF
--- a/src/components/settings/settings.tsx
+++ b/src/components/settings/settings.tsx
@@ -262,6 +262,10 @@ class Settings extends Component<any, any> {
    */
   onCVAAOverlayClose = (e?: KeyboardEvent, byKeyboard?: boolean): void => {
     this.toggleCVAAOverlay();
+    // Set flag to prevent tooltip from showing when focus is restored
+    if (this._buttonRef) {
+      this._buttonRef.dataset.kalturaFocusRestore = 'true';
+    }
     this.onControlButtonClick(e, byKeyboard);
   };
 


### PR DESCRIPTION
isse:
when open advanced captions settings and click x settings tooltip appears

solution:
set a flag to prevent tooltip from show

fix [SUP-52516](https://kaltura.atlassian.net/browse/SUP-52516)




[SUP-52516]: https://kaltura.atlassian.net/browse/SUP-52516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ