### PR TITLE
fix(ADA-3093): Remove Talkback stop

### DIFF
--- a/src/components/shell/shell.tsx
+++ b/src/components/shell/shell.tsx
@@ -461,7 +461,6 @@ class Shell extends Component<any, any> {
 
     return (
       <div
-        tabIndex={-1}
         ref={node => (this._playerRef = node)}
         className={joinedPlayerClasses}
         onTouchEnd={this.onTouchEnd}


### PR DESCRIPTION
This fixes https://kaltura.atlassian.net/browse/ADA-3093
### Description of the Changes

The ticket's issue is multiple swipes when reaching pre-playback button while using android Talkback. Talkback sees the player container as an accessibility node, because of the use of tabindex="-1". Tabindex="-1" should be used to stop focusing an interactive item or to make it be focused programmatically. None of these cases is being used here, so removing it fixes one of the multiple swipes for Talkback

**Issue:**

**Fix:**

#### Resolves FEC-[Please add the ticket reference here]


