### PR TITLE
fix(SUP-52089): Player controls language doesn't change while changing the site language in KAF

### DIFF
--- a/src/ui-manager.tsx
+++ b/src/ui-manager.tsx
@@ -153,8 +153,11 @@ class UIManager {
         this._translations[locale] = translation;
       });
     }
-    if (config.locale && this._translations[config.locale]) {
-      this._locale = config.locale;
+    if (config.locale) {
+      const normalizedLocale = config.locale.toLowerCase();
+      if (this._translations[normalizedLocale]) {
+        this._locale = normalizedLocale;
+      }
     }
   }
 


### PR DESCRIPTION
issue:
when use catalan language on kaf, it have locale code ad ca_ES, and due to capital laetters the player not find it and fallback to english

explanation :
ca_ES is the correct POSIX identifier for Catalan as spoken in Spain (lowercase language code + uppercase country code). 
so ask to send only lowercases is not correct as the standard is different


solution:
as player only use lowercase, in case get uppercase translate first to lower case


solved [SUP-52089](https://kaltura.atlassian.net/browse/SUP-52089)




[SUP-52089]: https://kaltura.atlassian.net/browse/SUP-52089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ