### PR TITLE
fix(ADA-3041): Replace text icons with text

### DIFF
--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -2,8 +2,9 @@ import style from '../../styles/style.scss';
 import {h, Component, VNode} from 'preact';
 import {connect} from 'react-redux';
 import {Menu} from '../menu';
-import {BadgeType, Icon, IconType} from '../icon';
+import {Icon, IconType} from '../icon';
 import {KeyMap} from '../../utils/key-map';
+import {getQualityBadgeText} from '../../utils/quality-badge';
 
 /**
  * mapping state to props
@@ -129,7 +130,7 @@ class DropDown extends Component<any, any> {
    */
   getActiveOption(): any {
     const activeOption = this.props.options.find(option => option.active);
-    return activeOption ? activeOption : this.props.options[0] || {label: 'Unlabled'};
+    return activeOption ? activeOption : this.props.options[0] || {label: 'Unlabeled'};
   }
 
   /**
@@ -160,14 +161,8 @@ class DropDown extends Component<any, any> {
   render(props: any): VNode<any> {
     const activeOptionId = props.name + 'Active';
     const activeOption = this.getActiveOption();
-    const label = activeOption?.dropdownOptions?.label || activeOption.label;
-    const badgeType = BadgeType[activeOption.badgeType || activeOption?.dropdownOptions?.badgeType];
-    let badgeText = '';
-    if (badgeType?.includes('quality-hd')) {
-      badgeText = ' HD';
-    } else if (badgeType?.includes('quality-4k')) {
-      badgeText = ' 4K';
-    }
+    const label = activeOption?.dropdownOptions?.label || activeOption?.label;
+    const badgeText = getQualityBadgeText(activeOption?.badgeType || activeOption?.dropdownOptions?.badgeType);
     return props.isMobile || props.isSmallSize ? (
       this.renderNativeSelect(props.name)
     ) : (
@@ -193,10 +188,11 @@ class DropDown extends Component<any, any> {
         >
           <span
             id={activeOptionId}
-            className={badgeType ? [style.labelBadge, badgeType].join(' ') : ''}
-            aria-label={`${label}${badgeText}`}
+            className={badgeText ? style.labelBadge : ''}
+            aria-label={badgeText ? `${label} ${badgeText}` : label}
           >
             {label}
+            {badgeText ? <span className={style.qualityBadge}>{badgeText}</span> : undefined}
           </span>
           <Icon type={IconType.ArrowDown} />
           {!this.state.dropMenuActive ? undefined : (

--- a/src/components/icon/icon.scss
+++ b/src/components/icon/icon.scss
@@ -147,23 +147,10 @@
   filter: drop-shadow(0px 0px 2px rgba(0, 0, 0, 0.7));
 }
 
-.badge-icon:after {
-  content: '';
-  position: absolute;
-  height: 16px;
-  width: 16px;
-  background-size: cover;
-  background-repeat: no-repeat;
-  background-position: 50% 50%;
-}
-
 // Dynamic Colored Icons
 .player {
   --playkit-icon-vr-stereo-full-url: #{icon(vrStereoOn, $brand-color)};
   --playkit-icon-chromecast-url: #{icon(chromecast, $brand-color)};
-  --playkit-icon-quality-HD-active-url: #{icon(qualityHdActive, '#fff', '16', '0 0 16 16')};
-  --playkit-icon-quality-4K-active-url: #{icon(quality4kActive, '#fff', '16', '0 0 16 16')};
-  --playkit-icon-quality-8K-active-url: #{icon(quality8kActive, '#fff', '16', '0 0 16 16')};
 }
 
 .icon-maximize {
@@ -328,42 +315,6 @@
 
 .icon-advanced-audio-description-disabled-dropdown {
   background-image: icon(advancedAudioDescriptionOff, '#c4c4c4', '32', '0 0 32 32');
-}
-
-.icon-quality-hd {
-  &:after {
-    background-image: icon(qualityHd, '#fff', '16', '0 0 16 16');
-  }
-}
-
-.icon-quality-hd-active {
-  &:after {
-    background-image: var(--playkit-icon-quality-HD-active-url);
-  }
-}
-
-.icon-quality-4k {
-  &:after {
-    background-image: icon(quality4k, '#fff', '16', '0 0 16 16');
-  }
-}
-
-.icon-quality-4k-active {
-  &:after {
-    background-image: var(--playkit-icon-quality-4K-active-url);
-  }
-}
-
-.icon-quality-8k {
-  &:after {
-    background-image: icon(quality8k, '#fff', '16', '0 0 16 16');
-  }
-}
-
-.icon-quality-8k-active {
-  &:after {
-    background-image: var(--playkit-icon-quality-8K-active-url);
-  }
 }
 
 .icon-closed-captions-on {

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -49,15 +49,6 @@ const IconType = {
   QualityButton: 'quality-button'
 };
 
-const BadgeType = {
-  qualityHd: `${style.badgeIcon} ${style.iconQualityHd}`,
-  qualityHdActive: `${style.badgeIcon} ${style.iconQualityHdActive}`,
-  quality4k: `${style.badgeIcon} ${style.iconQuality4K}`,
-  quality4kActive: `${style.badgeIcon} ${style.iconQuality4KActive}`,
-  quality8k: `${style.badgeIcon} ${style.iconQuality8K}`,
-  quality8kActive: `${style.badgeIcon} ${style.iconQuality8KActive}`
-};
-
 const IconState: {[state: string]: number} = {
   INACTIVE: 0,
   ACTIVE: 1
@@ -355,4 +346,4 @@ class Icon extends Component<any, any> {
 }
 
 export default Icon;
-export {Icon, IconType, BadgeType, IconState};
+export {Icon, IconType, IconState};

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -20,7 +20,7 @@ export {EngineConnector} from './engine-connector';
 export {ErrorOverlay} from './error-overlay';
 export * from './event-dispatcher';
 export * from './keyboard';
-export {Icon, IconType, IconState, BadgeType} from './icon';
+export {Icon, IconType, IconState} from './icon';
 export {LiveTag} from './live-tag';
 export {Loading} from './loading';
 export {MediaInfoDisplay} from './media-info-display';

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -1,11 +1,12 @@
 import style from '../../styles/style.scss';
 import {h, Component, VNode} from 'preact';
-import {BadgeType, default as Icon, IconType} from '../icon';
+import {default as Icon, IconType} from '../icon';
 import {connect} from 'react-redux';
 import {withKeyboardA11y} from '../../utils';
 import {KeyMap} from '../../utils';
 import {withEventManager} from '../../event';
 import {WithEventManagerProps} from '../../event/with-event-manager';
+import {getQualityBadgeText, QualityBadgeType} from '../../utils/quality-badge';
 
 type OptionType = {
   value: any;
@@ -283,13 +284,14 @@ class MenuItem extends Component<any, any> {
    */
   public render(props: any): VNode<any> {
     const ariaLabel = props.data.ariaLabel || props.data.label;
-    const badgeType: string | null = props.data.badgeType && !props.isSelected(props.data) ? BadgeType[props.data.badgeType] : BadgeType[props.data.badgeType + 'Active'];
-    let badgeText = '';
-    if (badgeType?.includes('quality-hd')) {
-      badgeText = ' HD';
-    } else if (badgeType?.includes('quality-4k')) {
-      badgeText = ' 4K';
+    let activeBadgeType: QualityBadgeType = null;
+    if (props.data.badgeType) {
+      activeBadgeType = props.data.badgeType;
+      if (props.isSelected(props.data)) {
+        activeBadgeType = `${props.data.badgeType}Active` as QualityBadgeType;
+      }
     }
+    const badgeText = getQualityBadgeText(activeBadgeType);
     return (
       <div
         role={props?.role}
@@ -310,9 +312,10 @@ class MenuItem extends Component<any, any> {
         onClick={this.onClick}
         onKeyDown={this.onKeyDown}>
         <span
-          className={badgeType ? [style.labelBadge, badgeType].join(' ') : ''}
-          aria-label={`${ariaLabel}${badgeText}`}>
+          className={badgeText ? style.labelBadge : ''}
+          aria-label={badgeText ? `${ariaLabel} ${badgeText}` : ariaLabel}>
           {props.data.label}
+          {badgeText ? <span className={style.qualityBadge}>{badgeText}</span> : undefined}
         </span>
         <span className={[style.menuIconContainer, style.active].join(' ')}>
           <Icon type={IconType.CheckActive} />

--- a/src/components/quality-control/quality-control.tsx
+++ b/src/components/quality-control/quality-control.tsx
@@ -5,7 +5,7 @@ import {withText} from 'preact-i18n';
 import {ButtonControl} from '../button-control';
 import {Tooltip} from '../tooltip';
 import {Button} from '../button';
-import {Icon, IconType, BadgeType} from '../icon';
+import {Icon, IconType} from '../icon';
 import {SmartContainer} from '../smart-container';
 import {QualityMenu} from '../quality-menu';
 import {focusElement} from '../../utils';
@@ -13,6 +13,7 @@ import {isEnter, isSpace} from '../../utils/key-map';
 import style from '../../styles/style.scss';
 import {registerToBottomBar} from '../bottom-bar';
 import {getLabelBadgeType} from '../../components';
+import {getQualityBadgeText, QualityBadgeType} from '../../utils/quality-badge';
 
 const mapStateToProps = state => ({
   showQualityButton: state.config.showQualityButton,
@@ -94,7 +95,7 @@ const QualityControl = connect(mapStateToProps)(
       return videoTracks?.length > 1;
     }, [videoTracks]);
 
-    const getButtonBadgeType = (): string | null => {
+    const getButtonBadgeType = (): QualityBadgeType => {
         const activeVideoTrackHeight: number = player.getActiveTracks()?.video?.height;
         return activeVideoTrackHeight ? getLabelBadgeType(activeVideoTrackHeight) : null;
     };
@@ -121,7 +122,8 @@ const QualityControl = connect(mapStateToProps)(
 
     if (!props.showQualityButton || !hasQualityOptions || props.isAudio) return null;
 
-    const buttonBadgeType: string = getButtonBadgeType() || '';
+    const buttonBadgeType = getButtonBadgeType();
+    const badgeText = getQualityBadgeText(buttonBadgeType);
     const buttonAriaLabel = `${getQualityLabel(buttonBadgeType)}`;
 
     return (
@@ -136,11 +138,11 @@ const QualityControl = connect(mapStateToProps)(
                 style.controlButton, 
                 style.buttonBadge,
                 smartContainerOpen ? style.active : '',
-                BadgeType[buttonBadgeType + 'Active'],
               ].join(' ')}
               onClick={(e) => handleClick(true)}
               onKeyDown={onKeyDown}>
               <Icon type={IconType.QualityButton} />
+              {badgeText ? <span className={style.qualityControlBadge}>{badgeText}</span> : undefined}
             </Button>
           </Tooltip>
           {smartContainerOpen && (

--- a/src/components/quality-menu/quality-menu.tsx
+++ b/src/components/quality-menu/quality-menu.tsx
@@ -4,10 +4,11 @@ import {withText} from 'preact-i18n';
 import {connect} from 'react-redux';
 import {bindActions} from '../../utils';
 import {actions} from '../../reducers/settings';
-import {BadgeType, SmartContainerItem, Menu} from '../../components';
+import {SmartContainerItem, Menu} from '../../components';
 import {IconType} from '../icon';
 import {withPlayer} from '../player';
 import {withEventDispatcher} from '../event-dispatcher';
+import {QualityBadgeType} from '../../utils/quality-badge';
 
 const HeightResolution = {
   HD: 1080,
@@ -21,16 +22,15 @@ const DEFAULT_VIDEO_TRACK = 360;
  * Determines the badge icon type of the quality option based on the height of the resolution.
  *
  * @param {number} videoTrackHeight - video track resolution height.
- * @returns {string | null} - the badge icon type or null depends on the resolution height.
+ * @returns {QualityBadgeType} - the badge icon type or null depends on the resolution height.
  */
-function getLabelBadgeType(videoTrackHeight: number): string | null {
-  const [QHD, , Q4K, , Q8k] = Object.keys(BadgeType);
+function getLabelBadgeType(videoTrackHeight: number): QualityBadgeType {
   if (videoTrackHeight >= HeightResolution.HD && videoTrackHeight < HeightResolution.UHD_4K) {
-    return QHD;
+    return 'qualityHd';
   } else if (videoTrackHeight >= HeightResolution.UHD_4K && videoTrackHeight < HeightResolution.UHD_8K) {
-    return Q4K;
+    return 'quality4k';
   } else if (videoTrackHeight >= HeightResolution.UHD_8K) {
-    return Q8k;
+    return 'quality8k';
   }
   return null;
 }

--- a/src/components/settings/settings.tsx
+++ b/src/components/settings/settings.tsx
@@ -5,7 +5,7 @@ import {connect} from 'react-redux';
 import {bindActions, KeyMap} from '../../utils';
 import {actions} from '../../reducers/settings';
 import {AudioMenu, CaptionsMenu, QualityMenu, SmartContainer, SpeedMenu, CVAAOverlay, getLabelBadgeType} from '../../components';
-import {default as Icon, IconType, BadgeType} from '../icon';
+import {default as Icon, IconType} from '../icon';
 import {withPlayer} from '../player';
 import {withEventManager} from '../../event';
 import {actions as overlayIconActions} from '../../reducers/overlay-action';
@@ -20,6 +20,7 @@ import {withLogger} from '../logger';
 import {SpeedSelectedEvent} from '../../event/events/speed-selected-event';
 import {getOverlayPortalElement} from '../overlay-portal';
 import {AudioDescriptionMenu} from '../audio-description-menu';
+import {getQualityBadgeText, QualityBadgeType} from '../../utils/quality-badge';
 
 /**
  * mapping state to props
@@ -271,7 +272,7 @@ class Settings extends Component<any, any> {
    * @returns {string | null} - the badge icon type or null depends on the resolution height.
    * @memberof Settings
    */
-  getButtonBadgeType(): string | null {
+  getButtonBadgeType(): QualityBadgeType {
     const activeVideoTrackHeight: number = this.props.player.getActiveTracks()?.video?.height;
     return activeVideoTrackHeight ? getLabelBadgeType(activeVideoTrackHeight) : null;
   }
@@ -307,7 +308,8 @@ class Settings extends Component<any, any> {
     if (!(showAudioMenu || showCaptionsMenu || showQualityMenu || showSpeedMenu || showAudioDescriptionMenu))
       return undefined;
     if (props.isLive && props.videoTracks.length <= 1 && !showAudioMenu && !showCaptionsMenu) return undefined;
-    const buttonBadgeType: string = this.getButtonBadgeType() || '';
+    const buttonBadgeType = this.getButtonBadgeType();
+    const badgeText = getQualityBadgeText(buttonBadgeType);
 
     const buttonAriaLabel = `${props.buttonLabel} ${showQualityMenu ? this.getQualityLabel(buttonBadgeType) : ''} `;
     return (
@@ -322,11 +324,11 @@ class Settings extends Component<any, any> {
             className={[
               style.controlButton,
               showQualityMenu? style.buttonBadge : '',
-              showQualityMenu? BadgeType[buttonBadgeType + 'Active'] : '',
               this.state.smartContainerOpen ? style.active : ''
             ].join(' ')}
             onClick={this.onControlButtonClick}>
             <Icon type={IconType.Settings} />
+            {showQualityMenu && badgeText ? <span className={style.qualityControlBadge}>{badgeText}</span> : undefined}
           </Button>
         </Tooltip>
         {this.state.smartContainerOpen && !this.state.cvaaOverlay && (

--- a/src/components/smart-container/_smart-container.scss
+++ b/src/components/smart-container/_smart-container.scss
@@ -80,7 +80,7 @@
         align-self: flex-end;
       }
       .dropdown {
-        span:not(.badge-icon) {
+        span:not(.quality-badge) {
           overflow: hidden;
           text-overflow: ellipsis;
           vertical-align: middle;

--- a/src/styles/_control-button.scss
+++ b/src/styles/_control-button.scss
@@ -16,6 +16,25 @@
       top: -4px;
       right: -1px;
     }
+
+    .quality-control-badge {
+      position: absolute;
+      top: 0;
+      right: -1px;
+      display: inline-block;
+      width: 14px;
+      height: 8px;
+      box-sizing: border-box;
+      border-radius: 1px;
+      background: var(--W-100, #fff);
+      color: var(--B-100, #000);
+      text-align: center;
+      font-family: Arial, sans-serif;
+      font-size: 7px;
+      font-style: normal;
+      font-weight: 900;
+      line-height: 8px;
+    }
   }
 
   i {

--- a/src/styles/_dropdown.scss
+++ b/src/styles/_dropdown.scss
@@ -53,8 +53,8 @@
     }
 
     & > .label-badge {
-      &.badge-icon {
-        margin-right: 13px;
+      .quality-badge {
+        margin-left: 3px;
       }
     }
   }
@@ -133,8 +133,8 @@
     }
 
     & > .label-badge {
-      &.badge-icon {
-        margin-right: 5px;
+      .quality-badge {
+        margin-left: 3px;
       }
     }
 
@@ -142,6 +142,24 @@
       color: #888;
     }
   }
+}
+
+.quality-badge {
+  display: inline-block;
+  position: relative;
+  top: -8px; 
+  width: 14px;
+  height: 8px;
+  box-sizing: border-box;
+  border-radius: 1px;
+  background: var(--W-100, #fff);
+  color: var(--B-100, #000);
+  text-align: center;
+  font-family: Arial, sans-serif;
+  font-size: 7px;
+  font-style: normal;
+  font-weight: 900;
+  line-height: 8px;
 }
 
 .smart-container {

--- a/src/styles/_dropdown.scss
+++ b/src/styles/_dropdown.scss
@@ -147,7 +147,7 @@
 .quality-badge {
   display: inline-block;
   position: relative;
-  top: -8px; 
+  top: -6px; 
   width: 14px;
   height: 8px;
   box-sizing: border-box;

--- a/src/utils/quality-badge.ts
+++ b/src/utils/quality-badge.ts
@@ -1,0 +1,17 @@
+export type QualityBadgeType = 'qualityHd' | 'qualityHdActive' | 'quality4k' | 'quality4kActive' | 'quality8k' | 'quality8kActive' | null | undefined;
+
+export const getQualityBadgeText = (badgeType: QualityBadgeType): string => {
+  switch (badgeType) {
+    case 'qualityHd':
+    case 'qualityHdActive':
+      return 'HD';
+    case 'quality4k':
+    case 'quality4kActive':
+      return '4K';
+    case 'quality8k':
+    case 'quality8kActive':
+      return '8K';
+    default:
+      return '';
+  }
+};


### PR DESCRIPTION
This fixes https://kaltura.atlassian.net/browse/ADA-3041 changing the Quality badge text icons into text with same meaning.

Reverts kaltura/playkit-js-ui#1185