### PR TITLE
fix(ADA-3484): Remove focus trap from error overlay

### DIFF
--- a/src/components/error-overlay/error-overlay.tsx
+++ b/src/components/error-overlay/error-overlay.tsx
@@ -167,7 +167,7 @@ class ErrorOverlay extends Component<any, any> {
       const errorOverlayStyles = backgroundUrl ? {backgroundImage: `url(${backgroundUrl})`} : undefined;
       return (
         <div className={['overlay-portal', backgroundUrl ? style.customErrorSlate : ''].join(' ')}>
-          <Overlay open permanent={true} type="error">
+          <Overlay open permanent={true} type="error" disableFocusTrap={true}>
             <div className={style.errorOverlay} style={errorOverlayStyles}>
               <p className={style.errorText} />
               {this.renderErrorHead()}

--- a/src/components/overlay/overlay.tsx
+++ b/src/components/overlay/overlay.tsx
@@ -30,6 +30,7 @@ interface OverlayProps {
   addAccessibleChild?: (el: HTMLElement) => void;
   pauseOnOpen?: boolean;
   closeAriaLabel?: string;
+  disableFocusTrap?: boolean;
 }
 
 /**
@@ -129,7 +130,7 @@ class Overlay extends Component<OverlayProps, any> {
    * @memberof Overlay
    */
   private onKeyDown = (e: KeyboardEvent): void => {
-    if (e.code === KeyCode.Tab) {
+    if (!this.props.disableFocusTrap && e.code === KeyCode.Tab) {
       const container = e.currentTarget as HTMLElement;
       const focusable = container.querySelectorAll<HTMLElement>('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
 


### PR DESCRIPTION
This fixes https://kaltura.atlassian.net/browse/ADA-3484 by removing the focus trap from error overlay