### PR TITLE
Revert "fix(SUP-52516): Prevent settings tooltip from appearing after closing Advanced Caption Settings"

### DIFF
--- a/src/components/settings/settings.tsx
+++ b/src/components/settings/settings.tsx
@@ -262,10 +262,6 @@ class Settings extends Component<any, any> {
    */
   onCVAAOverlayClose = (e?: KeyboardEvent, byKeyboard?: boolean): void => {
     this.toggleCVAAOverlay();
-    // Set flag to prevent tooltip from showing when focus is restored
-    if (this._buttonRef) {
-      this._buttonRef.dataset.kalturaFocusRestore = 'true';
-    }
     this.onControlButtonClick(e, byKeyboard);
   };
 


### PR DESCRIPTION
Reverts kaltura/playkit-js-ui#1175